### PR TITLE
Add browser prototype with hex map and units

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Autobattles 4X Finsauna (Web Prototype)
+
+This is a minimal browser-based scaffold for the Finsim AA Club autobattler.
+It renders a simple hex grid and two placeholder units using plain JavaScript
+modules and the HTML5 canvas.
+
+## Run
+Serve the files with any static web server, for example:
+
+```
+npx http-server .
+```
+
+Then open `http://localhost:8080` in a browser.

--- a/game.js
+++ b/game.js
@@ -1,0 +1,37 @@
+import { HexMap } from './hexmap.js';
+import { Unit } from './unit.js';
+
+export class Game {
+  constructor(canvas) {
+    this.ctx = canvas.getContext('2d');
+    this.map = new HexMap(10, 10);
+    this.units = [
+      new Unit({ q: 0, r: 0 }, 'blue'),
+      new Unit({ q: 5, r: 5 }, 'red')
+    ];
+    this.lastTime = 0;
+  }
+
+  start() {
+    requestAnimationFrame(this.loop.bind(this));
+  }
+
+  loop(time) {
+    const dt = (time - this.lastTime) / 1000;
+    this.lastTime = time;
+    this.update(dt);
+    this.render();
+    requestAnimationFrame(this.loop.bind(this));
+  }
+
+  update(dt) {
+    this.units.forEach(u => u.update(dt, this.map, this.units));
+  }
+
+  render() {
+    const { ctx } = this;
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    this.map.render(ctx);
+    this.units.forEach(u => u.render(ctx, this.map));
+  }
+}

--- a/hexmap.js
+++ b/hexmap.js
@@ -1,0 +1,36 @@
+export class HexMap {
+  constructor(width, height) {
+    this.width = width;
+    this.height = height;
+    this.size = 32; // pixel radius of each hex
+  }
+
+  hexToPixel({ q, r }) {
+    const x = this.size * (Math.sqrt(3) * q + (Math.sqrt(3) / 2) * r);
+    const y = this.size * (3 / 2) * r;
+    return { x, y };
+  }
+
+  render(ctx) {
+    for (let q = 0; q < this.width; q++) {
+      for (let r = 0; r < this.height; r++) {
+        const { x, y } = this.hexToPixel({ q, r });
+        this.drawHex(ctx, x, y, '#ddd');
+      }
+    }
+  }
+
+  drawHex(ctx, x, y, color) {
+    const s = this.size;
+    ctx.beginPath();
+    for (let i = 0; i < 6; i++) {
+      const angle = Math.PI / 3 * i;
+      ctx.lineTo(x + s * Math.cos(angle), y + s * Math.sin(angle));
+    }
+    ctx.closePath();
+    ctx.strokeStyle = '#555';
+    ctx.fillStyle = color;
+    ctx.fill();
+    ctx.stroke();
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Finsim 4X Autobattler (Web)</title>
+  <style>
+    html, body, canvas { margin:0; padding:0; width:100%; height:100%; overflow:hidden; }
+  </style>
+</head>
+<body>
+  <canvas id="game"></canvas>
+  <script type="module">
+    import { Game } from './game.js';
+    const canvas = document.getElementById('game');
+    const game = new Game(canvas);
+    game.start();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "autobattles4xfinsauna",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module"
+}

--- a/unit.js
+++ b/unit.js
@@ -1,0 +1,20 @@
+export class Unit {
+  constructor(pos, color) {
+    this.pos = pos; // { q, r }
+    this.color = color;
+    this.speed = 1; // hexes per second
+  }
+
+  update(dt, map, units) {
+    // Placeholder for AI logic
+    // e.g., move toward nearest enemy or wander
+  }
+
+  render(ctx, map) {
+    const { x, y } = map.hexToPixel(this.pos);
+    ctx.beginPath();
+    ctx.arc(x, y, map.size / 2, 0, Math.PI * 2);
+    ctx.fillStyle = this.color;
+    ctx.fill();
+  }
+}


### PR DESCRIPTION
## Summary
- Scaffold HTML entry point that boots a simple canvas-based game.
- Implement `Game` module with render loop and placeholder units.
- Add `HexMap` and `Unit` modules for hex-grid rendering and unit drawing.

## Testing
- `node --check game.js && node --check hexmap.js && node --check unit.js`


------
https://chatgpt.com/codex/tasks/task_e_68c57dfb9b348330b77645c6205bfa58