### PR TITLE
Add hex grid utilities and map rendering

### DIFF
--- a/src/hex/HexMap.ts
+++ b/src/hex/HexMap.ts
@@ -1,0 +1,83 @@
+import { AxialCoord, axialToPixel } from './HexUtils.ts';
+import { HexTile } from './HexTile.ts';
+
+/** Simple hex map composed of tiles in axial coordinates. */
+export class HexMap {
+  readonly tiles: HexTile[][];
+
+  constructor(
+    public readonly width = 10,
+    public readonly height = 10,
+    public readonly hexSize = 32
+  ) {
+    this.tiles = [];
+    for (let r = 0; r < height; r++) {
+      const row: HexTile[] = [];
+      for (let q = 0; q < width; q++) {
+        row.push(new HexTile());
+      }
+      this.tiles.push(row);
+    }
+  }
+
+  getTile(q: number, r: number): HexTile | undefined {
+    return this.tiles[r]?.[q];
+  }
+
+  forEachTile(cb: (tile: HexTile, coord: AxialCoord) => void): void {
+    for (let r = 0; r < this.height; r++) {
+      for (let q = 0; q < this.width; q++) {
+        cb(this.tiles[r][q], { q, r });
+      }
+    }
+  }
+
+  /** Draw the map onto a canvas context. */
+  draw(ctx: CanvasRenderingContext2D): void {
+    this.forEachTile((tile, coord) => {
+      const { x, y } = axialToPixel(coord, this.hexSize);
+      this.drawHex(ctx, x + this.hexSize, y + this.hexSize, this.hexSize, this.getFillColor(tile));
+    });
+  }
+
+  private getFillColor(tile: HexTile): string {
+    if (tile.isFogged) {
+      return '#000000';
+    }
+    switch (tile.terrain) {
+      case 'water':
+        return '#1E90FF';
+      case 'forest':
+        return '#228B22';
+      case 'mountain':
+        return '#A9A9A9';
+      default:
+        return '#98FB98';
+    }
+  }
+
+  private drawHex(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    size: number,
+    fill: string
+  ): void {
+    ctx.beginPath();
+    for (let i = 0; i < 6; i++) {
+      const angle = (Math.PI / 180) * (60 * i - 30);
+      const px = x + size * Math.cos(angle);
+      const py = y + size * Math.sin(angle);
+      if (i === 0) {
+        ctx.moveTo(px, py);
+      } else {
+        ctx.lineTo(px, py);
+      }
+    }
+    ctx.closePath();
+    ctx.fillStyle = fill;
+    ctx.strokeStyle = '#000000';
+    ctx.fill();
+    ctx.stroke();
+  }
+}

--- a/src/hex/HexTile.ts
+++ b/src/hex/HexTile.ts
@@ -1,0 +1,16 @@
+export type TerrainType = 'plain' | 'water' | 'forest' | 'mountain';
+export type BuildingType = 'city' | 'farm' | 'mine' | null;
+
+/** Represents a single hex tile on the map. */
+export class HexTile {
+  constructor(
+    public terrain: TerrainType = 'plain',
+    public building: BuildingType = null,
+    public isFogged: boolean = true
+  ) {}
+
+  /** Reveal the tile by removing fog. */
+  reveal(): void {
+    this.isFogged = false;
+  }
+}

--- a/src/hex/HexUtils.ts
+++ b/src/hex/HexUtils.ts
@@ -1,0 +1,64 @@
+export interface AxialCoord {
+  q: number;
+  r: number;
+}
+
+export interface PixelCoord {
+  x: number;
+  y: number;
+}
+
+const SQRT3 = Math.sqrt(3);
+
+const DIRECTIONS: AxialCoord[] = [
+  { q: 1, r: 0 },
+  { q: 1, r: -1 },
+  { q: 0, r: -1 },
+  { q: -1, r: 0 },
+  { q: -1, r: 1 },
+  { q: 0, r: 1 }
+];
+
+/** Convert axial coordinates to pixel coordinates for pointy-topped hexes. */
+export function axialToPixel(hex: AxialCoord, size: number): PixelCoord {
+  return {
+    x: size * SQRT3 * (hex.q + hex.r / 2),
+    y: size * (3 / 2) * hex.r
+  };
+}
+
+/** Convert pixel coordinates to axial coordinates for pointy-topped hexes. */
+export function pixelToAxial(x: number, y: number, size: number): AxialCoord {
+  const q = (SQRT3 / 3 * x - 1 / 3 * y) / size;
+  const r = (2 / 3 * y) / size;
+  return hexRound({ q, r });
+}
+
+/** Get the six neighboring axial coordinates. */
+export function getNeighbors(hex: AxialCoord): AxialCoord[] {
+  return DIRECTIONS.map((d) => ({ q: hex.q + d.q, r: hex.r + d.r }));
+}
+
+function hexRound(frac: AxialCoord): AxialCoord {
+  let x = frac.q;
+  let z = frac.r;
+  let y = -x - z;
+
+  let rx = Math.round(x);
+  let ry = Math.round(y);
+  let rz = Math.round(z);
+
+  const xDiff = Math.abs(rx - x);
+  const yDiff = Math.abs(ry - y);
+  const zDiff = Math.abs(rz - z);
+
+  if (xDiff > yDiff && xDiff > zDiff) {
+    rx = -ry - rz;
+  } else if (yDiff > zDiff) {
+    ry = -rx - rz;
+  } else {
+    rz = -rx - ry;
+  }
+
+  return { q: rx, r: rz };
+}


### PR DESCRIPTION
## Summary
- add axial/pixel conversion helpers and neighbor lookup
- create HexTile with terrain, building, and fog state
- implement HexMap that builds a 10x10 grid and draws hexes to a canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c58d2207ac8330812de55b103c9539