### PR TITLE
feat: expand hex grid utilities

### DIFF
--- a/src/hex/HexMap.ts
+++ b/src/hex/HexMap.ts
@@ -40,6 +40,15 @@ export class HexMap {
     });
   }
 
+  /** Convenience method to draw directly to a canvas element. */
+  drawToCanvas(canvas: HTMLCanvasElement): void {
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas 2D context not available');
+    }
+    this.draw(ctx);
+  }
+
   private getFillColor(tile: HexTile): string {
     if (tile.isFogged) {
       return '#000000';

--- a/src/hex/HexTile.ts
+++ b/src/hex/HexTile.ts
@@ -13,4 +13,14 @@ export class HexTile {
   reveal(): void {
     this.isFogged = false;
   }
+
+  /** Place or replace a building on this tile. */
+  placeBuilding(building: BuildingType): void {
+    this.building = building;
+  }
+
+  /** Toggle fog of war state. */
+  setFogged(value: boolean): void {
+    this.isFogged = value;
+  }
 }

--- a/src/hex/HexUtils.ts
+++ b/src/hex/HexUtils.ts
@@ -8,16 +8,18 @@ export interface PixelCoord {
   y: number;
 }
 
+/** Square root of three used in many of the hex math formulae. */
 const SQRT3 = Math.sqrt(3);
 
-const DIRECTIONS: AxialCoord[] = [
+/** Direction vectors for axial coordinates (pointy topped). */
+export const DIRECTIONS: ReadonlyArray<AxialCoord> = [
   { q: 1, r: 0 },
   { q: 1, r: -1 },
   { q: 0, r: -1 },
   { q: -1, r: 0 },
   { q: -1, r: 1 },
   { q: 0, r: 1 }
-];
+] as const;
 
 /** Convert axial coordinates to pixel coordinates for pointy-topped hexes. */
 export function axialToPixel(hex: AxialCoord, size: number): PixelCoord {
@@ -37,6 +39,16 @@ export function pixelToAxial(x: number, y: number, size: number): AxialCoord {
 /** Get the six neighboring axial coordinates. */
 export function getNeighbors(hex: AxialCoord): AxialCoord[] {
   return DIRECTIONS.map((d) => ({ q: hex.q + d.q, r: hex.r + d.r }));
+}
+
+/**
+ * Get a single neighboring coordinate in a specific direction.
+ *
+ * Directions are numbered 0-5 corresponding to {@link DIRECTIONS}.
+ */
+export function getNeighbor(hex: AxialCoord, direction: number): AxialCoord {
+  const dir = DIRECTIONS[(direction % 6 + 6) % 6];
+  return { q: hex.q + dir.q, r: hex.r + dir.r };
 }
 
 function hexRound(frac: AxialCoord): AxialCoord {


### PR DESCRIPTION
## Summary
- refine hex math utilities with exported direction vectors and neighbor helpers
- expand HexTile with building placement and fog helpers
- add canvas convenience method to HexMap for easy drawing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58ef3bdd0833096be2efa23e76b16