### PR TITLE
Implement unit combat and pathfinding

### DIFF
--- a/src/units/Unit.test.ts
+++ b/src/units/Unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Unit, UnitStats } from './Unit.ts';
+import type { AxialCoord } from '../hex/HexUtils.ts';
+
+function createUnit(id: string, coord: AxialCoord, stats: UnitStats): Unit {
+  return new Unit(id, coord, 'faction', { ...stats });
+}
+
+describe('Unit combat', () => {
+  it('deals damage within range', () => {
+    const attacker = createUnit('a', { q: 0, r: 0 }, {
+      health: 10,
+      attackDamage: 3,
+      attackRange: 1,
+      movementRange: 1
+    });
+    const defender = createUnit('b', { q: 1, r: 0 }, {
+      health: 10,
+      attackDamage: 2,
+      attackRange: 1,
+      movementRange: 1
+    });
+    attacker.attack(defender);
+    expect(defender.stats.health).toBe(7);
+  });
+
+  it('does not deal damage when out of range', () => {
+    const attacker = createUnit('a', { q: 0, r: 0 }, {
+      health: 10,
+      attackDamage: 3,
+      attackRange: 1,
+      movementRange: 1
+    });
+    const defender = createUnit('b', { q: 2, r: 0 }, {
+      health: 10,
+      attackDamage: 2,
+      attackRange: 1,
+      movementRange: 1
+    });
+    attacker.attack(defender);
+    expect(defender.stats.health).toBe(10);
+  });
+
+  it('emits death event when health reaches zero', () => {
+    const attacker = createUnit('a', { q: 0, r: 0 }, {
+      health: 10,
+      attackDamage: 5,
+      attackRange: 1,
+      movementRange: 1
+    });
+    const defender = createUnit('b', { q: 1, r: 0 }, {
+      health: 4,
+      attackDamage: 2,
+      attackRange: 1,
+      movementRange: 1
+    });
+    const onDeath = vi.fn();
+    defender.onDeath(onDeath);
+    attacker.attack(defender);
+    expect(defender.stats.health).toBe(0);
+    expect(onDeath).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -1,0 +1,162 @@
+import { AxialCoord, getNeighbors } from '../hex/HexUtils.ts';
+import { HexMap } from '../hex/HexMap.ts';
+
+export interface UnitStats {
+  health: number;
+  attackDamage: number;
+  attackRange: number;
+  movementRange: number;
+}
+
+type Listener = () => void;
+
+function coordKey(c: AxialCoord): string {
+  return `${c.q},${c.r}`;
+}
+
+function fromKey(key: string): AxialCoord {
+  const [q, r] = key.split(',').map(Number);
+  return { q, r };
+}
+
+function hexDistance(a: AxialCoord, b: AxialCoord): number {
+  const ay = -a.q - a.r;
+  const by = -b.q - b.r;
+  return Math.max(
+    Math.abs(a.q - b.q),
+    Math.abs(a.r - b.r),
+    Math.abs(ay - by)
+  );
+}
+
+export class Unit {
+  private listeners: { death?: Listener[] } = {};
+
+  constructor(
+    public readonly id: string,
+    public coord: AxialCoord,
+    public readonly faction: string,
+    public readonly stats: UnitStats
+  ) {}
+
+  onDeath(cb: Listener): void {
+    (this.listeners.death ??= []).push(cb);
+  }
+
+  private emitDeath(): void {
+    for (const cb of this.listeners.death ?? []) {
+      cb();
+    }
+  }
+
+  isDead(): boolean {
+    return this.stats.health <= 0;
+  }
+
+  distanceTo(coord: AxialCoord): number {
+    return hexDistance(this.coord, coord);
+  }
+
+  attack(target: Unit): void {
+    if (this.distanceTo(target.coord) <= this.stats.attackRange) {
+      target.takeDamage(this.stats.attackDamage);
+    }
+  }
+
+  takeDamage(amount: number): void {
+    this.stats.health -= amount;
+    if (this.stats.health <= 0) {
+      this.stats.health = 0;
+      this.emitDeath();
+    }
+  }
+
+  moveTowards(target: AxialCoord, map: HexMap): void {
+    const path = this.findPath(target, map);
+    if (path.length < 2) {
+      return;
+    }
+    const steps = Math.min(this.stats.movementRange, path.length - 1);
+    this.coord = path[steps];
+  }
+
+  findPath(target: AxialCoord, map: HexMap): AxialCoord[] {
+    const start = this.coord;
+    const startKey = coordKey(start);
+    const targetKey = coordKey(target);
+    const queue: AxialCoord[] = [start];
+    const cameFrom = new Map<string, string | null>();
+    cameFrom.set(startKey, null);
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const currentKey = coordKey(current);
+      if (currentKey === targetKey) {
+        break;
+      }
+      for (const neighbor of getNeighbors(current)) {
+        if (!this.isPassable(neighbor, map)) {
+          continue;
+        }
+        const nKey = coordKey(neighbor);
+        if (cameFrom.has(nKey)) {
+          continue;
+        }
+        queue.push(neighbor);
+        cameFrom.set(nKey, currentKey);
+      }
+    }
+
+    if (!cameFrom.has(targetKey)) {
+      return [start];
+    }
+
+    const path: AxialCoord[] = [];
+    let curr: string | null = targetKey;
+    while (curr) {
+      path.push(fromKey(curr));
+      curr = cameFrom.get(curr) ?? null;
+    }
+    return path.reverse();
+  }
+
+  seekNearestEnemy(enemies: Unit[], map: HexMap): Unit | null {
+    const enemyMap = new Map<string, Unit>();
+    for (const enemy of enemies) {
+      enemyMap.set(coordKey(enemy.coord), enemy);
+    }
+    const queue: AxialCoord[] = [this.coord];
+    const visited = new Set<string>([coordKey(this.coord)]);
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const key = coordKey(current);
+      const enemy = enemyMap.get(key);
+      if (enemy) {
+        return enemy;
+      }
+      for (const neighbor of getNeighbors(current)) {
+        if (!this.isPassable(neighbor, map)) {
+          continue;
+        }
+        const nKey = coordKey(neighbor);
+        if (visited.has(nKey)) {
+          continue;
+        }
+        visited.add(nKey);
+        queue.push(neighbor);
+      }
+    }
+    return null;
+  }
+
+  private isPassable(coord: AxialCoord, map: HexMap): boolean {
+    const tile = map.getTile(coord.q, coord.r);
+    if (!tile) {
+      return false;
+    }
+    return tile.terrain !== 'water' && tile.terrain !== 'mountain';
+  }
+}
+
+export { hexDistance };
+


### PR DESCRIPTION
## Summary
- Add Unit class with health, movement, attack, and death events
- Implement hex-grid pathfinding and nearest enemy targeting
- Test combat damage, range checks, and death event emission

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c590fb586483309b09cb67944c5743