### PR TITLE
Add basic UI overlay and canvas interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,17 @@
     <title>Vite + TS</title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="game-container">
+      <canvas id="game-canvas" width="800" height="600"></canvas>
+      <div id="ui-overlay">
+        <div id="resource-bar">Resources: 0</div>
+        <div id="build-menu">
+          <button id="build-farm">Build Farm</button>
+          <button id="upgrade-farm">Upgrade Farm</button>
+          <button id="policy-eco">Eco Policy</button>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -6,6 +6,12 @@ export class GameState {
   resources = 0;
   private lastSaved = Date.now();
 
+  /** Track constructed buildings by type. */
+  private buildings: Record<string, number> = {};
+
+  /** Policies currently applied. */
+  private policies = new Set<string>();
+
   constructor(
     private readonly tickInterval: number,
     private readonly resourcePerTick = 1,
@@ -40,5 +46,35 @@ export class GameState {
     } catch {
       this.lastSaved = Date.now();
     }
+  }
+
+  /** Determine if the player can afford a cost. */
+  canAfford(cost: number): boolean {
+    return this.resources >= cost;
+  }
+
+  /** Spend resources to construct a building of the given type. */
+  construct(building: string, cost: number): boolean {
+    if (!this.canAfford(cost)) {
+      return false;
+    }
+    this.resources -= cost;
+    this.buildings[building] = (this.buildings[building] ?? 0) + 1;
+    return true;
+  }
+
+  /** Spend resources to upgrade a building. */
+  upgrade(building: string, cost: number): boolean {
+    return this.construct(`upgrade:${building}`, cost);
+  }
+
+  /** Spend resources to apply a policy. */
+  applyPolicy(policy: string, cost: number): boolean {
+    if (!this.canAfford(cost)) {
+      return false;
+    }
+    this.resources -= cost;
+    this.policies.add(policy);
+    return true;
   }
 }

--- a/src/hex/HexMap.ts
+++ b/src/hex/HexMap.ts
@@ -33,20 +33,28 @@ export class HexMap {
   }
 
   /** Draw the map onto a canvas context. */
-  draw(ctx: CanvasRenderingContext2D): void {
+  draw(ctx: CanvasRenderingContext2D, selected?: AxialCoord): void {
     this.forEachTile((tile, coord) => {
       const { x, y } = axialToPixel(coord, this.hexSize);
-      this.drawHex(ctx, x + this.hexSize, y + this.hexSize, this.hexSize, this.getFillColor(tile));
+      const isSelected = selected && coord.q === selected.q && coord.r === selected.r;
+      this.drawHex(
+        ctx,
+        x + this.hexSize,
+        y + this.hexSize,
+        this.hexSize,
+        this.getFillColor(tile),
+        Boolean(isSelected)
+      );
     });
   }
 
   /** Convenience method to draw directly to a canvas element. */
-  drawToCanvas(canvas: HTMLCanvasElement): void {
+  drawToCanvas(canvas: HTMLCanvasElement, selected?: AxialCoord): void {
     const ctx = canvas.getContext('2d');
     if (!ctx) {
       throw new Error('Canvas 2D context not available');
     }
-    this.draw(ctx);
+    this.draw(ctx, selected);
   }
 
   private getFillColor(tile: HexTile): string {
@@ -70,7 +78,8 @@ export class HexMap {
     x: number,
     y: number,
     size: number,
-    fill: string
+    fill: string,
+    selected = false
   ): void {
     ctx.beginPath();
     for (let i = 0; i < 6; i++) {
@@ -85,7 +94,7 @@ export class HexMap {
     }
     ctx.closePath();
     ctx.fillStyle = fill;
-    ctx.strokeStyle = '#000000';
+    ctx.strokeStyle = selected ? '#ff0000' : '#000000';
     ctx.fill();
     ctx.stroke();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,24 +1,86 @@
-import './style.css'
-import typescriptLogo from './typescript.svg'
-import viteLogo from '/vite.svg'
-import { setupCounter } from './counter.ts'
+import './style.css';
+import { GameState } from './core/GameState.ts';
+import { HexMap } from './hex/HexMap.ts';
+import { pixelToAxial, axialToPixel, AxialCoord } from './hex/HexUtils.ts';
+import { Unit } from './units/Unit.ts';
 
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://www.typescriptlang.org/" target="_blank">
-      <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />
-    </a>
-    <h1>Vite + TypeScript</h1>
-    <div class="card">
-      <button id="counter" type="button"></button>
-    </div>
-    <p class="read-the-docs">
-      Click on the Vite and TypeScript logos to learn more
-    </p>
-  </div>
-`
+const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
+const resourceBar = document.getElementById('resource-bar')!;
+const buildFarmBtn = document.getElementById('build-farm') as HTMLButtonElement;
+const upgradeFarmBtn = document.getElementById('upgrade-farm') as HTMLButtonElement;
+const policyBtn = document.getElementById('policy-eco') as HTMLButtonElement;
 
-setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+const map = new HexMap(10, 10, 32);
+// Reveal all tiles for simplicity
+map.forEachTile((t) => t.setFogged(false));
+
+const state = new GameState(1000);
+state.load();
+
+const units: Unit[] = [
+  new Unit('u1', { q: 2, r: 2 }, 'player', {
+    health: 10,
+    attackDamage: 2,
+    attackRange: 1,
+    movementRange: 1
+  })
+];
+
+let selected: AxialCoord | null = null;
+
+function draw(): void {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  map.draw(ctx, selected ?? undefined);
+  drawUnits(ctx);
+}
+
+function drawUnits(ctx: CanvasRenderingContext2D): void {
+  for (const unit of units) {
+    const { x, y } = axialToPixel(unit.coord, map.hexSize);
+    ctx.fillStyle = 'red';
+    ctx.beginPath();
+    ctx.arc(x + map.hexSize, y + map.hexSize, map.hexSize / 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+canvas.addEventListener('click', (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left - map.hexSize;
+  const y = e.clientY - rect.top - map.hexSize;
+  selected = pixelToAxial(x, y, map.hexSize);
+  draw();
+});
+
+function updateResources(): void {
+  resourceBar.textContent = `Resources: ${state.resources}`;
+}
+
+setInterval(() => {
+  state.tick();
+  updateResources();
+  state.save();
+}, 1000);
+
+buildFarmBtn.addEventListener('click', () => {
+  if (state.construct('farm', 10)) {
+    updateResources();
+  }
+});
+
+upgradeFarmBtn.addEventListener('click', () => {
+  if (state.upgrade('farm', 20)) {
+    updateResources();
+  }
+});
+
+policyBtn.addEventListener('click', () => {
+  if (state.applyPolicy('eco', 15)) {
+    updateResources();
+  }
+});
+
+updateResources();
+draw();

--- a/src/style.css
+++ b/src/style.css
@@ -30,6 +30,36 @@ body {
   min-height: 100vh;
 }
 
+#game-container {
+  position: relative;
+}
+
+#game-canvas {
+  display: block;
+  border: 1px solid #333;
+}
+
+#ui-overlay {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+}
+
+#resource-bar {
+  pointer-events: auto;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 4px;
+}
+
+#build-menu {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  pointer-events: auto;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 4px;
+}
+
 h1 {
   font-size: 3.2em;
   line-height: 1.1;


### PR DESCRIPTION
## Summary
- Add HTML/CSS overlay with resource bar and build menu buttons
- Enable tile selection with canvas click handler and selection highlight
- Wire UI buttons to new GameState construction, upgrade, and policy APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5921816b48330b5ef41093dfcb104