### PR TITLE
Add asset loader with data URL placeholders

### DIFF
--- a/public/assets/sounds/README.md
+++ b/public/assets/sounds/README.md
@@ -1,0 +1,1 @@
+Placeholder sound assets should be placed here.

--- a/public/assets/sprites/README.md
+++ b/public/assets/sprites/README.md
@@ -1,0 +1,1 @@
+Placeholder sprite assets should be placed here.

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,0 +1,41 @@
+export type AssetPaths = {
+  images?: Record<string, string>;
+  sounds?: Record<string, string>;
+};
+
+export type LoadedAssets = {
+  images: Record<string, HTMLImageElement>;
+  sounds: Record<string, HTMLAudioElement>;
+};
+
+export async function loadAssets(paths: AssetPaths): Promise<LoadedAssets> {
+  const images: Record<string, HTMLImageElement> = {};
+  const imagePromises = Object.entries(paths.images ?? {}).map(([key, src]) => {
+    return new Promise<void>((resolve, reject) => {
+      const img = new Image();
+      img.src = src;
+      img.onload = () => {
+        images[key] = img;
+        resolve();
+      };
+      img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+    });
+  });
+
+  const sounds: Record<string, HTMLAudioElement> = {};
+  const soundPromises = Object.entries(paths.sounds ?? {}).map(([key, src]) => {
+    return new Promise<void>((resolve, reject) => {
+      const audio = new Audio();
+      audio.src = src;
+      audio.oncanplaythrough = () => {
+        sounds[key] = audio;
+        resolve();
+      };
+      audio.onerror = () => reject(new Error(`Failed to load sound: ${src}`));
+      audio.load();
+    });
+  });
+
+  await Promise.all([...imagePromises, ...soundPromises]);
+  return { images, sounds };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { HexMap } from './hex/HexMap.ts';
 import { pixelToAxial, axialToPixel, AxialCoord } from './hex/HexUtils.ts';
 import { Unit } from './units/Unit.ts';
 import { eventBus } from './events';
+import { loadAssets, AssetPaths, LoadedAssets } from './loader.ts';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const resourceBar = document.getElementById('resource-bar')!;
@@ -11,6 +12,19 @@ const eventLog = document.getElementById('event-log')!;
 const buildFarmBtn = document.getElementById('build-farm') as HTMLButtonElement;
 const upgradeFarmBtn = document.getElementById('upgrade-farm') as HTMLButtonElement;
 const policyBtn = document.getElementById('policy-eco') as HTMLButtonElement;
+
+const assetPaths: AssetPaths = {
+  images: {
+    placeholder:
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII='
+  },
+  sounds: {
+    // Minimal silent WAV
+    placeholder:
+      'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YQAAAAA='
+  }
+};
+let assets: LoadedAssets;
 
 const map = new HexMap(10, 10, 32);
 // Reveal all tiles for simplicity
@@ -72,11 +86,6 @@ eventBus.on('policyApplied', ({ policy }) => {
   log(`Policy applied: ${policy}`);
 });
 
-setInterval(() => {
-  state.tick();
-  state.save();
-}, 1000);
-
 buildFarmBtn.addEventListener('click', () => {
   state.construct('farm', 10);
 });
@@ -89,5 +98,14 @@ policyBtn.addEventListener('click', () => {
   state.applyPolicy('eco', 15);
 });
 
-resourceBar.textContent = `Resources: ${state.getResource(Resource.GOLD)}`;
-draw();
+async function start(): Promise<void> {
+  assets = await loadAssets(assetPaths);
+  resourceBar.textContent = `Resources: ${state.getResource(Resource.GOLD)}`;
+  draw();
+  setInterval(() => {
+    state.tick();
+    state.save();
+  }, 1000);
+}
+
+start();


### PR DESCRIPTION
## Summary
- replace binary placeholders with inline data URLs for image and sound
- document placeholder directories under `public/assets`
- keep asset loader to preload resources before game start

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5941d269c8330ac408e178cbb69ff