### PR TITLE
feat: add hex grid utilities and tests

### DIFF
--- a/src/hex/HexTile.test.ts
+++ b/src/hex/HexTile.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { HexTile } from './HexTile.ts';
+
+describe('HexTile', () => {
+  it('tracks terrain, building and fog state', () => {
+    const tile = new HexTile('water', null, true);
+    expect(tile.terrain).toBe('water');
+    expect(tile.isFogged).toBe(true);
+    tile.reveal();
+    expect(tile.isFogged).toBe(false);
+    tile.placeBuilding('city');
+    expect(tile.building).toBe('city');
+    tile.setFogged(true);
+    expect(tile.isFogged).toBe(true);
+  });
+});

--- a/src/hex/HexUtils.test.ts
+++ b/src/hex/HexUtils.test.ts
@@ -1,0 +1,26 @@
+import { axialToPixel, pixelToAxial, getNeighbors, getNeighbor, hexRound } from './HexUtils.ts';
+import { describe, it, expect } from 'vitest';
+
+describe('HexUtils', () => {
+  it('converts axial to pixel and back', () => {
+    const size = 10;
+    const coord = { q: 2, r: -3 };
+    const pixel = axialToPixel(coord, size);
+    const back = pixelToAxial(pixel.x, pixel.y, size);
+    expect(back).toEqual(coord);
+  });
+
+  it('provides neighbor lookups', () => {
+    const origin = { q: 0, r: 0 };
+    const neighbors = getNeighbors(origin);
+    expect(neighbors).toHaveLength(6);
+    expect(neighbors).toContainEqual({ q: 1, r: 0 });
+    const dir = getNeighbor(origin, 2);
+    expect(dir).toEqual(neighbors[2]);
+  });
+
+  it('rounds fractional coordinates', () => {
+    const rounded = hexRound({ q: 1.2, r: -0.7 });
+    expect(rounded).toEqual({ q: 1, r: -1 });
+  });
+});

--- a/src/hex/HexUtils.ts
+++ b/src/hex/HexUtils.ts
@@ -51,7 +51,8 @@ export function getNeighbor(hex: AxialCoord, direction: number): AxialCoord {
   return { q: hex.q + dir.q, r: hex.r + dir.r };
 }
 
-function hexRound(frac: AxialCoord): AxialCoord {
+/** Round a fractional axial coordinate to the nearest valid hex. */
+export function hexRound(frac: AxialCoord): AxialCoord {
   let x = frac.q;
   let z = frac.r;
   let y = -x - z;

--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { HexMap } from './hexmap.ts';
+import { HexTile } from './hex/HexTile.ts';
+
+describe('HexMap', () => {
+  it('generates a grid of tiles', () => {
+    const map = new HexMap(3, 3);
+    let count = 0;
+    map.forEachTile(() => count++);
+    expect(count).toBe(9);
+    expect(map.getTile(0, 0)).toBeInstanceOf(HexTile);
+  });
+
+  it('returns neighboring tiles', () => {
+    const map = new HexMap(3, 3);
+    const neighbors = map.getNeighbors(1, 1);
+    expect(neighbors).toHaveLength(6);
+    neighbors.forEach((tile) => expect(tile).toBeInstanceOf(HexTile));
+  });
+});

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -1,4 +1,4 @@
-import { AxialCoord, axialToPixel } from './hex/HexUtils.ts';
+import { AxialCoord, axialToPixel, getNeighbors as axialNeighbors } from './hex/HexUtils.ts';
 import { HexTile } from './hex/HexTile.ts';
 
 /** Simple hex map composed of tiles in axial coordinates. */
@@ -30,6 +30,13 @@ export class HexMap {
         cb(this.tiles[r][q], { q, r });
       }
     }
+  }
+
+  /** Retrieve existing neighbor tiles around the given coordinate. */
+  getNeighbors(q: number, r: number): HexTile[] {
+    return axialNeighbors({ q, r })
+      .map((c) => this.getTile(c.q, c.r))
+      .filter((t): t is HexTile => Boolean(t));
   }
 
   /** Draw the map onto a canvas context. */


### PR DESCRIPTION
## Summary
- add neighbor lookup to `HexMap`
- expose hex rounding helper in `HexUtils`
- cover hex utilities, tiles, and map with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5c1477318833081f054a3b53e32c4