### PR TITLE
feat: add event bus off method

### DIFF
--- a/src/events/EventBus.test.ts
+++ b/src/events/EventBus.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from './EventBus';
+
+describe('EventBus.off', () => {
+  it('removes a specific listener', () => {
+    const bus = new EventBus();
+    const listener = vi.fn();
+    const other = vi.fn();
+    bus.on('test', listener);
+    bus.on('test', other);
+
+    bus.off('test', listener);
+    bus.emit('test', 42);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(other).toHaveBeenCalledWith(42);
+  });
+});

--- a/src/events/EventBus.ts
+++ b/src/events/EventBus.ts
@@ -9,6 +9,20 @@ export class EventBus {
     this.listeners.set(event, list);
   }
 
+  off<T>(event: string, listener: Listener<T>): void {
+    const list = this.listeners.get(event);
+    if (!list) return;
+    const idx = list.indexOf(listener as Listener<any>);
+    if (idx !== -1) {
+      list.splice(idx, 1);
+      if (list.length === 0) {
+        this.listeners.delete(event);
+      } else {
+        this.listeners.set(event, list);
+      }
+    }
+  }
+
   emit<T>(event: string, payload: T): void {
     const list = this.listeners.get(event);
     if (!list) return;

--- a/src/events/policies.ts
+++ b/src/events/policies.ts
@@ -4,10 +4,13 @@ import { Resource } from '../core/GameState';
 
 type PolicyPayload = { policy: string; state: GameState };
 
-// Example policy listeners.
-eventBus.on<PolicyPayload>('policyApplied', ({ policy, state }) => {
+const onPolicyApplied = ({ policy, state }: PolicyPayload): void => {
   if (policy === 'eco') {
     // Increase gold generation by 1 when eco policy applied
     state.modifyPassiveGeneration(Resource.GOLD, 1);
+    eventBus.off('policyApplied', onPolicyApplied);
   }
-});
+};
+
+// Example policy listeners.
+eventBus.on<PolicyPayload>('policyApplied', onPolicyApplied);

--- a/src/game.ts
+++ b/src/game.ts
@@ -81,14 +81,21 @@ function log(msg: string): void {
   eventLog.appendChild(div);
 }
 
-eventBus.on('resourceChanged', ({ resource, total, amount }) => {
+const onResourceChanged = ({ resource, total, amount }) => {
   resourceBar.textContent = `Resources: ${total}`;
   const sign = amount > 0 ? '+' : '';
   log(`${resource}: ${sign}${amount}`);
-});
+};
+eventBus.on('resourceChanged', onResourceChanged);
 
-eventBus.on('policyApplied', ({ policy }) => {
+const onPolicyApplied = ({ policy }) => {
   log(`Policy applied: ${policy}`);
+};
+eventBus.on('policyApplied', onPolicyApplied);
+
+window.addEventListener('beforeunload', () => {
+  eventBus.off('resourceChanged', onResourceChanged);
+  eventBus.off('policyApplied', onPolicyApplied);
 });
 
 buildFarmBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add `off` method to `EventBus` for removing registered listeners
- unregister long-lived listeners in policy and game modules
- test `EventBus.off` to ensure listeners are removed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c66d0ad9ac83309078c44861440958