### PR TITLE
test: cover construct and upgrade resource handling

### DIFF
--- a/src/core/GameState.test.ts
+++ b/src/core/GameState.test.ts
@@ -33,4 +33,32 @@ describe('GameState', () => {
     state.tick();
     expect(state.getResource(Resource.GOLD)).toBe(2); // base 1 + eco policy
   });
+
+  it('constructs and upgrades buildings when affordable', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 100);
+
+    const built = state.construct('hut', 60);
+    const upgraded = state.upgrade('hut', 30);
+
+    expect(built).toBe(true);
+    expect(upgraded).toBe(true);
+    expect(state.getResource(Resource.GOLD)).toBe(10);
+    expect((state as any).buildings['hut']).toBe(1);
+    expect((state as any).buildings['upgrade:hut']).toBe(1);
+  });
+
+  it('fails to construct or upgrade without sufficient resources', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 5);
+
+    const built = state.construct('hut', 10);
+    const upgraded = state.upgrade('hut', 10);
+
+    expect(built).toBe(false);
+    expect(upgraded).toBe(false);
+    expect(state.getResource(Resource.GOLD)).toBe(5);
+    expect((state as any).buildings['hut']).toBeUndefined();
+    expect((state as any).buildings['upgrade:hut']).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for constructing and upgrading buildings
- verify insufficient resources prevent construction and upgrades

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6739c45508330a60c01aa755bd4f9