### PR TITLE
Add basic building system with farm and barracks

### DIFF
--- a/src/buildings/Barracks.ts
+++ b/src/buildings/Barracks.ts
@@ -1,0 +1,10 @@
+import type { BuildingType } from '../hex/HexTile.ts';
+import type { Building } from './Building.ts';
+
+/** Military building capable of training units. */
+export class Barracks implements Building {
+  readonly type: BuildingType = 'barracks';
+  readonly cost = 100;
+  /** Number of units that can be trained simultaneously. */
+  readonly trainingCapacity = 1;
+}

--- a/src/buildings/Building.ts
+++ b/src/buildings/Building.ts
@@ -1,0 +1,9 @@
+import type { BuildingType } from '../hex/HexTile.ts';
+
+/** Basic building interface shared by all buildings. */
+export interface Building {
+  /** Unique string identifier for the building type. */
+  readonly type: BuildingType;
+  /** One-time gold cost to construct the building. */
+  readonly cost: number;
+}

--- a/src/buildings/Farm.ts
+++ b/src/buildings/Farm.ts
@@ -1,0 +1,10 @@
+import type { BuildingType } from '../hex/HexTile.ts';
+import type { Building } from './Building.ts';
+
+/** Simple economic building that increases food production. */
+export class Farm implements Building {
+  readonly type: BuildingType = 'farm';
+  readonly cost = 50;
+  /** Amount of food generated each tick. */
+  readonly foodPerTick = 1;
+}

--- a/src/buildings/index.ts
+++ b/src/buildings/index.ts
@@ -1,0 +1,3 @@
+export * from './Building.ts';
+export * from './Farm.ts';
+export * from './Barracks.ts';

--- a/src/game.ts
+++ b/src/game.ts
@@ -6,11 +6,13 @@ import { pixelToAxial, axialToPixel, AxialCoord } from './hex/HexUtils.ts';
 import { Unit } from './unit.ts';
 import { eventBus } from './events';
 import { loadAssets, AssetPaths, LoadedAssets } from './loader.ts';
+import { Farm, Barracks } from './buildings/index.ts';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const resourceBar = document.getElementById('resource-bar')!;
 const eventLog = document.getElementById('event-log')!;
 const buildFarmBtn = document.getElementById('build-farm') as HTMLButtonElement;
+const buildBarracksBtn = document.getElementById('build-barracks') as HTMLButtonElement;
 const upgradeFarmBtn = document.getElementById('upgrade-farm') as HTMLButtonElement;
 const policyBtn = document.getElementById('policy-eco') as HTMLButtonElement;
 
@@ -99,7 +101,19 @@ window.addEventListener('beforeunload', () => {
 });
 
 buildFarmBtn.addEventListener('click', () => {
-  state.construct('farm', 10);
+  if (!selected) return;
+  if (state.placeBuilding(new Farm(), selected, map)) {
+    log('Farm constructed');
+    draw();
+  }
+});
+
+buildBarracksBtn.addEventListener('click', () => {
+  if (!selected) return;
+  if (state.placeBuilding(new Barracks(), selected, map)) {
+    log('Barracks constructed');
+    draw();
+  }
 });
 
 upgradeFarmBtn.addEventListener('click', () => {

--- a/src/hex/HexTile.ts
+++ b/src/hex/HexTile.ts
@@ -1,5 +1,5 @@
 export type TerrainType = 'plain' | 'water' | 'forest' | 'mountain';
-export type BuildingType = 'city' | 'farm' | 'mine' | null;
+export type BuildingType = 'city' | 'farm' | 'barracks' | 'mine' | null;
 
 /** Represents a single hex tile on the map. */
 export class HexTile {

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
         <div id="event-log"></div>
         <div id="build-menu">
           <button id="build-farm">Build Farm</button>
+          <button id="build-barracks">Build Barracks</button>
           <button id="upgrade-farm">Upgrade Farm</button>
           <button id="policy-eco">Eco Policy</button>
         </div>


### PR DESCRIPTION
## Summary
- introduce Farm and Barracks building classes with costs and simple stats
- extend GameState to place building instances on hex map tiles
- allow constructing farms and barracks on selected hexes via new UI buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6756425ac8330b8cedaf25ff021f1