### PR TITLE
Add unit subclasses and spawning mechanic with tests

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -3,7 +3,7 @@ import { GameState, Resource } from './core/GameState.ts';
 import { GameClock } from './core/GameClock.ts';
 import { HexMap } from './hexmap.ts';
 import { pixelToAxial, axialToPixel, AxialCoord } from './hex/HexUtils.ts';
-import { Unit } from './unit.ts';
+import { Unit, spawnUnit, UnitType } from './unit.ts';
 import { eventBus } from './events';
 import { loadAssets, AssetPaths, LoadedAssets } from './loader.ts';
 
@@ -38,14 +38,18 @@ const clock = new GameClock(1000, () => {
   state.save();
 });
 
-const units: Unit[] = [
-  new Unit('u1', { q: 2, r: 2 }, 'player', {
-    health: 10,
-    attackDamage: 2,
-    attackRange: 1,
-    movementRange: 1
-  })
-];
+const units: Unit[] = [];
+
+function spawn(type: UnitType, coord: AxialCoord): void {
+  const id = `u${units.length + 1}`;
+  const unit = spawnUnit(state, type, id, coord, 'player');
+  if (unit) {
+    units.push(unit);
+  }
+}
+
+state.addResource(Resource.GOLD, 200);
+spawn('soldier', { q: 2, r: 2 });
 
 let selected: AxialCoord | null = null;
 

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -1,1 +1,4 @@
 export * from './units/Unit.ts';
+export * from './units/Soldier.ts';
+export * from './units/Archer.ts';
+export * from './units/UnitFactory.ts';

--- a/src/units/Archer.ts
+++ b/src/units/Archer.ts
@@ -1,0 +1,18 @@
+import { Unit, UnitStats } from './Unit.ts';
+import type { AxialCoord } from '../hex/HexUtils.ts';
+
+export const ARCHER_STATS: UnitStats = {
+  health: 15,
+  attackDamage: 3,
+  attackRange: 3,
+  movementRange: 2
+};
+
+export const ARCHER_COST = 75;
+
+export class Archer extends Unit {
+  constructor(id: string, coord: AxialCoord, faction: string) {
+    super(id, coord, faction, { ...ARCHER_STATS });
+  }
+}
+

--- a/src/units/Soldier.ts
+++ b/src/units/Soldier.ts
@@ -1,0 +1,18 @@
+import { Unit, UnitStats } from './Unit.ts';
+import type { AxialCoord } from '../hex/HexUtils.ts';
+
+export const SOLDIER_STATS: UnitStats = {
+  health: 20,
+  attackDamage: 5,
+  attackRange: 1,
+  movementRange: 2
+};
+
+export const SOLDIER_COST = 50;
+
+export class Soldier extends Unit {
+  constructor(id: string, coord: AxialCoord, faction: string) {
+    super(id, coord, faction, { ...SOLDIER_STATS });
+  }
+}
+

--- a/src/units/UnitFactory.test.ts
+++ b/src/units/UnitFactory.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { GameState, Resource } from '../core/GameState.ts';
+import { spawnUnit } from './UnitFactory.ts';
+import { SOLDIER_STATS, SOLDIER_COST } from './Soldier.ts';
+import { ARCHER_STATS, ARCHER_COST } from './Archer.ts';
+
+const origin = { q: 0, r: 0 };
+
+describe('UnitFactory', () => {
+  it('spawns a soldier and deducts resources', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 100);
+    const unit = spawnUnit(state, 'soldier', 's1', origin, 'player');
+    expect(unit).not.toBeNull();
+    expect(unit!.stats).toEqual(SOLDIER_STATS);
+    expect(state.getResource(Resource.GOLD)).toBe(100 - SOLDIER_COST);
+  });
+
+  it('spawns an archer with correct stats', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 200);
+    const unit = spawnUnit(state, 'archer', 'a1', origin, 'player');
+    expect(unit).not.toBeNull();
+    expect(unit!.stats).toEqual(ARCHER_STATS);
+    expect(state.getResource(Resource.GOLD)).toBe(200 - ARCHER_COST);
+  });
+
+  it('fails when resources are insufficient', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 10);
+    const unit = spawnUnit(state, 'soldier', 's1', origin, 'player');
+    expect(unit).toBeNull();
+    expect(state.getResource(Resource.GOLD)).toBe(10);
+  });
+});
+

--- a/src/units/UnitFactory.ts
+++ b/src/units/UnitFactory.ts
@@ -1,0 +1,35 @@
+import type { AxialCoord } from '../hex/HexUtils.ts';
+import { GameState, Resource } from '../core/GameState.ts';
+import { Unit } from './Unit.ts';
+import { Soldier, SOLDIER_COST } from './Soldier.ts';
+import { Archer, ARCHER_COST } from './Archer.ts';
+
+export type UnitType = 'soldier' | 'archer';
+
+const UNIT_COST: Record<UnitType, number> = {
+  soldier: SOLDIER_COST,
+  archer: ARCHER_COST
+};
+
+export function spawnUnit(
+  state: GameState,
+  type: UnitType,
+  id: string,
+  coord: AxialCoord,
+  faction: string
+): Unit | null {
+  const cost = UNIT_COST[type];
+  if (!state.canAfford(cost, Resource.GOLD)) {
+    return null;
+  }
+  state.addResource(Resource.GOLD, -cost);
+  switch (type) {
+    case 'soldier':
+      return new Soldier(id, coord, faction);
+    case 'archer':
+      return new Archer(id, coord, faction);
+    default:
+      return null;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `Soldier` and `Archer` unit subclasses with unique stats and costs
- implement `spawnUnit` factory and use it in game to spawn units using resources
- cover spawning behavior with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6759748d48330b11d29acee144a77