### PR TITLE
Add battle manager with combat events

### DIFF
--- a/src/battle/BattleManager.test.ts
+++ b/src/battle/BattleManager.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { BattleManager } from './BattleManager.ts';
+import { Unit, UnitStats } from '../units/Unit.ts';
+import { HexMap } from '../hexmap.ts';
+import { eventBus } from '../events';
+
+function createUnit(
+  id: string,
+  coord: { q: number; r: number },
+  faction: string,
+  stats: UnitStats
+): Unit {
+  return new Unit(id, coord, faction, { ...stats });
+}
+
+describe('BattleManager', () => {
+  it('moves units toward enemies and handles combat events', () => {
+    const map = new HexMap(5, 5);
+    const attacker = createUnit('a', { q: 0, r: 0 }, 'A', {
+      health: 10,
+      attackDamage: 5,
+      attackRange: 1,
+      movementRange: 1
+    });
+    const defender = createUnit('b', { q: 2, r: 0 }, 'B', {
+      health: 5,
+      attackDamage: 1,
+      attackRange: 1,
+      movementRange: 0
+    });
+
+    const manager = new BattleManager(map);
+    const units = [attacker, defender];
+
+    const damageEvents: any[] = [];
+    const deathEvents: any[] = [];
+    const onDamage = (e: any) => damageEvents.push(e);
+    const onDeath = (e: any) => deathEvents.push(e);
+    eventBus.on('unitDamaged', onDamage);
+    eventBus.on('unitDied', onDeath);
+
+    manager.tick(units);
+
+    eventBus.off('unitDamaged', onDamage);
+    eventBus.off('unitDied', onDeath);
+
+    expect(attacker.coord).toEqual({ q: 1, r: 0 });
+    expect(damageEvents).toHaveLength(1);
+    expect(deathEvents).toHaveLength(1);
+    expect(damageEvents[0]).toMatchObject({
+      attackerId: 'a',
+      targetId: 'b',
+      amount: 5,
+      remainingHealth: 0
+    });
+    expect(deathEvents[0]).toMatchObject({ unitId: 'b', attackerId: 'a' });
+  });
+});
+

--- a/src/battle/BattleManager.ts
+++ b/src/battle/BattleManager.ts
@@ -1,0 +1,27 @@
+import { Unit } from '../units/Unit.ts';
+import { HexMap } from '../hexmap.ts';
+
+/** Handles unit movement and combat each game tick. */
+export class BattleManager {
+  constructor(private readonly map: HexMap) {}
+
+  /** Process a single game tick for the provided units. */
+  tick(units: Unit[]): void {
+    for (const unit of units) {
+      if (unit.isDead()) continue;
+      const enemies = units.filter(
+        (u) => u.faction !== unit.faction && !u.isDead()
+      );
+      if (enemies.length === 0) continue;
+      const target = unit.seekNearestEnemy(enemies, this.map);
+      if (!target) continue;
+      if (unit.distanceTo(target.coord) > unit.stats.attackRange) {
+        unit.moveTowards(target.coord, this.map);
+      }
+      if (unit.distanceTo(target.coord) <= unit.stats.attackRange && !target.isDead()) {
+        unit.attack(target);
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add `BattleManager` to move units toward enemies and handle attacks each tick
- Emit `unitDamaged` and `unitDied` events from `Unit` for UI and log updates
- Test combat simulation ensuring movement, damage, and death events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6780603e883308fc76294aed692c8