### PR TITLE
Implement targeting system for units

### DIFF
--- a/src/ai/Targeting.test.ts
+++ b/src/ai/Targeting.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { Targeting } from './Targeting.ts';
+import { Unit, UnitStats } from '../units/Unit.ts';
+
+function createUnit(
+  id: string,
+  coord: { q: number; r: number },
+  faction: string,
+  stats: UnitStats,
+  priorityFactions: string[] = []
+): Unit {
+  return new Unit(id, coord, faction, { ...stats }, priorityFactions);
+}
+
+describe('Targeting', () => {
+  it('prefers enemies of priority faction within range', () => {
+    const attacker = createUnit('a', { q: 0, r: 0 }, 'A', {
+      health: 10,
+      attackDamage: 1,
+      attackRange: 1,
+      movementRange: 0
+    }, ['B']);
+    const enemyB = createUnit('b', { q: 1, r: 0 }, 'B', {
+      health: 5,
+      attackDamage: 0,
+      attackRange: 0,
+      movementRange: 0
+    });
+    const enemyC = createUnit('c', { q: 0, r: 1 }, 'C', {
+      health: 1,
+      attackDamage: 0,
+      attackRange: 0,
+      movementRange: 0
+    });
+    const target = Targeting.selectTarget(attacker, [attacker, enemyB, enemyC]);
+    expect(target?.id).toBe('b');
+  });
+
+  it('chooses lowest health enemy when no priority faction', () => {
+    const attacker = createUnit('a', { q: 0, r: 0 }, 'A', {
+      health: 10,
+      attackDamage: 1,
+      attackRange: 2,
+      movementRange: 0
+    });
+    const enemy1 = createUnit('b', { q: 1, r: 0 }, 'B', {
+      health: 5,
+      attackDamage: 0,
+      attackRange: 0,
+      movementRange: 0
+    });
+    const enemy2 = createUnit('c', { q: 2, r: 0 }, 'B', {
+      health: 3,
+      attackDamage: 0,
+      attackRange: 0,
+      movementRange: 0
+    });
+    const target = Targeting.selectTarget(attacker, [attacker, enemy1, enemy2]);
+    expect(target?.id).toBe('c');
+  });
+});

--- a/src/ai/Targeting.ts
+++ b/src/ai/Targeting.ts
@@ -1,0 +1,40 @@
+import { Unit } from '../units/Unit.ts';
+
+/** Target selection logic for units. */
+export class Targeting {
+  /**
+   * Select an enemy target for a unit based on faction priorities, range and distance.
+   */
+  static selectTarget(unit: Unit, units: Unit[]): Unit | null {
+    let enemies = units.filter(
+      (u) => u.faction !== unit.faction && !u.isDead()
+    );
+    if (enemies.length === 0) {
+      return null;
+    }
+
+    if (unit.priorityFactions.length > 0) {
+      const preferred = enemies.filter((e) =>
+        unit.priorityFactions.includes(e.faction)
+      );
+      if (preferred.length > 0) {
+        enemies = preferred;
+      }
+    }
+
+    const inRange = enemies.filter(
+      (e) => unit.distanceTo(e.coord) <= unit.stats.attackRange
+    );
+    if (inRange.length > 0) {
+      inRange.sort((a, b) => a.stats.health - b.stats.health);
+      return inRange[0];
+    }
+
+    enemies.sort(
+      (a, b) => unit.distanceTo(a.coord) - unit.distanceTo(b.coord)
+    );
+    return enemies[0] ?? null;
+  }
+}
+
+export default Targeting;

--- a/src/battle/BattleManager.test.ts
+++ b/src/battle/BattleManager.test.ts
@@ -8,9 +8,10 @@ function createUnit(
   id: string,
   coord: { q: number; r: number },
   faction: string,
-  stats: UnitStats
+  stats: UnitStats,
+  priorityFactions: string[] = []
 ): Unit {
-  return new Unit(id, coord, faction, { ...stats });
+  return new Unit(id, coord, faction, { ...stats }, priorityFactions);
 }
 
 describe('BattleManager', () => {
@@ -54,6 +55,36 @@ describe('BattleManager', () => {
       remainingHealth: 0
     });
     expect(deathEvents[0]).toMatchObject({ unitId: 'b', attackerId: 'a' });
+  });
+
+  it('prioritizes targets based on faction when multiple enemies are in range', () => {
+    const map = new HexMap(5, 5);
+    const attacker = createUnit('a', { q: 0, r: 0 }, 'A', {
+      health: 10,
+      attackDamage: 5,
+      attackRange: 1,
+      movementRange: 0
+    }, ['B']);
+    const defenderB = createUnit('b', { q: 1, r: 0 }, 'B', {
+      health: 5,
+      attackDamage: 0,
+      attackRange: 0,
+      movementRange: 0
+    });
+    const defenderC = createUnit('c', { q: 0, r: 1 }, 'C', {
+      health: 5,
+      attackDamage: 0,
+      attackRange: 0,
+      movementRange: 0
+    });
+
+    const manager = new BattleManager(map);
+    const units = [attacker, defenderB, defenderC];
+
+    manager.tick(units);
+
+    expect(defenderB.stats.health).toBe(0);
+    expect(defenderC.stats.health).toBe(5);
   });
 });
 

--- a/src/battle/BattleManager.ts
+++ b/src/battle/BattleManager.ts
@@ -1,5 +1,6 @@
 import { Unit } from '../units/Unit.ts';
 import { HexMap } from '../hexmap.ts';
+import { Targeting } from '../ai/Targeting.ts';
 
 /** Handles unit movement and combat each game tick. */
 export class BattleManager {
@@ -9,11 +10,7 @@ export class BattleManager {
   tick(units: Unit[]): void {
     for (const unit of units) {
       if (unit.isDead()) continue;
-      const enemies = units.filter(
-        (u) => u.faction !== unit.faction && !u.isDead()
-      );
-      if (enemies.length === 0) continue;
-      const target = unit.seekNearestEnemy(enemies, this.map);
+      const target = Targeting.selectTarget(unit, units);
       if (!target) continue;
       if (unit.distanceTo(target.coord) > unit.stats.attackRange) {
         unit.moveTowards(target.coord, this.map);

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -39,7 +39,8 @@ export class Unit {
     public readonly id: string,
     public coord: AxialCoord,
     public readonly faction: string,
-    public readonly stats: UnitStats
+    public readonly stats: UnitStats,
+    public readonly priorityFactions: string[] = []
   ) {}
 
   onDeath(cb: Listener): void {


### PR DESCRIPTION
## Summary
- add Targeting component to choose enemy based on range, faction priority and health
- integrate Targeting with BattleManager for automatic target pursuit
- extend Unit with faction priorities and add tests for target selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c67922f8a4833080dbe603936f7e72