### PR TITLE
Add CI workflow for Node tests and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- add CI workflow running npm install, tests, and build on pushes and pull requests

## Testing
- `npm test`
- `npm run build` *(fails: TS1484 type-only import required, TS1294 syntax not allowed, TS2345 string|null not assignable)*

------
https://chatgpt.com/codex/tasks/task_e_68c67b2539d883308cfb7457605ef98b