### PR TITLE
feat: render map and units using sprite images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Sprite assets (binary files not tracked)
+public/assets/sprites/*.png
+public/assets/sprites/*.jpg
+public/assets/sprites/*.gif

--- a/public/assets/sprites/README.md
+++ b/public/assets/sprites/README.md
@@ -1,1 +1,3 @@
-Placeholder sprite assets should be placed here.
+Binary sprite assets are not tracked in this repository.
+The game currently relies on inline base64 placeholders defined in code.
+Add real sprite files here locally if desired (they are ignored by git).

--- a/src/game.ts
+++ b/src/game.ts
@@ -19,7 +19,15 @@ const policyBtn = document.getElementById('policy-eco') as HTMLButtonElement;
 const assetPaths: AssetPaths = {
   images: {
     placeholder:
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII='
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=',
+    grass:
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGNU6lb6z0ABYKJE86gBowaMGjCYDAAAlL8B7iuXN0wAAAAASUVORK5CYII=',
+    water:
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGOUm/D/PwMFgIkSzaMGjBowasBgMgAAGD4CzKXqJDYAAAAASUVORK5CYII=',
+    'unit-soldier':
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGPcpKT0n4ECwESJ5lEDRg0YNWAwGQAAM4ACFQNjXqgAAAAASUVORK5CYII=',
+    farm:
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGO8tVThPwMFgIkSzaMGjBowasBgMgAA4QYCvtGd17wAAAAASUVORK5CYII='
   },
   sounds: {
     // Minimal silent WAV
@@ -57,19 +65,19 @@ let selected: AxialCoord | null = null;
 
 function draw(): void {
   const ctx = canvas.getContext('2d');
-  if (!ctx) return;
+  if (!ctx || !assets) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  map.draw(ctx, selected ?? undefined);
+  map.draw(ctx, assets.images, selected ?? undefined);
   drawUnits(ctx);
 }
 
 function drawUnits(ctx: CanvasRenderingContext2D): void {
+  const sprite = assets.images['unit-soldier'];
+  const hexWidth = map.hexSize * Math.sqrt(3);
+  const hexHeight = map.hexSize * 2;
   for (const unit of units) {
     const { x, y } = axialToPixel(unit.coord, map.hexSize);
-    ctx.fillStyle = 'red';
-    ctx.beginPath();
-    ctx.arc(x + map.hexSize, y + map.hexSize, map.hexSize / 2, 0, Math.PI * 2);
-    ctx.fill();
+    ctx.drawImage(sprite, x, y, hexWidth, hexHeight);
   }
 }
 

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -40,44 +40,45 @@ export class HexMap {
   }
 
   /** Draw the map onto a canvas context. */
-  draw(ctx: CanvasRenderingContext2D, selected?: AxialCoord): void {
+  draw(
+    ctx: CanvasRenderingContext2D,
+    images: Record<string, HTMLImageElement>,
+    selected?: AxialCoord
+  ): void {
+    const hexWidth = this.hexSize * Math.sqrt(3);
+    const hexHeight = this.hexSize * 2;
     this.forEachTile((tile, coord) => {
       const { x, y } = axialToPixel(coord, this.hexSize);
+      const terrainKey = tile.terrain === 'water' ? 'water' : 'grass';
+      const terrain = images[terrainKey] ?? images['placeholder'];
+      ctx.drawImage(terrain, x, y, hexWidth, hexHeight);
+      if (tile.building === 'farm') {
+        const building = images['farm'] ?? images['placeholder'];
+        ctx.drawImage(building, x, y, hexWidth, hexHeight);
+      }
       const isSelected = selected && coord.q === selected.q && coord.r === selected.r;
       this.drawHex(
         ctx,
         x + this.hexSize,
         y + this.hexSize,
         this.hexSize,
-        this.getFillColor(tile),
+        'rgba(0,0,0,0)',
         Boolean(isSelected)
       );
     });
   }
 
   /** Convenience method to draw directly to a canvas element. */
-  drawToCanvas(canvas: HTMLCanvasElement, selected?: AxialCoord): void {
+  drawToCanvas(
+    canvas: HTMLCanvasElement,
+    images: Record<string, HTMLImageElement>,
+    selected?: AxialCoord
+  ): void {
     const ctx = canvas.getContext('2d');
     if (!ctx) {
       throw new Error('Canvas 2D context not available');
     }
-    this.draw(ctx, selected);
-  }
-
-  private getFillColor(tile: HexTile): string {
-    if (tile.isFogged) {
-      return '#000000';
-    }
-    switch (tile.terrain) {
-      case 'water':
-        return '#1E90FF';
-      case 'forest':
-        return '#228B22';
-      case 'mountain':
-        return '#A9A9A9';
-      default:
-        return '#98FB98';
-    }
+    this.draw(ctx, images, selected);
   }
 
   private drawHex(


### PR DESCRIPTION
## Summary
- replace binary sprite files with inline base64 placeholders
- reference base64 sprites in asset loader to render tiles and units
- document and ignore binary sprite assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c67aa5f03c833099ceefbcecc803ea