### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# autobattles4xfinsauna
+
+This project uses Vite and TypeScript.
+
+## Deployment
+
+The site is published to GitHub Pages. After the workflow runs, it will be available at:
+
+https://<your-github-username>.github.io/autobattles4xfinsauna/
+
+Replace `<your-github-username>` with your GitHub account name.
+


### PR DESCRIPTION
## Summary
- add deploy workflow for GitHub Pages that builds the project and publishes `dist/`
- document the GitHub Pages URL in the README

## Testing
- `npm test`
- `npm run build` *(fails: Binding element 'amount' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68c67ef53f8c8330b570be64e4c4a471