### PR TITLE
Persist building state across save/load

### DIFF
--- a/src/core/GameState.test.ts
+++ b/src/core/GameState.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GameState, Resource } from './GameState';
+import { HexMap } from '../hexmap.ts';
+import { Farm } from '../buildings/index.ts';
 import '../events';
 
 describe('GameState', () => {
@@ -60,5 +62,21 @@ describe('GameState', () => {
     expect(state.getResource(Resource.GOLD)).toBe(5);
     expect((state as any).buildings['hut']).toBeUndefined();
     expect((state as any).buildings['upgrade:hut']).toBeUndefined();
+  });
+
+  it('persists building placements across save/load', () => {
+    const map1 = new HexMap(3, 3, 1);
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 100);
+    const coord = { q: 1, r: 1 };
+    expect(state.placeBuilding(new Farm(), coord, map1)).toBe(true);
+    state.save();
+
+    const map2 = new HexMap(3, 3, 1);
+    const loaded = new GameState(1000);
+    loaded.load(map2);
+
+    expect(map2.getTile(coord.q, coord.r)?.building).toBe('farm');
+    expect(loaded.getBuildingAt(coord)?.type).toBe('farm');
   });
 });

--- a/src/game.ts
+++ b/src/game.ts
@@ -43,7 +43,7 @@ const map = new HexMap(10, 10, 32);
 map.forEachTile((t) => t.setFogged(false));
 
 const state = new GameState(1000);
-state.load();
+state.load(map);
 const clock = new GameClock(1000, () => {
   state.tick();
   state.save();


### PR DESCRIPTION
## Summary
- Serialize building records and placements in GameState
- Restore building placements and effects when loading
- Add regression test ensuring buildings survive save/load cycles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6977cc0d4833080ad4c5d8121bcaf