### PR TITLE
Support building image lookup in HexMap

### DIFF
--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { HexMap } from './hexmap.ts';
 import { HexTile } from './hex/HexTile.ts';
 
@@ -16,5 +16,37 @@ describe('HexMap', () => {
     const neighbors = map.getNeighbors(1, 1);
     expect(neighbors).toHaveLength(6);
     neighbors.forEach((tile) => expect(tile).toBeInstanceOf(HexTile));
+  });
+
+  it('draws a barracks image when tile has a barracks building', () => {
+    const map = new HexMap(1, 1);
+    const tile = map.getTile(0, 0)!;
+    tile.placeBuilding('barracks');
+    // stub canvas context
+    const ctx = {
+      drawImage: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      fill: vi.fn(),
+      stroke: vi.fn(),
+      fillStyle: '',
+      strokeStyle: '',
+    } as unknown as CanvasRenderingContext2D;
+    const createImg = () => document.createElement('img') as HTMLImageElement;
+    const images = {
+      grass: createImg(),
+      barracks: createImg(),
+      placeholder: createImg(),
+    };
+    map.draw(ctx, images);
+    expect(ctx.drawImage).toHaveBeenCalledWith(
+      images.barracks,
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number)
+    );
   });
 });

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -52,8 +52,8 @@ export class HexMap {
       const terrainKey = tile.terrain === 'water' ? 'water' : 'grass';
       const terrain = images[terrainKey] ?? images['placeholder'];
       ctx.drawImage(terrain, x, y, hexWidth, hexHeight);
-      if (tile.building === 'farm') {
-        const building = images['farm'] ?? images['placeholder'];
+      if (tile.building) {
+        const building = images[tile.building] ?? images['placeholder'];
         ctx.drawImage(building, x, y, hexWidth, hexHeight);
       }
       const isSelected = selected && coord.q === selected.q && coord.r === selected.r;


### PR DESCRIPTION
## Summary
- draw any building tile by looking up the image via its building key
- verify barracks image rendering with new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6a59471c48330b0baf071fa964e3a