### PR TITLE
feat: add building placement effects and tests

### DIFF
--- a/src/buildings/effects.test.ts
+++ b/src/buildings/effects.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { GameState, Resource } from '../core/GameState.ts';
+import { Farm, Barracks } from './index.ts';
+import { HexMap } from '../hexmap.ts';
+import * as UnitFactory from '../units/UnitFactory.ts';
+
+// register event listeners
+import '../events';
+
+const coordFarm = { q: 0, r: 0 };
+const coordBarracks = { q: 1, r: 0 };
+
+const spawnUnitSpy = vi.spyOn(UnitFactory, 'spawnUnit');
+
+describe('building effects', () => {
+  beforeEach(() => {
+    spawnUnitSpy.mockClear();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    spawnUnitSpy.mockReset();
+  });
+
+  it('increases passive gold when a farm is placed', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 100);
+    const map = new HexMap(3, 3, 1);
+    expect(state.placeBuilding(new Farm(), coordFarm, map)).toBe(true);
+    state.tick();
+    // 100 start - 50 cost + (1 base + 1 farm) = 52
+    expect(state.getResource(Resource.GOLD)).toBe(52);
+  });
+
+  it('spawns a unit when a barracks is placed', async () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 500);
+    const map = new HexMap(3, 3, 1);
+    expect(state.placeBuilding(new Barracks(), coordBarracks, map)).toBe(true);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(spawnUnitSpy).toHaveBeenCalledWith(
+      state,
+      'soldier',
+      expect.any(String),
+      coordBarracks,
+      'player'
+    );
+  });
+});

--- a/src/buildings/effects.ts
+++ b/src/buildings/effects.ts
@@ -1,0 +1,27 @@
+import { eventBus } from '../events/EventBus.ts';
+import type { AxialCoord } from '../hex/HexUtils.ts';
+import type { GameState } from '../core/GameState.ts';
+import { Resource } from '../core/GameState.ts';
+import { Farm } from './Farm.ts';
+import { Barracks } from './Barracks.ts';
+import type { Building } from './Building.ts';
+
+export type BuildingPlacedPayload = {
+  building: Building;
+  coord: AxialCoord;
+  state: GameState;
+};
+
+const onBuildingPlaced = ({ building, coord, state }: BuildingPlacedPayload): void => {
+  if (building instanceof Farm) {
+    state.modifyPassiveGeneration(Resource.GOLD, building.foodPerTick);
+  } else if (building instanceof Barracks) {
+    // Spawn a basic unit for the player when barracks is placed
+    import('../units/UnitFactory.ts').then(({ spawnUnit }) => {
+      spawnUnit(state, 'soldier', `barracks-${coord.q}-${coord.r}`, coord, 'player');
+    });
+  }
+};
+
+// register listeners for building effects
+eventBus.on<BuildingPlacedPayload>('buildingPlaced', onBuildingPlaced);

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -188,6 +188,7 @@ export class GameState {
     }
     this.buildingPlacements.set(coordKey(coord), building);
     tile.placeBuilding(building.type);
+    eventBus.emit('buildingPlaced', { building, coord, state: this });
     return true;
   }
 

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -2,3 +2,5 @@ export { eventBus } from './EventBus';
 
 // register policy listeners
 import './policies';
+// register building listeners
+import '../buildings/effects.ts';


### PR DESCRIPTION
## Summary
- emit `buildingPlaced` events from `GameState.placeBuilding`
- add building effect listeners to grant passive gold and spawn units
- cover building effects with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6a7f6a8c883308c0956ba6ddc87c3