### PR TITLE
Emit buildingPlaced on load and test farm bonus persistence

### DIFF
--- a/src/core/GameState.test.ts
+++ b/src/core/GameState.test.ts
@@ -95,4 +95,20 @@ describe('GameState', () => {
     expect((loaded as any).buildings['farm']).toBe(1);
     expect(map2.getTile(coord.q, coord.r)?.building).toBe('farm');
   });
+
+  it("retains farm passive bonus after save/load", () => {
+    const map1 = new HexMap(3, 3, 1);
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 100);
+    const coord = { q: 0, r: 0 };
+    expect(state.placeBuilding(new Farm(), coord, map1)).toBe(true);
+    state.save();
+
+    const map2 = new HexMap(3, 3, 1);
+    const loaded = new GameState(1000);
+    loaded.load(map2);
+    loaded.tick();
+
+    expect(loaded.getResource(Resource.GOLD)).toBe(52);
+  });
 });

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -103,11 +103,12 @@ export class GameState {
           const b = createBuilding(type);
           if (!b) return;
           this.buildingPlacements.set(key, b);
+          const [q, r] = key.split(',').map(Number);
           if (map) {
-            const [q, r] = key.split(',').map(Number);
             const tile = map.getTile(q, r);
             tile?.placeBuilding(b.type);
           }
+          eventBus.emit('buildingPlaced', { building: b, coord: { q, r }, state: this });
         });
       }
       this.lastSaved = data.lastSaved ?? Date.now();


### PR DESCRIPTION
## Summary
- Emit `buildingPlaced` for each saved building when loading so effects reapply
- Add regression test to ensure farm foodPerTick bonus persists after save/load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6b3855de883309ec0e804df78c380