### PR TITLE
feat: allow building removal

### DIFF
--- a/src/buildings/effects.test.ts
+++ b/src/buildings/effects.test.ts
@@ -46,4 +46,18 @@ describe('building effects', () => {
       'player'
     );
   });
+
+  it('removes passive gold when a farm is removed', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.GOLD, 100);
+    const map = new HexMap(3, 3, 1);
+    expect(state.placeBuilding(new Farm(), coordFarm, map)).toBe(true);
+    state.tick();
+    expect(state.getResource(Resource.GOLD)).toBe(52);
+    expect(state.removeBuilding(coordFarm, map)).toBe(true);
+    state.tick();
+    // only base generation after removal
+    expect(state.getResource(Resource.GOLD)).toBe(53);
+    expect(state.getBuildingAt(coordFarm)).toBeUndefined();
+  });
 });

--- a/src/buildings/effects.ts
+++ b/src/buildings/effects.ts
@@ -12,6 +12,12 @@ export type BuildingPlacedPayload = {
   state: GameState;
 };
 
+export type BuildingRemovedPayload = {
+  building: Building;
+  coord: AxialCoord;
+  state: GameState;
+};
+
 const onBuildingPlaced = ({ building, coord, state }: BuildingPlacedPayload): void => {
   if (building instanceof Farm) {
     state.modifyPassiveGeneration(Resource.GOLD, building.foodPerTick);
@@ -23,5 +29,12 @@ const onBuildingPlaced = ({ building, coord, state }: BuildingPlacedPayload): vo
   }
 };
 
+const onBuildingRemoved = ({ building, state }: BuildingRemovedPayload): void => {
+  if (building instanceof Farm) {
+    state.modifyPassiveGeneration(Resource.GOLD, -building.foodPerTick);
+  }
+};
+
 // register listeners for building effects
 eventBus.on<BuildingPlacedPayload>('buildingPlaced', onBuildingPlaced);
+eventBus.on<BuildingRemovedPayload>('buildingRemoved', onBuildingRemoved);

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -198,6 +198,29 @@ export class GameState {
     return this.buildingPlacements.get(coordKey(coord));
   }
 
+  /**
+   * Remove a building at the given coordinate if one exists.
+   * Returns true if a building was removed.
+   */
+  removeBuilding(coord: AxialCoord, map: HexMap): boolean {
+    const key = coordKey(coord);
+    const building = this.buildingPlacements.get(key);
+    if (!building) {
+      return false;
+    }
+    this.buildingPlacements.delete(key);
+    const tile = map.getTile(coord.q, coord.r);
+    tile?.placeBuilding(null);
+    if (this.buildings[building.type] !== undefined) {
+      this.buildings[building.type] -= 1;
+      if (this.buildings[building.type] <= 0) {
+        delete this.buildings[building.type];
+      }
+    }
+    eventBus.emit('buildingRemoved', { building, coord, state: this });
+    return true;
+  }
+
   /** Spend resources to upgrade a building. */
   upgrade(building: string, cost: number, res: Resource = Resource.GOLD): boolean {
     return this.construct(`upgrade:${building}`, cost, res);


### PR DESCRIPTION
## Summary
- add GameState.removeBuilding to track and emit removals
- listen for buildingRemoved to undo passive farm bonuses
- test farm removal effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e12a588c83308b4583d321bd0f02