### PR TITLE
Add manual deploy trigger and static site fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -27,6 +28,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - run: if [ -f dist/index.html ]; then cp dist/index.html dist/404.html; fi
+      - run: touch dist/.nojekyll
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist


### PR DESCRIPTION
## Summary
- allow manually triggering deploy workflow
- copy built index.html to 404.html when available
- add .nojekyll file prior to artifact upload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e56bc7a88330a1c7384d20a3eee6