### PR TITLE
Configure Vite build output directory

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,9 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   base: "/autobattles4xfinsauna/",
   root: 'src',
-  publicDir: '../public'
+  publicDir: '../public',
+  build: {
+    outDir: '../dist',
+    emptyOutDir: true
+  }
 });


### PR DESCRIPTION
## Summary
- configure Vite to output builds into a root dist directory and clean it before building

## Testing
- `npm test`
- `npm run build`
- `ls dist/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c6e8c12bcc83309367b795aa6bce14