### PR TITLE
Implement fog of war vision radius

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -39,14 +39,21 @@ const assetPaths: AssetPaths = {
 let assets: LoadedAssets;
 
 const map = new HexMap(10, 10, 32);
-// Reveal all tiles for simplicity
-map.forEachTile((t) => t.setFogged(false));
+// Ensure all tiles start fogged
+map.forEachTile((t) => t.setFogged(true));
 
 const state = new GameState(1000);
 state.load(map);
+const VISION_RADIUS = 2;
 const clock = new GameClock(1000, () => {
   state.tick();
   state.save();
+  // Reveal around all friendly units each tick
+  for (const unit of units) {
+    if (!unit.isDead() && unit.faction === 'player') {
+      map.revealAround(unit.coord, VISION_RADIUS);
+    }
+  }
   draw();
 });
 

--- a/src/hex/HexTile.test.ts
+++ b/src/hex/HexTile.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { HexTile } from './HexTile.ts';
+import { HexMap } from '../hexmap.ts';
 
 describe('HexTile', () => {
   it('tracks terrain, building and fog state', () => {
@@ -12,5 +13,14 @@ describe('HexTile', () => {
     expect(tile.building).toBe('city');
     tile.setFogged(true);
     expect(tile.isFogged).toBe(true);
+  });
+
+  it('reveals tiles within radius and leaves distant tiles fogged', () => {
+    const map = new HexMap(5, 5);
+    // reveal around center with radius 1
+    map.revealAround({ q: 2, r: 2 }, 1);
+    expect(map.getTile(2, 2)?.isFogged).toBe(false);
+    expect(map.getTile(2, 3)?.isFogged).toBe(false); // neighbor within radius
+    expect(map.getTile(4, 2)?.isFogged).toBe(true); // outside radius
   });
 });

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -39,6 +39,24 @@ export class HexMap {
       .filter((t): t is HexTile => Boolean(t));
   }
 
+  /**
+   * Reveal all tiles within the given radius around a central coordinate.
+   *
+   * The hex range iteration is based on axial coordinates. For each offset
+   * within the radius we reveal the tile if it exists on the map. Tiles
+   * outside the radius remain fogged.
+   */
+  revealAround(center: AxialCoord, radius: number): void {
+    for (let dq = -radius; dq <= radius; dq++) {
+      const rMin = Math.max(-radius, -dq - radius);
+      const rMax = Math.min(radius, -dq + radius);
+      for (let dr = rMin; dr <= rMax; dr++) {
+        const tile = this.getTile(center.q + dq, center.r + dr);
+        tile?.reveal();
+      }
+    }
+  }
+
   /** Draw the map onto a canvas context. */
   draw(
     ctx: CanvasRenderingContext2D,


### PR DESCRIPTION
## Summary
- Start new maps with all tiles fogged and reveal around friendly units every tick
- Add HexMap.revealAround helper to uncover tiles within a radius
- Extend HexTile tests to ensure tiles beyond vision range remain fogged

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e9e1dbe8833095f0f34192682e7a