### PR TITLE
Cap event log length

### DIFF
--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+
+describe('log function', () => {
+  it('caps event log at 100 messages', async () => {
+    document.body.innerHTML = `
+      <canvas id="game-canvas"></canvas>
+      <div id="resource-bar"></div>
+      <div id="event-log"></div>
+      <button id="build-farm"></button>
+      <button id="build-barracks"></button>
+      <button id="upgrade-farm"></button>
+      <button id="policy-eco"></button>
+    `;
+
+    const { log } = await import('./game.ts');
+    const eventLog = document.getElementById('event-log')!;
+
+    for (let i = 1; i <= 150; i++) {
+      log(`msg ${i}`);
+    }
+
+    expect(eventLog.childElementCount).toBe(100);
+    expect(eventLog.firstChild?.textContent).toBe('msg 51');
+  });
+});

--- a/src/game.ts
+++ b/src/game.ts
@@ -113,10 +113,15 @@ canvas.addEventListener('click', (e) => {
   draw();
 });
 
+const MAX_LOG_MESSAGES = 100;
+
 function log(msg: string): void {
   const div = document.createElement('div');
   div.textContent = msg;
   eventLog.appendChild(div);
+  while (eventLog.childElementCount > MAX_LOG_MESSAGES) {
+    eventLog.removeChild(eventLog.firstChild!);
+  }
 }
 
 const onResourceChanged = ({ resource, total, amount }) => {
@@ -188,4 +193,8 @@ async function start(): Promise<void> {
   requestAnimationFrame(gameLoop);
 }
 
-start();
+if (!import.meta.vitest) {
+  start();
+}
+
+export { log };


### PR DESCRIPTION
## Summary
- cap event log to last 100 entries and export log for testing
- add regression test ensuring log size is capped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6eefee0988330bcedd1c43e69cdae