### PR TITLE
Add Sauna spawner with UI control

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -8,6 +8,8 @@ import Animator from './render/Animator.ts';
 import { eventBus } from './events';
 import { loadAssets, AssetPaths, LoadedAssets } from './loader.ts';
 import { Farm, Barracks } from './buildings/index.ts';
+import { createSauna } from './sim/sauna.ts';
+import { setupSaunaUI } from './ui/sauna.tsx';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const resourceBar = document.getElementById('resource-bar')!;
@@ -60,6 +62,11 @@ const clock = new GameClock(1000, () => {
 const animator = new Animator(draw);
 
 const units: Unit[] = [];
+const sauna = createSauna({
+  q: Math.floor(map.width / 2),
+  r: Math.floor(map.height / 2)
+});
+const updateSaunaUI = setupSaunaUI(sauna);
 
 function spawn(type: UnitType, coord: AxialCoord): void {
   const id = `u${units.length + 1}`;
@@ -188,6 +195,11 @@ async function start(): Promise<void> {
     const delta = now - last;
     last = now;
     clock.tick(delta);
+    sauna.update(delta / 1000, units, (u) => {
+      units.push(u);
+      draw();
+    });
+    updateSaunaUI();
     requestAnimationFrame(gameLoop);
   }
   requestAnimationFrame(gameLoop);

--- a/src/sim/sauna.ts
+++ b/src/sim/sauna.ts
@@ -1,0 +1,56 @@
+import type { AxialCoord } from '../hex/HexUtils.ts';
+import type { Unit } from '../units/Unit.ts';
+import { Raider } from '../units/Raider.ts';
+
+export interface Sauna {
+  id: 'sauna';
+  pos: AxialCoord;
+  spawnCooldown: number;
+  timer: number;
+  auraRadius: number;
+  regenPerSec: number;
+  rallyToFront: boolean;
+  update(dt: number, units: Unit[], addUnit: (u: Unit) => void): void;
+}
+
+export function createSauna(pos: AxialCoord): Sauna {
+  return {
+    id: 'sauna',
+    pos,
+    spawnCooldown: 30,
+    timer: 30,
+    auraRadius: 2,
+    regenPerSec: 1,
+    rallyToFront: false,
+    update(dt: number, units: Unit[], addUnit: (u: Unit) => void): void {
+      this.timer -= dt;
+      if (this.timer > 0) return;
+
+      const targets: AxialCoord[] = [];
+      for (let dq = -2; dq <= 2; dq++) {
+        const rMin = Math.max(-2, -dq - 2);
+        const rMax = Math.min(2, -dq + 2);
+        for (let dr = rMin; dr <= rMax; dr++) {
+          const dist = Math.max(Math.abs(dq), Math.abs(dr), Math.abs(-dq - dr));
+          if (dist === 0 || dist > 2) continue;
+          const coord = { q: this.pos.q + dq, r: this.pos.r + dr };
+          const occupied = units.some(
+            (u) => !u.isDead() && u.coord.q === coord.q && u.coord.r === coord.r
+          );
+          if (!occupied) {
+            targets.push(coord);
+          }
+        }
+      }
+
+      if (targets.length > 0) {
+        const coord = targets[Math.floor(Math.random() * targets.length)];
+        const id = `raider${units.length + 1}`;
+        const raider = new Raider(id, coord, 'player');
+        addUnit(raider);
+      }
+      this.timer = this.spawnCooldown;
+    }
+  };
+}
+

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -1,0 +1,54 @@
+import type { Sauna } from '../sim/sauna.ts';
+
+export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
+  const overlay = document.getElementById('ui-overlay');
+  if (!overlay) return () => {};
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Sauna \u2668\ufe0f';
+  overlay.appendChild(btn);
+
+  const card = document.createElement('div');
+  card.style.position = 'absolute';
+  card.style.left = '0';
+  card.style.top = '0';
+  card.style.background = 'rgba(0,0,0,0.7)';
+  card.style.color = '#fff';
+  card.style.padding = '8px';
+  card.style.display = 'none';
+  card.style.minWidth = '120px';
+
+  const barContainer = document.createElement('div');
+  barContainer.style.height = '8px';
+  barContainer.style.background = '#555';
+  const barFill = document.createElement('div');
+  barFill.style.height = '100%';
+  barFill.style.background = '#0f0';
+  barFill.style.width = '0%';
+  barContainer.appendChild(barFill);
+  card.appendChild(barContainer);
+
+  const label = document.createElement('label');
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = sauna.rallyToFront;
+  checkbox.addEventListener('change', () => {
+    sauna.rallyToFront = checkbox.checked;
+  });
+  label.appendChild(checkbox);
+  label.appendChild(document.createTextNode(' Rally to Front'));
+  card.appendChild(label);
+
+  overlay.appendChild(card);
+
+  btn.addEventListener('click', () => {
+    card.style.display = card.style.display === 'none' ? 'block' : 'none';
+  });
+
+  return () => {
+    const progress = 1 - sauna.timer / sauna.spawnCooldown;
+    barFill.style.width = `${Math.max(0, Math.min(progress, 1)) * 100}%`;
+    checkbox.checked = sauna.rallyToFront;
+  };
+}
+

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -1,4 +1,5 @@
 export * from './units/Unit.ts';
 export * from './units/Soldier.ts';
 export * from './units/Archer.ts';
+export * from './units/Raider.ts';
 export * from './units/UnitFactory.ts';

--- a/src/units/Raider.ts
+++ b/src/units/Raider.ts
@@ -1,0 +1,16 @@
+import { Unit, UnitStats } from './Unit.ts';
+import type { AxialCoord } from '../hex/HexUtils.ts';
+
+export const RAIDER_STATS: UnitStats = {
+  health: 12,
+  attackDamage: 4,
+  attackRange: 1,
+  movementRange: 2
+};
+
+export class Raider extends Unit {
+  constructor(id: string, coord: AxialCoord, faction: string) {
+    super(id, coord, faction, { ...RAIDER_STATS });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Sauna entity that periodically spawns Raiders on nearby empty hexes
- introduce Raider unit class and expose via unit module
- show Sauna UI overlay with cooldown bar and rally checkbox
- wire Sauna and UI into game loop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6eff84cf88330917221227950c14d