### PR TITLE
chore: update deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-      - work
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 permissions:
@@ -29,7 +26,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: if [ -f dist/index.html ]; then cp dist/index.html dist/404.html; fi
+      - run: cp dist/index.html dist/404.html
       - run: touch dist/.nojekyll
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- refine GitHub Pages deploy workflow to only run on pushes to main and manual dispatch
- copy built index to 404 and disable Jekyll during build

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f16bd9f48330be4cb942ceb09143