### PR TITLE
Fix GitHub Pages deploy: base path and workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - work
     tags:
       - 'v*'
   workflow_dispatch:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "https://wasab1kastike.github.io/autobattles4xfinsauna/",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vite';
+import pkg from './package.json' assert { type: 'json' };
 
 export default defineConfig(({ command }) => ({
-  base: command === 'build' ? '/autobattles4xfinsauna/' : '/',
+  base: command === 'build' && pkg.homepage
+    ? new URL(pkg.homepage).pathname
+    : '/',
   root: 'src',
   publicDir: '../public',
   build: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
 
-export default defineConfig({
-  base: "/autobattles4xfinsauna/",
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/autobattles4xfinsauna/' : '/',
   root: 'src',
   publicDir: '../public',
   build: {
     outDir: '../dist',
     emptyOutDir: true
   }
-});
+}));


### PR DESCRIPTION
## Summary
- Set Vite base path dynamically for GitHub Pages
- Declare project homepage for deployment
- Simplify deploy workflow to run only from the main branch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6f16cea688330a2711887fe49066c