### PR TITLE
feat: auto frame camera on map reveal

### DIFF
--- a/src/camera/autoFrame.ts
+++ b/src/camera/autoFrame.ts
@@ -1,0 +1,95 @@
+import { AxialCoord, axialToPixel } from '../hex/HexUtils.ts';
+
+/**
+ * Track revealed hexes and compute a camera frame that fits them
+ * into a viewport. The revealed hexes are stored as "q,r" strings.
+ */
+export const revealedHexes = new Set<string>();
+
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+export interface FrameResult {
+  center: { x: number; y: number };
+  zoom: number;
+}
+
+const PADDING = 96;
+const HEX_SIZE = 32;
+const HEX_WIDTH = HEX_SIZE * Math.sqrt(3);
+const HEX_HEIGHT = HEX_SIZE * 2;
+
+/** Register a revealed hex coordinate. */
+export function addRevealedHex(coord: AxialCoord): void {
+  revealedHexes.add(`${coord.q},${coord.r}`);
+}
+
+/**
+ * Compute the center and zoom so all revealed tiles fit within the given
+ * viewport size with padding. If no tiles are revealed, returns a default
+ * frame at the origin with zoom 1.
+ */
+export function autoFrame(viewport: ViewportSize): FrameResult {
+  if (revealedHexes.size === 0) {
+    return { center: { x: 0, y: 0 }, zoom: 1 };
+  }
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const key of revealedHexes) {
+    const [qStr, rStr] = key.split(',');
+    const q = Number(qStr);
+    const r = Number(rStr);
+    const { x, y } = axialToPixel({ q, r }, HEX_SIZE);
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x + HEX_WIDTH);
+    maxY = Math.max(maxY, y + HEX_HEIGHT);
+  }
+
+  const width = maxX - minX;
+  const height = maxY - minY;
+  const center = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
+  const zoom = Math.min(
+    viewport.width / (width + PADDING * 2),
+    viewport.height / (height + PADDING * 2)
+  );
+
+  return { center, zoom };
+}
+
+export interface CameraState {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+/** Global camera state */
+export const camera: CameraState = { x: 0, y: 0, zoom: 1 };
+
+/**
+ * Tween the global camera state to the provided center/zoom over the
+ * specified duration (default 300ms).
+ */
+export function tweenCamera(target: FrameResult, duration = 300): void {
+  const start = { x: camera.x, y: camera.y, zoom: camera.zoom };
+  const startTime = performance.now();
+
+  function step(now: number): void {
+    const t = Math.min((now - startTime) / duration, 1);
+    camera.x = start.x + (target.center.x - start.x) * t;
+    camera.y = start.y + (target.center.y - start.y) * t;
+    camera.zoom = start.zoom + (target.zoom - start.zoom) * t;
+    if (t < 1) {
+      requestAnimationFrame(step);
+    }
+  }
+
+  requestAnimationFrame(step);
+}
+

--- a/src/game.ts
+++ b/src/game.ts
@@ -53,7 +53,10 @@ const clock = new GameClock(1000, () => {
   // Reveal around all friendly units each tick
   for (const unit of units) {
     if (!unit.isDead() && unit.faction === 'player') {
-      map.revealAround(unit.coord, VISION_RADIUS);
+      map.revealAround(unit.coord, VISION_RADIUS, {
+        width: canvas.width,
+        height: canvas.height,
+      });
     }
   }
   draw();
@@ -189,6 +192,8 @@ async function start(): Promise<void> {
     console.warn('Failed to load assets', failures);
   }
   resourceBar.textContent = `Resources: ${state.getResource(Resource.GOLD)}`;
+  // Initial reveal around the Sauna and auto-frame the camera
+  map.revealAround(sauna.pos, 3, { width: canvas.width, height: canvas.height });
   draw();
   let last = performance.now();
   function gameLoop(now: number) {

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -1,5 +1,6 @@
 import { AxialCoord, axialToPixel, getNeighbors as axialNeighbors } from './hex/HexUtils.ts';
 import { HexTile } from './hex/HexTile.ts';
+import { addRevealedHex, autoFrame, tweenCamera, ViewportSize } from './camera/autoFrame.ts';
 
 /** Simple hex map composed of tiles in axial coordinates. */
 export class HexMap {
@@ -46,14 +47,22 @@ export class HexMap {
    * within the radius we reveal the tile if it exists on the map. Tiles
    * outside the radius remain fogged.
    */
-  revealAround(center: AxialCoord, radius: number): void {
+  revealAround(center: AxialCoord, radius: number, viewport?: ViewportSize): void {
     for (let dq = -radius; dq <= radius; dq++) {
       const rMin = Math.max(-radius, -dq - radius);
       const rMax = Math.min(radius, -dq + radius);
       for (let dr = rMin; dr <= rMax; dr++) {
-        const tile = this.getTile(center.q + dq, center.r + dr);
-        tile?.reveal();
+        const coord = { q: center.q + dq, r: center.r + dr };
+        const tile = this.getTile(coord.q, coord.r);
+        if (tile) {
+          tile.reveal();
+          addRevealedHex(coord);
+        }
       }
+    }
+    if (viewport) {
+      const frame = autoFrame(viewport);
+      tweenCamera(frame, 300);
     }
   }
 


### PR DESCRIPTION
## Summary
- implement autoFrame to compute camera center and zoom based on revealed hexes
- update HexMap.revealAround to track revealed tiles and tween camera
- auto-frame camera around Sauna at game start and during unit vision updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6f179dd708330a7adf13ff88321b0