### PR TITLE
Add terrain noise and canvas rendering for hex map

### DIFF
--- a/src/hex/HexTile.test.ts
+++ b/src/hex/HexTile.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { HexTile } from './HexTile.ts';
 import { HexMap } from '../hexmap.ts';
+import { TerrainId } from '../map/terrain.ts';
 
 describe('HexTile', () => {
   it('tracks terrain, building and fog state', () => {
-    const tile = new HexTile('water', null, true);
-    expect(tile.terrain).toBe('water');
+    const tile = new HexTile(TerrainId.Lake, null, true);
+    expect(tile.terrain).toBe(TerrainId.Lake);
     expect(tile.isFogged).toBe(true);
     tile.reveal();
     expect(tile.isFogged).toBe(false);

--- a/src/hex/HexTile.ts
+++ b/src/hex/HexTile.ts
@@ -1,10 +1,12 @@
-export type TerrainType = 'plain' | 'water' | 'forest' | 'mountain';
+import { TerrainId } from '../map/terrain.ts';
+
+export type TerrainType = TerrainId;
 export type BuildingType = 'city' | 'farm' | 'barracks' | 'mine' | null;
 
 /** Represents a single hex tile on the map. */
 export class HexTile {
   constructor(
-    public terrain: TerrainType = 'plain',
+    public terrain: TerrainType = TerrainId.Plains,
     public building: BuildingType = null,
     public isFogged: boolean = true
   ) {}

--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -31,6 +31,11 @@ describe('HexMap', () => {
       closePath: vi.fn(),
       fill: vi.fn(),
       stroke: vi.fn(),
+      clip: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      arc: vi.fn(),
+      globalAlpha: 1,
       fillStyle: '',
       strokeStyle: '',
     } as unknown as CanvasRenderingContext2D;

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -1,5 +1,6 @@
 import { AxialCoord, axialToPixel, getNeighbors as axialNeighbors } from './hex/HexUtils.ts';
 import { HexTile } from './hex/HexTile.ts';
+import { TerrainId, generateTerrain } from './map/terrain.ts';
 
 /** Simple hex map composed of tiles in axial coordinates. */
 export class HexMap {
@@ -8,13 +9,15 @@ export class HexMap {
   constructor(
     public readonly width = 10,
     public readonly height = 10,
-    public readonly hexSize = 32
+    public readonly hexSize = 32,
+    seed = 0
   ) {
     this.tiles = [];
+    const terrain = generateTerrain(width, height, seed);
     for (let r = 0; r < height; r++) {
       const row: HexTile[] = [];
       for (let q = 0; q < width; q++) {
-        row.push(new HexTile());
+        row.push(new HexTile(terrain[r][q]));
       }
       this.tiles.push(row);
     }
@@ -67,22 +70,26 @@ export class HexMap {
     const hexHeight = this.hexSize * 2;
     this.forEachTile((tile, coord) => {
       const { x, y } = axialToPixel(coord, this.hexSize);
-      const terrainKey = tile.terrain === 'water' ? 'water' : 'grass';
-      const terrain = images[terrainKey] ?? images['placeholder'];
-      ctx.drawImage(terrain, x, y, hexWidth, hexHeight);
+      ctx.save();
+      if (tile.isFogged) ctx.globalAlpha *= 0.4;
+
+      this.drawTerrain(ctx, tile.terrain, x + this.hexSize, y + this.hexSize);
+
       if (tile.building) {
         const building = images[tile.building] ?? images['placeholder'];
         ctx.drawImage(building, x, y, hexWidth, hexHeight);
       }
-      const isSelected = selected && coord.q === selected.q && coord.r === selected.r;
-      this.drawHex(
+
+      const isSelected =
+        selected && coord.q === selected.q && coord.r === selected.r;
+      this.strokeHex(
         ctx,
         x + this.hexSize,
         y + this.hexSize,
         this.hexSize,
-        'rgba(0,0,0,0)',
         Boolean(isSelected)
       );
+      ctx.restore();
     });
   }
 
@@ -99,13 +106,11 @@ export class HexMap {
     this.draw(ctx, images, selected);
   }
 
-  private drawHex(
+  private hexPath(
     ctx: CanvasRenderingContext2D,
     x: number,
     y: number,
-    size: number,
-    fill: string,
-    selected = false
+    size: number
   ): void {
     ctx.beginPath();
     for (let i = 0; i < 6; i++) {
@@ -119,9 +124,56 @@ export class HexMap {
       }
     }
     ctx.closePath();
-    ctx.fillStyle = fill;
-    ctx.strokeStyle = selected ? '#ff0000' : '#000000';
+  }
+
+  private drawTerrain(
+    ctx: CanvasRenderingContext2D,
+    terrain: TerrainId,
+    x: number,
+    y: number
+  ): void {
+    const size = this.hexSize;
+    this.hexPath(ctx, x, y, size);
+    if (terrain === TerrainId.Lake) {
+      ctx.fillStyle = '#3399ff';
+      ctx.fill();
+      return;
+    }
+
+    ctx.fillStyle = '#c2d1a1';
     ctx.fill();
+    ctx.save();
+    ctx.clip();
+    if (terrain === TerrainId.Forest) {
+      ctx.strokeStyle = '#2e8b57';
+      for (let i = -size; i <= size; i += 4) {
+        ctx.beginPath();
+        ctx.moveTo(x - size, y + i);
+        ctx.lineTo(x + size, y + i);
+        ctx.stroke();
+      }
+    } else if (terrain === TerrainId.Hills) {
+      ctx.fillStyle = '#8b7765';
+      for (let dx = -size; dx <= size; dx += 6) {
+        for (let dy = -size; dy <= size; dy += 6) {
+          ctx.beginPath();
+          ctx.arc(x + dx, y + dy, 1, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+    }
+    ctx.restore();
+  }
+
+  private strokeHex(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    size: number,
+    selected = false
+  ): void {
+    this.hexPath(ctx, x, y, size);
+    ctx.strokeStyle = selected ? '#ff0000' : '#000000';
     ctx.stroke();
   }
 }

--- a/src/map/terrain.ts
+++ b/src/map/terrain.ts
@@ -1,0 +1,34 @@
+export enum TerrainId {
+  Plains = 0,
+  Forest = 1,
+  Hills = 2,
+  Lake = 3,
+}
+
+// Simple deterministic hash-based noise returning value in [0,1).
+function noise(x: number, y: number, seed: number): number {
+  let h = x * 374761393 + y * 668265263 + seed * 1442695040888963407;
+  h = (h ^ (h >> 13)) * 1274126177;
+  h ^= h >> 16;
+  return (h >>> 0) / 0xffffffff;
+}
+
+export function terrainAt(q: number, r: number, seed = 0): TerrainId {
+  const n = noise(q, r, seed);
+  if (n < 0.1) return TerrainId.Lake;
+  if (n < 0.3) return TerrainId.Forest;
+  if (n < 0.5) return TerrainId.Hills;
+  return TerrainId.Plains;
+}
+
+export function generateTerrain(width: number, height: number, seed = 0): TerrainId[][] {
+  const rows: TerrainId[][] = [];
+  for (let r = 0; r < height; r++) {
+    const row: TerrainId[] = [];
+    for (let q = 0; q < width; q++) {
+      row.push(terrainAt(q, r, seed));
+    }
+    rows.push(row);
+  }
+  return rows;
+}

--- a/src/units/Unit.test.ts
+++ b/src/units/Unit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { Unit, UnitStats } from './Unit.ts';
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import { HexMap } from '../hexmap.ts';
+import { TerrainId } from '../map/terrain.ts';
 import { eventBus } from '../events';
 import { Sauna } from '../buildings/Sauna.ts';
 
@@ -104,7 +105,7 @@ describe('Unit combat', () => {
 describe('Unit movement', () => {
   it('moves around impassable terrain', () => {
     const map = new HexMap(3, 3);
-    map.getTile(1, 0)!.terrain = 'water';
+    map.getTile(1, 0)!.terrain = TerrainId.Lake;
     const unit = createUnit('a', { q: 0, r: 0 }, {
       health: 10,
       attackDamage: 2,
@@ -122,7 +123,7 @@ describe('Unit movement', () => {
 
   it('selects the nearest reachable enemy', () => {
     const map = new HexMap(3, 3);
-    map.getTile(1, 0)!.terrain = 'water';
+    map.getTile(1, 0)!.terrain = TerrainId.Lake;
     const unit = createUnit('a', { q: 0, r: 0 }, {
       health: 10,
       attackDamage: 2,

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -1,5 +1,6 @@
 import { AxialCoord, getNeighbors, axialToPixel } from '../hex/HexUtils.ts';
 import { HexMap } from '../hexmap.ts';
+import { TerrainId } from '../map/terrain.ts';
 import { eventBus } from '../events';
 import type { Sauna } from '../buildings/Sauna.ts';
 
@@ -257,7 +258,7 @@ export class Unit {
     if (occupied && occupied.has(coordKey(coord))) {
       return false;
     }
-    return tile.terrain !== 'water' && tile.terrain !== 'mountain';
+    return tile.terrain !== TerrainId.Lake;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add seeded noise terrain generator with Plains, Forest, Hills and Lake IDs
- Render hex terrain with canvas paths, hatches and dots and dim fogged tiles
- Block units from entering lakes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f19068948330ba18e51c55aeab46