### PR TITLE
Fix GitHub Pages deploy: base path and workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+        env:
+          BASE_PATH: /${{ github.event.repository.name }}/
       - run: cp dist/index.html dist/404.html
       - run: touch dist/.nojekyll
       - uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "autobattles4xfinsauna",
   "private": true,
   "version": "0.0.0",
+  "homepage": "https://wasab1kastike.github.io/autobattles4xfinsauna/",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 
-export default defineConfig({
-  base: "/autobattles4xfinsauna/",
+export default defineConfig(() => ({
+  base: process.env.BASE_PATH ?? '/',
   // plugins: [...]
-});
+}));


### PR DESCRIPTION
## Summary
- read Vite base path from `BASE_PATH` environment variable
- record project homepage URL in package.json
- supply `BASE_PATH` during GitHub Pages build

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f32025008330aaa93b53adae334d