### PR TITLE
Auto-frame camera on map reveal

### DIFF
--- a/src/camera/autoFrame.ts
+++ b/src/camera/autoFrame.ts
@@ -1,0 +1,109 @@
+import type { AxialCoord, PixelCoord } from '../hex/HexUtils.ts';
+import { axialToPixel } from '../hex/HexUtils.ts';
+
+/** Set of revealed hex coordinates serialized as "q,r" strings. */
+const revealedHexes = new Set<string>();
+let currentHexSize = 32;
+
+function key(c: AxialCoord): string {
+  return `${c.q},${c.r}`;
+}
+
+/** Track a hex as revealed and update the current hex size. */
+export function markRevealed(coord: AxialCoord, hexSize: number): void {
+  currentHexSize = hexSize;
+  revealedHexes.add(key(coord));
+}
+
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+export interface CameraFrame {
+  center: PixelCoord;
+  zoom: number;
+}
+
+/**
+ * Compute the axis-aligned bounding box of all revealed hex tiles and return
+ * a camera center and zoom that fits them within the given viewport while
+ * leaving 96px padding on all sides.
+ */
+export function autoFrame(viewport: ViewportSize): CameraFrame {
+  if (revealedHexes.size === 0) {
+    return { center: { x: 0, y: 0 }, zoom: 1 };
+  }
+
+  const hexWidth = currentHexSize * Math.sqrt(3);
+  const hexHeight = currentHexSize * 2;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const h of revealedHexes) {
+    const [q, r] = h.split(',').map(Number);
+    const { x, y } = axialToPixel({ q, r }, currentHexSize);
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x + hexWidth);
+    maxY = Math.max(maxY, y + hexHeight);
+  }
+
+  const width = maxX - minX;
+  const height = maxY - minY;
+  const padding = 96;
+  const center = { x: minX + width / 2, y: minY + height / 2 };
+  const zoomX = viewport.width / (width + padding * 2);
+  const zoomY = viewport.height / (height + padding * 2);
+  const zoom = Math.min(zoomX, zoomY);
+  return { center, zoom };
+}
+
+export interface CameraState {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+/** Simple camera state manipulated by tweenCamera. */
+export const camera: CameraState = { x: 0, y: 0, zoom: 1 };
+
+/**
+ * Tween the global camera state toward the target frame over the given
+ * duration (default 300ms).
+ */
+export function tweenCamera(target: CameraFrame, duration = 300): void {
+  const startX = camera.x;
+  const startY = camera.y;
+  const startZoom = camera.zoom;
+  const startTime = typeof performance !== 'undefined' ? performance.now() : Date.now();
+
+  const step = (now: number) => {
+    const t = Math.min((now - startTime) / duration, 1);
+    camera.x = startX + (target.center.x - startX) * t;
+    camera.y = startY + (target.center.y - startY) * t;
+    camera.zoom = startZoom + (target.zoom - startZoom) * t;
+    if (t < 1) {
+      if (typeof requestAnimationFrame !== 'undefined') {
+        requestAnimationFrame(step);
+      } else {
+        setTimeout(() => step(typeof performance !== 'undefined' ? performance.now() : Date.now()), 16);
+      }
+    }
+  };
+
+  if (typeof requestAnimationFrame !== 'undefined') {
+    requestAnimationFrame(step);
+  } else {
+    setTimeout(() => step(typeof performance !== 'undefined' ? performance.now() : Date.now()), 0);
+  }
+}
+
+/** Clear all tracked revealed tiles. Useful when starting a new game. */
+export function resetAutoFrame(): void {
+  revealedHexes.clear();
+}
+
+export { revealedHexes };

--- a/src/game.ts
+++ b/src/game.ts
@@ -10,6 +10,7 @@ import { loadAssets, AssetPaths, LoadedAssets } from './loader.ts';
 import { Farm, Barracks } from './buildings/index.ts';
 import { createSauna } from './sim/sauna.ts';
 import { setupSaunaUI } from './ui/sauna.tsx';
+import { resetAutoFrame } from './camera/autoFrame.ts';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const resourceBar = document.getElementById('resource-bar')!;
@@ -43,6 +44,7 @@ let assets: LoadedAssets;
 const map = new HexMap(10, 10, 32);
 // Ensure all tiles start fogged
 map.forEachTile((t) => t.setFogged(true));
+resetAutoFrame();
 
 const state = new GameState(1000);
 state.load(map);
@@ -66,6 +68,7 @@ const sauna = createSauna({
   q: Math.floor(map.width / 2),
   r: Math.floor(map.height / 2)
 });
+map.revealAround(sauna.pos, 3);
 const updateSaunaUI = setupSaunaUI(sauna);
 
 function spawn(type: UnitType, coord: AxialCoord): void {

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -1,6 +1,7 @@
 import { AxialCoord, axialToPixel, getNeighbors as axialNeighbors } from './hex/HexUtils.ts';
 import { HexTile } from './hex/HexTile.ts';
 import { TerrainId, generateTerrain } from './map/terrain.ts';
+import { markRevealed, autoFrame, tweenCamera } from './camera/autoFrame.ts';
 
 /** Simple hex map composed of tiles in axial coordinates. */
 export class HexMap {
@@ -54,10 +55,20 @@ export class HexMap {
       const rMin = Math.max(-radius, -dq - radius);
       const rMax = Math.min(radius, -dq + radius);
       for (let dr = rMin; dr <= rMax; dr++) {
-        const tile = this.getTile(center.q + dq, center.r + dr);
-        tile?.reveal();
+        const coord = { q: center.q + dq, r: center.r + dr };
+        const tile = this.getTile(coord.q, coord.r);
+        if (tile) {
+          tile.reveal();
+          markRevealed(coord, this.hexSize);
+        }
       }
     }
+
+    const viewport = typeof window !== 'undefined'
+      ? { width: window.innerWidth, height: window.innerHeight }
+      : { width: 0, height: 0 };
+    const frame = autoFrame(viewport);
+    tweenCamera(frame, 300);
   }
 
   /** Draw the map onto a canvas context. */


### PR DESCRIPTION
## Summary
- Add camera auto-framing module that tracks revealed hexes and computes a centered zoomed frame
- Update HexMap.revealAround to record revealed tiles and tween camera to new frame
- Reveal starting area around the Sauna when a new game begins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f3792a588330acc0d61d2843c038