### PR TITLE
Add SVG raider sprite with HP-based tint

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -4,6 +4,7 @@ import { GameClock } from './core/GameClock.ts';
 import { HexMap } from './hexmap.ts';
 import { pixelToAxial, axialToPixel, AxialCoord } from './hex/HexUtils.ts';
 import { Unit, spawnUnit, UnitType } from './unit.ts';
+import { raiderSVG } from './ui/sprites.ts';
 import Animator from './render/Animator.ts';
 import { eventBus } from './events';
 import { loadAssets, AssetPaths, LoadedAssets } from './loader.ts';
@@ -93,12 +94,18 @@ function draw(): void {
 }
 
 function drawUnits(ctx: CanvasRenderingContext2D): void {
-  const sprite = assets.images['unit-soldier'];
   const hexWidth = map.hexSize * Math.sqrt(3);
   const hexHeight = map.hexSize * 2;
+  const parser = new DOMParser();
   for (const unit of units) {
     const { x, y } = axialToPixel(unit.coord, map.hexSize);
-    ctx.drawImage(sprite, x, y, hexWidth, hexHeight);
+    const svg = parser
+      .parseFromString(raiderSVG(1), 'image/svg+xml')
+      .documentElement as unknown as SVGImageElement;
+    const color = unit.healthRatio < 0.5 ? 'hsl(0,0%,60%)' : 'hsl(0,100%,50%)';
+    svg.setAttribute('fill', color);
+    svg.setAttribute('stroke', color);
+    ctx.drawImage(svg, x, y, hexWidth, hexHeight);
   }
 }
 

--- a/src/ui/sprites.ts
+++ b/src/ui/sprites.ts
@@ -1,0 +1,10 @@
+export function raiderSVG(scale: number): string {
+  const size = 32 * scale;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 32 32" fill="currentColor" stroke="currentColor" stroke-width="2">
+  <polygon points="4,2 18,16 4,30" />
+  <circle cx="24" cy="16" r="6" />
+</svg>`;
+}
+
+export default { raiderSVG };

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -49,6 +49,11 @@ export class Unit {
     this.maxHealth = stats.health;
   }
 
+  /** Ratio of current to maximum health (0-1). */
+  get healthRatio(): number {
+    return this.stats.health / this.maxHealth;
+  }
+
   onDeath(cb: Listener): void {
     (this.listeners.death ??= []).push(cb);
   }


### PR DESCRIPTION
## Summary
- Add reusable `raiderSVG` sprite generator
- Expose `healthRatio` on Unit to colorize sprites
- Render SVG units in game with desaturation when below half HP

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f5dda60c83308de4527005ebe7b8