### PR TITLE
Add topbar UI with resource badges and sound effects

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -11,6 +11,8 @@ import { Farm, Barracks } from './buildings/index.ts';
 import { createSauna } from './sim/sauna.ts';
 import { setupSaunaUI } from './ui/sauna.tsx';
 import { resetAutoFrame } from './camera/autoFrame.ts';
+import { setupTopbar } from './ui/topbar.ts';
+import { sfx } from './sfx.ts';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const resourceBar = document.getElementById('resource-bar')!;
@@ -35,7 +37,7 @@ const assetPaths: AssetPaths = {
   },
   sounds: {
     // Minimal silent WAV
-    placeholder:
+    click:
       'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YQAAAAA='
   }
 };
@@ -70,6 +72,7 @@ const sauna = createSauna({
 });
 map.revealAround(sauna.pos, 3);
 const updateSaunaUI = setupSaunaUI(sauna);
+const updateTopbar = setupTopbar(state);
 
 function spawn(type: UnitType, coord: AxialCoord): void {
   const id = `u${units.length + 1}`;
@@ -188,6 +191,7 @@ policyBtn.addEventListener('click', () => {
 async function start(): Promise<void> {
   const { assets: loaded, failures } = await loadAssets(assetPaths);
   assets = loaded;
+  Object.entries(assets.sounds).forEach(([name, audio]) => sfx.register(name, audio));
   if (failures.length) {
     console.warn('Failed to load assets', failures);
   }
@@ -198,15 +202,16 @@ async function start(): Promise<void> {
     const delta = now - last;
     last = now;
     clock.tick(delta);
-    sauna.update(delta / 1000, units, (u) => {
-      units.push(u);
-      draw();
-    });
-    updateSaunaUI();
+      sauna.update(delta / 1000, units, (u) => {
+        units.push(u);
+        draw();
+      });
+      updateSaunaUI();
+      updateTopbar(delta);
+      requestAnimationFrame(gameLoop);
+    }
     requestAnimationFrame(gameLoop);
   }
-  requestAnimationFrame(gameLoop);
-}
 
 if (!import.meta.vitest) {
   start();

--- a/src/sfx.ts
+++ b/src/sfx.ts
@@ -1,0 +1,12 @@
+export const sfx = {
+  _sounds: new Map<string, HTMLAudioElement>(),
+  register(name: string, audio: HTMLAudioElement): void {
+    this._sounds.set(name, audio);
+  },
+  play(name: string): void {
+    const audio = this._sounds.get(name);
+    if (!audio) return;
+    audio.currentTime = 0;
+    void audio.play();
+  }
+};

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -1,0 +1,93 @@
+import { eventBus } from '../events';
+import { sfx } from '../sfx';
+import { GameState, Resource } from '../core/GameState.ts';
+
+type Badge = {
+  container: HTMLDivElement;
+  value: HTMLSpanElement;
+  delta: HTMLSpanElement;
+};
+
+function createBadge(label: string): Badge {
+  const container = document.createElement('div');
+  container.style.position = 'relative';
+  container.style.marginRight = '8px';
+
+  const labelSpan = document.createElement('span');
+  labelSpan.textContent = label + ': ';
+  container.appendChild(labelSpan);
+
+  const valueSpan = document.createElement('span');
+  valueSpan.textContent = '0';
+  container.appendChild(valueSpan);
+
+  const deltaSpan = document.createElement('span');
+  deltaSpan.style.position = 'absolute';
+  deltaSpan.style.right = '0';
+  deltaSpan.style.top = '-10px';
+  deltaSpan.style.opacity = '0';
+  deltaSpan.style.transition = 'opacity 0.5s';
+  container.appendChild(deltaSpan);
+
+  return { container, value: valueSpan, delta: deltaSpan };
+}
+
+export function setupTopbar(state: GameState): (deltaMs: number) => void {
+  const overlay = document.getElementById('ui-overlay');
+  if (!overlay) return () => {};
+
+  const bar = document.createElement('div');
+  bar.id = 'topbar';
+  bar.style.display = 'flex';
+  bar.style.alignItems = 'center';
+  overlay.appendChild(bar);
+
+  const saunakunnia = createBadge('Saunakunnia');
+  const sisu = createBadge('Sisu');
+  const gold = createBadge('Gold');
+  const time = createBadge('Time');
+  time.delta.style.display = 'none';
+
+  bar.appendChild(saunakunnia.container);
+  bar.appendChild(sisu.container);
+  bar.appendChild(gold.container);
+  bar.appendChild(time.container);
+
+  const sisuBtn = document.createElement('button');
+  sisuBtn.textContent = 'SISU';
+  sisuBtn.addEventListener('click', () => {
+    eventBus.emit('sisuPulse', {});
+    sfx.play('click');
+  });
+  bar.appendChild(sisuBtn);
+
+  gold.value.textContent = String(state.getResource(Resource.GOLD));
+
+  const badges: Record<string, Badge> = {
+    saunakunnia,
+    sisu,
+    gold
+  };
+
+  eventBus.on('resourceChanged', ({ resource, amount, total }) => {
+    const badge = badges[resource];
+    if (!badge) return;
+    badge.value.textContent = String(total);
+    const sign = amount > 0 ? '+' : '';
+    badge.delta.textContent = `${sign}${amount}`;
+    badge.delta.style.opacity = '1';
+    setTimeout(() => {
+      badge.delta.style.opacity = '0';
+    }, 1000);
+    sfx.play('click');
+  });
+
+  let elapsed = 0;
+  return (deltaMs: number) => {
+    elapsed += deltaMs;
+    const totalSeconds = Math.floor(elapsed / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    time.value.textContent = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  };
+}


### PR DESCRIPTION
## Summary
- add simple sound FX helper for registering and playing audio clips
- create topbar displaying Saunakunnia, Sisu, Gold, and Time with delta pop numbers and click SFX
- wire topbar into game loop and expose SISU button emitting `sisuPulse`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f6127a5c83309a12ddd83454be3b