### PR TITLE
Add raider SVG sprite and health-based tinting

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -13,6 +13,7 @@ import type { AssetPaths, LoadedAssets } from './loader.ts';
 import { Farm, Barracks } from './buildings/index.ts';
 import { createSauna } from './sim/sauna.ts';
 import { setupSaunaUI } from './ui/sauna.tsx';
+import { raiderSVG } from './ui/sprites.ts';
 import { resetAutoFrame } from './camera/autoFrame.ts';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
@@ -96,12 +97,25 @@ function draw(): void {
 }
 
 function drawUnits(ctx: CanvasRenderingContext2D): void {
-  const sprite = assets.images['unit-soldier'];
   const hexWidth = map.hexSize * Math.sqrt(3);
   const hexHeight = map.hexSize * 2;
+  const size = Math.min(hexWidth, hexHeight);
   for (const unit of units) {
     const { x, y } = axialToPixel(unit.coord, map.hexSize);
-    ctx.drawImage(sprite, x, y, hexWidth, hexHeight);
+    const img = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'image'
+    ) as unknown as SVGImageElement;
+    img.setAttribute(
+      'href',
+      `data:image/svg+xml;utf8,${encodeURIComponent(raiderSVG(size))}`
+    );
+    const maxHealth = (unit as any).maxHealth ?? unit.stats.health;
+    if (unit.stats.health / maxHealth < 0.5) {
+      ctx.filter = 'saturate(0)';
+    }
+    ctx.drawImage(img, x, y, hexWidth, hexHeight);
+    ctx.filter = 'none';
   }
 }
 

--- a/src/ui/sprites.ts
+++ b/src/ui/sprites.ts
@@ -1,0 +1,8 @@
+export function raiderSVG(scale: number): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${scale}" height="${scale}" viewBox="0 0 32 32">
+  <polygon points="16,2 4,30 28,30" fill="#c33" stroke="#000" stroke-width="2" />
+  <circle cx="22" cy="20" r="6" fill="#bbb" stroke="#000" stroke-width="2" />
+</svg>`;
+}
+


### PR DESCRIPTION
## Summary
- add `raiderSVG` helper returning helmet wedge and shield SVG
- render units using the SVG and desaturate when health drops below 50%

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f6e7f4408330beb50d0e155abae3