### PR TITLE
feat: add SISU pulse ability

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -17,6 +17,7 @@ import { raiderSVG } from './ui/sprites.ts';
 import { resetAutoFrame } from './camera/autoFrame.ts';
 import { setupTopbar } from './ui/topbar.ts';
 import { sfx } from './sfx.ts';
+import { activateSisuPulse, isSisuActive } from './sim/sisu.ts';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const resourceBar = document.getElementById('resource-bar')!;
@@ -77,6 +78,7 @@ const sauna = createSauna({
 map.revealAround(sauna.pos, 3);
 const updateSaunaUI = setupSaunaUI(sauna);
 const updateTopbar = setupTopbar(state);
+eventBus.on('sisuPulse', () => activateSisuPulse(state, units));
 
 function spawn(type: UnitType, coord: AxialCoord): void {
   const id = `u${units.length + 1}`;
@@ -119,6 +121,11 @@ function drawUnits(ctx: CanvasRenderingContext2D): void {
     }
     ctx.drawImage(img, x, y, hexWidth, hexHeight);
     ctx.filter = 'none';
+    if (isSisuActive() && unit.faction === 'player') {
+      ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x, y, hexWidth, hexHeight);
+    }
   }
 }
 

--- a/src/sim/sisu.ts
+++ b/src/sim/sisu.ts
@@ -1,0 +1,49 @@
+import type { GameState } from '../core/GameState.ts';
+import type { Unit } from '../units/Unit.ts';
+import { eventBus } from '../events';
+
+let active = false;
+let onCooldown = false;
+
+export function isSisuActive(): boolean {
+  return active;
+}
+
+export function activateSisuPulse(state: GameState, units: Unit[]): void {
+  void state;
+  if (active || onCooldown) return;
+  active = true;
+  onCooldown = true;
+  let remaining = 10;
+  eventBus.emit('sisuPulseStart', { remaining });
+
+  const affected: { unit: Unit; move: number; attack: number }[] = [];
+  for (const u of units) {
+    if (u.faction !== 'player' || u.isDead()) continue;
+    affected.push({ unit: u, move: u.stats.movementRange, attack: u.stats.attackDamage });
+    u.stats.movementRange *= 1.2;
+    u.stats.attackDamage *= 1.2;
+    (u as any).fearless = true;
+  }
+
+  const interval = setInterval(() => {
+    remaining -= 1;
+    if (remaining > 0) {
+      eventBus.emit('sisuPulseTick', { remaining });
+      return;
+    }
+    clearInterval(interval);
+    active = false;
+    for (const a of affected) {
+      a.unit.stats.movementRange = a.move;
+      a.unit.stats.attackDamage = a.attack;
+      delete (a.unit as any).fearless;
+    }
+    eventBus.emit('sisuPulseEnd', {});
+    setTimeout(() => {
+      onCooldown = false;
+      eventBus.emit('sisuCooldownEnd', {});
+    }, 120_000);
+  }, 1_000);
+}
+

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -43,7 +43,8 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
   overlay.appendChild(bar);
 
   const saunakunnia = createBadge('Saunakunnia');
-  const sisu = createBadge('Sisu');
+  const sisu = createBadge('SISU🔥');
+  sisu.container.style.display = 'none';
   const gold = createBadge('Gold');
   const time = createBadge('Time');
   time.delta.style.display = 'none';
@@ -60,6 +61,21 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
     sfx.play('click');
   });
   bar.appendChild(sisuBtn);
+
+  eventBus.on('sisuPulseStart', ({ remaining }) => {
+    sisuBtn.disabled = true;
+    sisu.container.style.display = 'block';
+    sisu.value.textContent = String(remaining);
+  });
+  eventBus.on('sisuPulseTick', ({ remaining }) => {
+    sisu.value.textContent = String(remaining);
+  });
+  eventBus.on('sisuPulseEnd', () => {
+    sisu.container.style.display = 'none';
+  });
+  eventBus.on('sisuCooldownEnd', () => {
+    sisuBtn.disabled = false;
+  });
 
   gold.value.textContent = String(state.getResource(Resource.GOLD));
 


### PR DESCRIPTION
## Summary
- add SISU pulse ability with 10s boost and 120s cooldown
- show SISU🔥 countdown and disable button during cooldown
- highlight allied units during SISU pulse

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f841ba3c83308ceb977c9a135aaa