### PR TITLE
Fix GitHub Pages base path to render game correctly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,8 +26,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-        env:
-          BASE_PATH: /${{ github.event.repository.name }}/
       - run: cp dist/index.html dist/404.html
       - run: touch dist/.nojekyll
       - uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ https://<your-github-username>.github.io/autobattles4xfinsauna/
 
 Replace `<your-github-username>` with your GitHub account name.
 
+The Vite configuration automatically sets the correct base path for the build
+using the repository name. This ensures asset URLs resolve properly on GitHub
+Pages and prevents the site from rendering as plain text. If you fork or rename
+the repository, update the `name` field in `package.json` so the build step
+continues to point to the right base path.
+
 ## Live Demo
 Deployed on GitHub Pages: https://wasab1kastike.github.io/autobattles4xfinsauna/
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from 'vite';
+import pkg from './package.json' assert { type: 'json' };
+const { name: repoName } = pkg;
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   root: 'src',
-  base: process.env.BASE_PATH ?? '/',
+  // Use the repository name as the base path for production builds so that
+  // assets resolve correctly on GitHub Pages deployments. In development we
+  // keep the base at '/' to match the local dev server.
+  base: command === 'build' ? `/${repoName}/` : '/',
   publicDir: '../public',
   build: {
     outDir: '../dist',
     emptyOutDir: true,
   },
-});
+}));


### PR DESCRIPTION
## Summary
- derive Vite base path from repository name so GitHub Pages serves assets correctly
- simplify deployment workflow by removing unused BASE_PATH variable
- document automatic base-path handling in README to avoid text-only site issues

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6f885ebac83308f0ebf4de1845f84