### PR TITLE
Refactor right panel into policies, events and log tabs

### DIFF
--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -235,4 +235,9 @@ export class GameState {
     eventBus.emit('policyApplied', { policy, state: this });
     return true;
   }
+
+  /** Check if a policy has been applied. */
+  hasPolicy(policy: string): boolean {
+    return this.policies.has(policy);
+  }
 }

--- a/src/events/policies.ts
+++ b/src/events/policies.ts
@@ -1,6 +1,6 @@
 import { eventBus } from './EventBus';
 import type { GameState } from '../core/GameState';
-import { Resource } from '../core/GameState';
+import { Resource, PASSIVE_GENERATION } from '../core/GameState';
 
 type PolicyPayload = { policy: string; state: GameState };
 
@@ -8,7 +8,21 @@ const onPolicyApplied = ({ policy, state }: PolicyPayload): void => {
   if (policy === 'eco') {
     // Increase gold generation by 1 when eco policy applied
     state.modifyPassiveGeneration(Resource.GOLD, 1);
-    eventBus.off('policyApplied', onPolicyApplied);
+    return;
+  }
+  if (policy === 'temperance') {
+    const bonus = PASSIVE_GENERATION[Resource.GOLD] * 0.05;
+    let active = false;
+    const onTimeOfDay = ({ isNight }: { isNight: boolean }): void => {
+      if (isNight && !active) {
+        state.modifyPassiveGeneration(Resource.GOLD, bonus);
+        active = true;
+      } else if (!isNight && active) {
+        state.modifyPassiveGeneration(Resource.GOLD, -bonus);
+        active = false;
+      }
+    };
+    eventBus.on('timeOfDayChanged', onTimeOfDay);
   }
 };
 

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -13,11 +13,14 @@ describe('log function', () => {
     `;
 
     const { log } = await import('./game.ts');
-    const eventLog = document.getElementById('event-log')!;
 
     for (let i = 1; i <= 150; i++) {
       log(`msg ${i}`);
     }
+
+    // flush batched logs
+    (log as any).flush();
+    const eventLog = document.getElementById('event-log')!;
 
     expect(eventLog.childElementCount).toBe(100);
     expect(eventLog.firstChild?.textContent).toBe('msg 51');

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,6 @@
       <canvas id="game-canvas" width="800" height="600"></canvas>
       <div id="ui-overlay">
         <div id="resource-bar">Resources: 0</div>
-        <div id="event-log"></div>
         <div id="build-menu">
           <button id="build-farm">Build Farm</button>
           <button id="build-barracks">Build Barracks</button>

--- a/src/style.css
+++ b/src/style.css
@@ -51,15 +51,34 @@ body {
   padding: 4px;
 }
 
-#event-log {
+#right-panel {
   pointer-events: auto;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 4px;
   position: absolute;
-  top: 24px;
-  left: 0;
-  max-height: 100px;
-  width: 200px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 250px;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+}
+
+#right-panel .tabs {
+  display: flex;
+}
+
+#right-panel .tabs button {
+  flex: 1;
+}
+
+#right-panel .tab-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px;
+}
+
+#event-log {
+  height: 100%;
   overflow-y: auto;
   font-size: 14px;
 }

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -1,0 +1,183 @@
+import type { GameState } from '../core/GameState';
+import { eventBus } from '../events';
+import { Resource as ResEnum } from '../core/GameState';
+
+// Event representation
+interface GameEvent {
+  id: number;
+  headline: string;
+  body: string;
+  button: string;
+}
+
+export function setupRightPanel(state: GameState) {
+  const overlay = document.getElementById('ui-overlay');
+  const existingLog = document.getElementById('event-log');
+
+  let eventLog: HTMLElement;
+  let panel: HTMLElement | null = null;
+
+  if (overlay) {
+    panel = document.createElement('div');
+    panel.id = 'right-panel';
+    overlay.appendChild(panel);
+
+    const tabs = document.createElement('div');
+    tabs.className = 'tabs';
+    panel.appendChild(tabs);
+
+    const content = document.createElement('div');
+    content.className = 'tab-content';
+    panel.appendChild(content);
+
+    const logTab = document.createElement('button');
+    logTab.textContent = 'Log';
+    const eventsTabBtn = document.createElement('button');
+    eventsTabBtn.textContent = 'Events';
+    const policiesTabBtn = document.createElement('button');
+    policiesTabBtn.textContent = 'Policies';
+
+    tabs.appendChild(policiesTabBtn);
+    tabs.appendChild(eventsTabBtn);
+    tabs.appendChild(logTab);
+
+    // containers
+    const policiesContainer = document.createElement('div');
+    const eventsContainer = document.createElement('div');
+    const logContainer = document.createElement('div');
+    logContainer.id = 'event-log';
+    content.appendChild(policiesContainer);
+    content.appendChild(eventsContainer);
+    content.appendChild(logContainer);
+
+    const switchTab = (tab: HTMLElement) => {
+      policiesContainer.style.display = 'none';
+      eventsContainer.style.display = 'none';
+      logContainer.style.display = 'none';
+      tab.style.display = 'block';
+    };
+    policiesTabBtn.addEventListener('click', () => switchTab(policiesContainer));
+    eventsTabBtn.addEventListener('click', () => switchTab(eventsContainer));
+    logTab.addEventListener('click', () => switchTab(logContainer));
+    switchTab(policiesContainer);
+
+    eventLog = logContainer;
+
+    // Policies
+    const policies = [
+      {
+        id: 'eco',
+        name: 'Eco Policy',
+        desc: '+1 gold generation',
+        cost: 15,
+        prereq: () => !state.hasPolicy('eco'),
+        apply: () => state.applyPolicy('eco', 15)
+      },
+      {
+        id: 'temperance',
+        name: 'Temperance',
+        desc: '+5% work speed at night',
+        cost: 20,
+        prereq: () => state.hasPolicy('eco') && !state.hasPolicy('temperance'),
+        apply: () => state.applyPolicy('temperance', 20)
+      }
+    ];
+
+    const policyButtons: Record<string, HTMLButtonElement> = {};
+
+    const updatePolicies = () => {
+      policies.forEach((p) => {
+        const btn = policyButtons[p.id];
+        btn.disabled = !p.prereq() || state.getResource(ResEnum.GOLD) < p.cost;
+      });
+    };
+
+    policies.forEach((p) => {
+      const btn = document.createElement('button');
+      btn.textContent = `${p.name} (${p.desc})`;
+      btn.addEventListener('click', () => {
+        if (p.apply()) updatePolicies();
+      });
+      policiesContainer.appendChild(btn);
+      policyButtons[p.id] = btn;
+    });
+
+    updatePolicies();
+    eventBus.on('resourceChanged', updatePolicies);
+    eventBus.on('policyApplied', updatePolicies);
+
+    // Events
+    const events: GameEvent[] = [];
+    let nextId = 1;
+
+    const renderEvents = () => {
+      eventsContainer.innerHTML = '';
+      events.forEach((ev) => {
+        const card = document.createElement('div');
+        const h = document.createElement('h4');
+        h.textContent = ev.headline;
+        const b = document.createElement('p');
+        b.textContent = ev.body;
+        const btn = document.createElement('button');
+        btn.textContent = ev.button;
+        btn.addEventListener('click', () => {
+          const idx = events.findIndex((e) => e.id === ev.id);
+          if (idx !== -1) {
+            events.splice(idx, 1);
+            renderEvents();
+          }
+        });
+        card.appendChild(h);
+        card.appendChild(b);
+        card.appendChild(btn);
+        eventsContainer.appendChild(card);
+      });
+    };
+
+    const addEvent = (headline: string, body: string, button = 'Acknowledge') => {
+      events.push({ id: nextId++, headline, body, button });
+      renderEvents();
+    };
+
+    return { log: createLogger(logContainer), addEvent };
+  }
+
+  // Fallback for tests or missing overlay
+  eventLog = existingLog || document.createElement('div');
+  if (!existingLog) {
+    document.body.appendChild(eventLog);
+  }
+  return { log: createLogger(eventLog), addEvent: () => {} };
+}
+
+// Logging with batching and auto-scroll
+function createLogger(container: HTMLElement) {
+  const buffer: string[] = [];
+  let flushing = false;
+  const flush = () => {
+    buffer.forEach((msg) => {
+      const div = document.createElement('div');
+      div.textContent = msg;
+      container.appendChild(div);
+      while (container.childElementCount > 100) {
+        container.removeChild(container.firstChild!);
+      }
+    });
+    container.scrollTop = container.scrollHeight;
+    buffer.length = 0;
+    flushing = false;
+  };
+  const schedule = () => {
+    if (flushing) return;
+    flushing = true;
+    (typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (cb: FrameRequestCallback) => setTimeout(cb, 16))(flush);
+  };
+  const log = (msg: string) => {
+    buffer.push(msg);
+    schedule();
+  };
+  (log as any).flush = flush;
+  return log as typeof log & { flush: () => void };
+}


### PR DESCRIPTION
## Summary
- Add tabbed right panel with Policies, Events and Log tabs
- Enable policy toggles with prerequisites and Temperance night bonus
- Batch log updates per frame with auto-scrolling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f84c15148330bf45edd4845a86a5