### PR TITLE
Add Web Audio SFX with mute control and triggers

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -38,11 +38,6 @@ const assetPaths: AssetPaths = {
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGPcpKT0n4ECwESJ5lEDRg0YNWAwGQAAM4ACFQNjXqgAAAAASUVORK5CYII=',
     farm:
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGO8tVThPwMFgIkSzaMGjBowasBgMgAA4QYCvtGd17wAAAAASUVORK5CYII='
-  },
-  sounds: {
-    // Minimal silent WAV
-    click:
-      'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YQAAAAA='
   }
 };
 let assets: LoadedAssets;
@@ -83,6 +78,9 @@ function spawn(type: UnitType, coord: AxialCoord): void {
   const unit = spawnUnit(state, type, id, coord, 'player');
   if (unit) {
     units.push(unit);
+    sfx.play('spawn');
+  } else {
+    sfx.play('error');
   }
 }
 
@@ -123,6 +121,7 @@ function drawUnits(ctx: CanvasRenderingContext2D): void {
 }
 
 canvas.addEventListener('click', (e) => {
+  sfx.play('click');
   const rect = canvas.getBoundingClientRect();
   const x = e.clientX - rect.left - map.hexSize;
   const y = e.clientY - rect.top - map.hexSize;
@@ -182,33 +181,44 @@ window.addEventListener('beforeunload', () => {
 });
 
 buildFarmBtn.addEventListener('click', () => {
+  sfx.play('click');
   if (!selected) return;
   if (state.placeBuilding(new Farm(), selected, map)) {
     log('Farm constructed');
     draw();
+  } else {
+    sfx.play('error');
   }
 });
 
 buildBarracksBtn.addEventListener('click', () => {
+  sfx.play('click');
   if (!selected) return;
   if (state.placeBuilding(new Barracks(), selected, map)) {
     log('Barracks constructed');
     draw();
+  } else {
+    sfx.play('error');
   }
 });
 
 upgradeFarmBtn.addEventListener('click', () => {
-  state.upgrade('farm', 20);
+  sfx.play('click');
+  if (!state.upgrade('farm', 20)) {
+    sfx.play('error');
+  }
 });
 
 policyBtn.addEventListener('click', () => {
-  state.applyPolicy('eco', 15);
+  sfx.play('click');
+  if (!state.applyPolicy('eco', 15)) {
+    sfx.play('error');
+  }
 });
 
 async function start(): Promise<void> {
   const { assets: loaded, failures } = await loadAssets(assetPaths);
   assets = loaded;
-  Object.entries(assets.sounds).forEach(([name, audio]) => sfx.register(name, audio));
   if (failures.length) {
     console.warn('Failed to load assets', failures);
   }
@@ -221,6 +231,7 @@ async function start(): Promise<void> {
     clock.tick(delta);
       sauna.update(delta / 1000, units, (u) => {
         units.push(u);
+        sfx.play('spawn');
         draw();
       });
       updateSaunaUI();

--- a/src/sfx.ts
+++ b/src/sfx.ts
@@ -1,12 +1,60 @@
-export const sfx = {
-  _sounds: new Map<string, HTMLAudioElement>(),
-  register(name: string, audio: HTMLAudioElement): void {
-    this._sounds.set(name, audio);
-  },
-  play(name: string): void {
-    const audio = this._sounds.get(name);
-    if (!audio) return;
-    audio.currentTime = 0;
-    void audio.play();
+export type SfxName = 'click' | 'spawn' | 'error' | 'sisu';
+
+const AudioCtx =
+  typeof window !== 'undefined'
+    ? (window.AudioContext || (window as any).webkitAudioContext)
+    : undefined;
+const ctx: AudioContext | null = AudioCtx ? new AudioCtx() : null;
+
+const buffers = new Map<SfxName, AudioBuffer>();
+if (ctx) {
+  buffers.set('click', createClickBuffer());
+  buffers.set('spawn', createToneBuffer(440, 0.25));
+  buffers.set('error', createToneBuffer(150, 0.3));
+  buffers.set('sisu', createToneBuffer(880, 0.5));
+}
+
+let muted =
+  typeof localStorage !== 'undefined' && localStorage.getItem('muted') === 'true';
+
+function setMuted(value: boolean): void {
+  muted = value;
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('muted', String(value));
   }
-};
+}
+
+function play(name: SfxName): void {
+  if (muted || !ctx) return;
+  const buffer = buffers.get(name);
+  if (!buffer) return;
+  if (ctx.state === 'suspended') void ctx.resume();
+  const src = ctx.createBufferSource();
+  src.buffer = buffer;
+  src.connect(ctx.destination);
+  src.start();
+}
+
+function createToneBuffer(freq: number, duration: number): AudioBuffer {
+  const length = Math.floor(ctx!.sampleRate * duration);
+  const buffer = ctx!.createBuffer(1, length, ctx!.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < length; i++) {
+    const t = i / ctx!.sampleRate;
+    data[i] = Math.sin(2 * Math.PI * freq * t) * Math.exp(-3 * t / duration);
+  }
+  return buffer;
+}
+
+function createClickBuffer(): AudioBuffer {
+  const duration = 0.05;
+  const length = Math.floor(ctx!.sampleRate * duration);
+  const buffer = ctx!.createBuffer(1, length, ctx!.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < length; i++) {
+    data[i] = (Math.random() * 2 - 1) * (1 - i / length);
+  }
+  return buffer;
+}
+
+export const sfx = { play, setMuted };

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -1,4 +1,5 @@
 import type { Sauna } from '../sim/sauna.ts';
+import { sfx } from '../sfx';
 
 export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   const overlay = document.getElementById('ui-overlay');
@@ -34,6 +35,7 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   checkbox.checked = sauna.rallyToFront;
   checkbox.addEventListener('change', () => {
     sauna.rallyToFront = checkbox.checked;
+    sfx.play('click');
   });
   label.appendChild(checkbox);
   label.appendChild(document.createTextNode(' Rally to Front'));
@@ -43,6 +45,7 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
 
   btn.addEventListener('click', () => {
     card.style.display = card.style.display === 'none' ? 'block' : 'none';
+    sfx.play('click');
   });
 
   return () => {

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -61,6 +61,17 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
   });
   bar.appendChild(sisuBtn);
 
+  const muteBtn = document.createElement('button');
+  let muted = localStorage.getItem('muted') === 'true';
+  muteBtn.textContent = muted ? 'Unmute' : 'Mute';
+  muteBtn.addEventListener('click', () => {
+    muted = !muted;
+    sfx.setMuted(muted);
+    muteBtn.textContent = muted ? 'Unmute' : 'Mute';
+    sfx.play('click');
+  });
+  bar.appendChild(muteBtn);
+
   gold.value.textContent = String(state.getResource(Resource.GOLD));
 
   const badges: Record<string, Badge> = {
@@ -81,6 +92,8 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
     }, 1000);
     sfx.play('click');
   });
+
+  eventBus.on('sisuPulse', () => sfx.play('sisu'));
 
   let elapsed = 0;
   return (deltaMs: number) => {


### PR DESCRIPTION
## Summary
- implement Web Audio API sound engine with click, spawn, error and sisu cues plus mute persistence
- add mute toggle in top bar and play sisu pulse sound
- hook click, spawn and error cues to UI buttons, unit spawns and purchases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6f848d0108330be7779e9234d6ef7