### PR TITLE
feat: add Web Audio sound effects and mute toggle

### DIFF
--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -3,6 +3,7 @@
  * Handles saving/loading via localStorage and offline progress.
  */
 import { eventBus } from '../events/EventBus';
+import { play } from '../sfx';
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import type { HexMap } from '../hexmap.ts';
 import { Farm, Barracks, type Building } from '../buildings/index.ts';
@@ -134,6 +135,7 @@ export class GameState {
 
   private spend(cost: number, res: Resource = Resource.GOLD): boolean {
     if (!this.canAfford(cost, res)) {
+      play('error');
       return false;
     }
     this.resources[res] -= cost;

--- a/src/game.ts
+++ b/src/game.ts
@@ -16,7 +16,7 @@ import { setupSaunaUI } from './ui/sauna.tsx';
 import { raiderSVG } from './ui/sprites.ts';
 import { resetAutoFrame } from './camera/autoFrame.ts';
 import { setupTopbar } from './ui/topbar.ts';
-import { sfx } from './sfx.ts';
+import { play } from './sfx.ts';
 import { activateSisuPulse, isSisuActive } from './sim/sisu.ts';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
@@ -130,6 +130,7 @@ function drawUnits(ctx: CanvasRenderingContext2D): void {
 }
 
 canvas.addEventListener('click', (e) => {
+  play('click');
   const rect = canvas.getBoundingClientRect();
   const x = e.clientX - rect.left - map.hexSize;
   const y = e.clientY - rect.top - map.hexSize;
@@ -189,6 +190,7 @@ window.addEventListener('beforeunload', () => {
 });
 
 buildFarmBtn.addEventListener('click', () => {
+  play('click');
   if (!selected) return;
   if (state.placeBuilding(new Farm(), selected, map)) {
     log('Farm constructed');
@@ -197,6 +199,7 @@ buildFarmBtn.addEventListener('click', () => {
 });
 
 buildBarracksBtn.addEventListener('click', () => {
+  play('click');
   if (!selected) return;
   if (state.placeBuilding(new Barracks(), selected, map)) {
     log('Barracks constructed');
@@ -205,17 +208,18 @@ buildBarracksBtn.addEventListener('click', () => {
 });
 
 upgradeFarmBtn.addEventListener('click', () => {
+  play('click');
   state.upgrade('farm', 20);
 });
 
 policyBtn.addEventListener('click', () => {
+  play('click');
   state.applyPolicy('eco', 15);
 });
 
 async function start(): Promise<void> {
   const { assets: loaded, failures } = await loadAssets(assetPaths);
   assets = loaded;
-  Object.entries(assets.sounds).forEach(([name, audio]) => sfx.register(name, audio));
   if (failures.length) {
     console.warn('Failed to load assets', failures);
   }

--- a/src/sfx.ts
+++ b/src/sfx.ts
@@ -1,12 +1,70 @@
-export const sfx = {
-  _sounds: new Map<string, HTMLAudioElement>(),
-  register(name: string, audio: HTMLAudioElement): void {
-    this._sounds.set(name, audio);
-  },
-  play(name: string): void {
-    const audio = this._sounds.get(name);
-    if (!audio) return;
-    audio.currentTime = 0;
-    void audio.play();
+// Simple sound effect generator using the Web Audio API.
+// Generates small tone buffers on load and exposes play() and setMuted().
+
+export type SfxName = 'click' | 'spawn' | 'error' | 'sisu';
+
+const AudioCtor =
+  typeof window !== 'undefined'
+    ? window.AudioContext || (window as any).webkitAudioContext
+    : undefined;
+
+let ctx: AudioContext | null = null;
+let buffers: Partial<Record<SfxName, AudioBuffer>> = {};
+
+if (AudioCtor) {
+  ctx = new AudioCtor();
+
+  function createBuffer(durations: number[], freqs: number[]): AudioBuffer {
+    const total = durations.reduce((a, b) => a + b, 0);
+    const sampleRate = ctx!.sampleRate;
+    const buffer = ctx!.createBuffer(1, Math.floor(sampleRate * total), sampleRate);
+    const data = buffer.getChannelData(0);
+    let offset = 0;
+    for (let i = 0; i < freqs.length; i++) {
+      const freq = freqs[i];
+      const dur = durations[i];
+      const len = Math.floor(sampleRate * dur);
+      for (let j = 0; j < len; j++) {
+        const t = j / sampleRate;
+        const env = 1 - j / len; // simple decay envelope
+        data[offset + j] = Math.sin(2 * Math.PI * freq * t) * env;
+      }
+      offset += len;
+    }
+    return buffer;
   }
-};
+
+  buffers = {
+    click: createBuffer([0.05], [700]),
+    spawn: createBuffer([0.08, 0.08], [400, 800]),
+    error: createBuffer([0.2], [150]),
+    sisu: createBuffer([0.1, 0.1, 0.2], [300, 600, 900])
+  };
+}
+
+let muted = false;
+try {
+  muted = localStorage.getItem('sfx-muted') === 'true';
+} catch {
+  muted = false;
+}
+
+export function setMuted(m: boolean): void {
+  muted = m;
+  try {
+    localStorage.setItem('sfx-muted', String(m));
+  } catch {}
+}
+
+export function play(name: SfxName): void {
+  if (muted || !ctx) return;
+  const buffer = buffers[name];
+  if (!buffer) return;
+  if (ctx.state === 'suspended') {
+    void ctx.resume();
+  }
+  const src = ctx.createBufferSource();
+  src.buffer = buffer;
+  src.connect(ctx.destination);
+  src.start();
+}

--- a/src/sim/sisu.ts
+++ b/src/sim/sisu.ts
@@ -1,6 +1,7 @@
 import type { GameState } from '../core/GameState.ts';
 import type { Unit } from '../units/Unit.ts';
 import { eventBus } from '../events';
+import { play } from '../sfx';
 
 let active = false;
 let onCooldown = false;
@@ -14,6 +15,7 @@ export function activateSisuPulse(state: GameState, units: Unit[]): void {
   if (active || onCooldown) return;
   active = true;
   onCooldown = true;
+  play('sisu');
   let remaining = 10;
   eventBus.emit('sisuPulseStart', { remaining });
 

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -1,5 +1,5 @@
 import { eventBus } from '../events';
-import { sfx } from '../sfx';
+import { play, setMuted } from '../sfx';
 import { GameState, Resource } from '../core/GameState.ts';
 
 type Badge = {
@@ -58,9 +58,20 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
   sisuBtn.textContent = 'SISU';
   sisuBtn.addEventListener('click', () => {
     eventBus.emit('sisuPulse', {});
-    sfx.play('click');
+    play('click');
   });
   bar.appendChild(sisuBtn);
+
+  const muteBtn = document.createElement('button');
+  let muted = localStorage.getItem('sfx-muted') === 'true';
+  muteBtn.textContent = muted ? 'Unmute' : 'Mute';
+  muteBtn.addEventListener('click', () => {
+    play('click');
+    muted = !muted;
+    setMuted(muted);
+    muteBtn.textContent = muted ? 'Unmute' : 'Mute';
+  });
+  bar.appendChild(muteBtn);
 
   eventBus.on('sisuPulseStart', ({ remaining }) => {
     sisuBtn.disabled = true;
@@ -95,7 +106,7 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
     setTimeout(() => {
       badge.delta.style.opacity = '0';
     }, 1000);
-    sfx.play('click');
+    play('click');
   });
 
   let elapsed = 0;

--- a/src/units/UnitFactory.ts
+++ b/src/units/UnitFactory.ts
@@ -3,6 +3,7 @@ import { GameState, Resource } from '../core/GameState.ts';
 import { Unit } from './Unit.ts';
 import { Soldier, SOLDIER_COST } from './Soldier.ts';
 import { Archer, ARCHER_COST } from './Archer.ts';
+import { play } from '../sfx';
 
 export type UnitType = 'soldier' | 'archer';
 
@@ -20,16 +21,22 @@ export function spawnUnit(
 ): Unit | null {
   const cost = UNIT_COST[type];
   if (!state.canAfford(cost, Resource.GOLD)) {
+    play('error');
     return null;
   }
   state.addResource(Resource.GOLD, -cost);
+  let unit: Unit | null = null;
   switch (type) {
     case 'soldier':
-      return new Soldier(id, coord, faction);
+      unit = new Soldier(id, coord, faction);
+      break;
     case 'archer':
-      return new Archer(id, coord, faction);
+      unit = new Archer(id, coord, faction);
+      break;
     default:
-      return null;
+      unit = null;
   }
+  if (unit) play('spawn');
+  return unit;
 }
 


### PR DESCRIPTION
## Summary
- replace audio handling with Web Audio generated buffers for click, spawn, error, and sisu cues
- hook sounds into UI actions, unit spawns, failed purchases, and Sisu Pulse activation
- add mute toggle in top bar with localStorage persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f9f8bfb48330a06eb744279b024b