### PR TITLE
docs: fix GitHub Pages demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the repository, update the `name` field in `package.json` so the build step
 continues to point to the right base path.
 
 ## Live Demo
-Deployed on GitHub Pages: https://wasab1kastike.github.io/autobattles4xfinsauna/
+Deployed on GitHub Pages: https://wasab1kastike.github.io/autobattles4xfinsauna/index.html?utm_source=chatgpt.com
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- point README demo link to built `index.html` on GitHub Pages

## Testing
- `curl -I https://wasab1kastike.github.io/autobattles4xfinsauna/index.html?utm_source=chatgpt.com` (failed: CONNECT tunnel failed, response 403)
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6fa7c3c1883309f75875b65e99c3e