### PR TITLE
feat: add web audio sfx with mute toggle

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -15,7 +15,7 @@ import { setupSaunaUI } from './ui/sauna.tsx';
 import { raiderSVG } from './ui/sprites.ts';
 import { resetAutoFrame } from './camera/autoFrame.ts';
 import { setupTopbar } from './ui/topbar.ts';
-import { sfx } from './sfx.ts';
+import { play } from './sfx.ts';
 import { activateSisuPulse, isSisuActive } from './sim/sisu.ts';
 import { setupRightPanel } from './ui/rightPanel.tsx';
 
@@ -34,11 +34,6 @@ const assetPaths: AssetPaths = {
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGPcpKT0n4ECwESJ5lEDRg0YNWAwGQAAM4ACFQNjXqgAAAAASUVORK5CYII=',
     farm:
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGO8tVThPwMFgIkSzaMGjBowasBgMgAA4QYCvtGd17wAAAAASUVORK5CYII='
-  },
-  sounds: {
-    // Minimal silent WAV
-    click:
-      'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YQAAAAA='
   }
 };
 let assets: LoadedAssets;
@@ -75,6 +70,7 @@ const updateSaunaUI = setupSaunaUI(sauna);
 const updateTopbar = setupTopbar(state);
 const { log, addEvent } = setupRightPanel(state);
 eventBus.on('sisuPulse', () => activateSisuPulse(state, units));
+eventBus.on('sisuPulseStart', () => play('sisu'));
 
 function spawn(type: UnitType, coord: AxialCoord): void {
   const id = `u${units.length + 1}`;
@@ -176,7 +172,6 @@ window.addEventListener('beforeunload', () => {
 async function start(): Promise<void> {
   const { assets: loaded, failures } = await loadAssets(assetPaths);
   assets = loaded;
-  Object.entries(assets.sounds).forEach(([name, audio]) => sfx.register(name, audio));
   if (failures.length) {
     console.warn('Failed to load assets', failures);
   }
@@ -187,16 +182,16 @@ async function start(): Promise<void> {
     const delta = now - last;
     last = now;
     clock.tick(delta);
-      sauna.update(delta / 1000, units, (u) => {
-        units.push(u);
-        draw();
-      });
-      updateSaunaUI();
-      updateTopbar(delta);
-      requestAnimationFrame(gameLoop);
-    }
+    sauna.update(delta / 1000, units, (u) => {
+      units.push(u);
+      draw();
+    });
+    updateSaunaUI();
+    updateTopbar(delta);
     requestAnimationFrame(gameLoop);
   }
+  requestAnimationFrame(gameLoop);
+}
 
 if (!import.meta.vitest) {
   start();

--- a/src/sfx.ts
+++ b/src/sfx.ts
@@ -1,12 +1,101 @@
-export const sfx = {
-  _sounds: new Map<string, HTMLAudioElement>(),
-  register(name: string, audio: HTMLAudioElement): void {
-    this._sounds.set(name, audio);
-  },
-  play(name: string): void {
-    const audio = this._sounds.get(name);
-    if (!audio) return;
-    audio.currentTime = 0;
-    void audio.play();
+// Simple Web Audio based sound effects helper
+// Generates a few short tones for UI feedback and gameplay events.
+
+export type SfxName = 'click' | 'spawn' | 'error' | 'sisu';
+
+let audioCtx: AudioContext | null = null;
+const buffers: Partial<Record<SfxName, AudioBuffer>> = {};
+
+function init(): void {
+  if (audioCtx || typeof window === 'undefined') return;
+  const AC = (window.AudioContext || (window as any).webkitAudioContext);
+  if (!AC) return;
+  audioCtx = new AC();
+  buffers.click = createClick();
+  buffers.spawn = createSpawn();
+  buffers.error = createError();
+  buffers.sisu = createSisu();
+}
+
+function createBuffer(length: number, fill: (t: number) => number): AudioBuffer {
+  const ctx = audioCtx!;
+  const buffer = ctx.createBuffer(1, length, ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < length; i++) {
+    const t = i / ctx.sampleRate;
+    data[i] = fill(t);
   }
-};
+  return buffer;
+}
+
+function createClick(): AudioBuffer {
+  const ctx = audioCtx!;
+  return createBuffer(Math.floor(ctx.sampleRate * 0.05), (t) =>
+    Math.sin(2 * Math.PI * 1000 * t) * Math.exp(-40 * t)
+  );
+}
+
+function createSpawn(): AudioBuffer {
+  const ctx = audioCtx!;
+  return createBuffer(Math.floor(ctx.sampleRate * 0.2), (t) =>
+    (Math.sin(2 * Math.PI * 440 * t) + Math.sin(2 * Math.PI * 660 * t)) *
+      0.5 *
+      Math.exp(-6 * t)
+  );
+}
+
+function createError(): AudioBuffer {
+  const ctx = audioCtx!;
+  return createBuffer(Math.floor(ctx.sampleRate * 0.3), (t) =>
+    Math.sin(2 * Math.PI * 110 * t) * Math.exp(-8 * t)
+  );
+}
+
+function createSisu(): AudioBuffer {
+  const ctx = audioCtx!;
+  return createBuffer(Math.floor(ctx.sampleRate * 0.5), (t) =>
+    Math.sin(2 * Math.PI * 880 * t) * Math.exp(-2 * t)
+  );
+}
+
+let muted = false;
+if (typeof localStorage !== 'undefined') {
+  muted = localStorage.getItem('sfx-muted') === 'true';
+}
+
+export function isMuted(): boolean {
+  return muted;
+}
+
+export function setMuted(m: boolean): void {
+  muted = m;
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('sfx-muted', m ? 'true' : 'false');
+  }
+}
+
+export function play(name: SfxName): void {
+  if (muted) return;
+  if (!audioCtx) init();
+  if (!audioCtx) return;
+  const buffer = buffers[name];
+  if (!buffer) return;
+  if (audioCtx.state === 'suspended') {
+    void audioCtx.resume();
+  }
+  const source = audioCtx.createBufferSource();
+  source.buffer = buffer;
+  source.connect(audioCtx.destination);
+  source.start();
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('click', (e) => {
+    if (e.target instanceof HTMLButtonElement) {
+      play('click');
+    }
+  });
+}
+
+// Initialize when module loaded (if possible)
+init();

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -1,5 +1,5 @@
 import { eventBus } from '../events';
-import { sfx } from '../sfx';
+import { setMuted, isMuted } from '../sfx.ts';
 import { GameState, Resource } from '../core/GameState.ts';
 
 type Badge = {
@@ -58,9 +58,19 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
   sisuBtn.textContent = 'SISU';
   sisuBtn.addEventListener('click', () => {
     eventBus.emit('sisuPulse', {});
-    sfx.play('click');
   });
   bar.appendChild(sisuBtn);
+
+  const muteBtn = document.createElement('button');
+  function renderMute(): void {
+    muteBtn.textContent = isMuted() ? 'Unmute' : 'Mute';
+  }
+  muteBtn.addEventListener('click', () => {
+    setMuted(!isMuted());
+    renderMute();
+  });
+  renderMute();
+  bar.appendChild(muteBtn);
 
   eventBus.on('sisuPulseStart', ({ remaining }) => {
     sisuBtn.disabled = true;
@@ -95,7 +105,6 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
     setTimeout(() => {
       badge.delta.style.opacity = '0';
     }, 1000);
-    sfx.play('click');
   });
 
   let elapsed = 0;

--- a/src/units/UnitFactory.ts
+++ b/src/units/UnitFactory.ts
@@ -3,6 +3,7 @@ import { GameState, Resource } from '../core/GameState.ts';
 import { Unit } from './Unit.ts';
 import { Soldier, SOLDIER_COST } from './Soldier.ts';
 import { Archer, ARCHER_COST } from './Archer.ts';
+import { play } from '../sfx.ts';
 
 export type UnitType = 'soldier' | 'archer';
 
@@ -20,16 +21,24 @@ export function spawnUnit(
 ): Unit | null {
   const cost = UNIT_COST[type];
   if (!state.canAfford(cost, Resource.GOLD)) {
+    play('error');
     return null;
   }
   state.addResource(Resource.GOLD, -cost);
+  let unit: Unit | null = null;
   switch (type) {
     case 'soldier':
-      return new Soldier(id, coord, faction);
+      unit = new Soldier(id, coord, faction);
+      break;
     case 'archer':
-      return new Archer(id, coord, faction);
+      unit = new Archer(id, coord, faction);
+      break;
     default:
-      return null;
+      unit = null;
   }
+  if (unit) {
+    play('spawn');
+  }
+  return unit;
 }
 


### PR DESCRIPTION
## Summary
- implement Web Audio based sound system with generated buffers and mute persistence
- play spawn/error click and sisu sounds on relevant events
- add UI mute toggle in top bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7065685688330ba133d2bddd7a1e0