### PR TITLE
chore: add demo link check

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the repository, update the `name` field in `package.json` so the build step
 continues to point to the right base path.
 
 ## Live Demo
-Deployed on GitHub Pages: https://wasab1kastike.github.io/autobattles4xfinsauna/
+Deployed on GitHub Pages: https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com
 
 ## Running Tests
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "check:demo": "node scripts/check-demo-link.js"
   },
   "devDependencies": {
     "jsdom": "^27.0.0",

--- a/scripts/check-demo-link.js
+++ b/scripts/check-demo-link.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+
+const demoUrl = 'https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com';
+
+// Verify README contains the expected demo URL
+const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
+if (!readme.includes(demoUrl)) {
+  console.error('README does not contain the expected demo link.');
+  process.exit(1);
+}
+
+// Ensure the URL responds with HTTP 200
+try {
+  const res = await fetch(demoUrl, { method: 'HEAD' });
+  if (!res.ok) {
+    console.error(`Demo link returned status ${res.status}.`);
+    process.exit(1);
+  }
+  console.log('Demo link is reachable.');
+} catch (err) {
+  console.error('Failed to fetch demo link:', err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- point README demo link to the GitHub Pages root with tracking parameter
- add script to verify README link and ensure deployed page responds
- expose `npm run check:demo` for link checks in CI

## Testing
- `npm test`
- `npm run build`
- `npm run check:demo` (failed: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_68c6fa7c3c1883309f75875b65e99c3e