### PR TITLE
feat: add web audio sfx and mute toggle

### DIFF
--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -6,6 +6,7 @@ import { eventBus } from '../events/EventBus';
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import type { HexMap } from '../hexmap.ts';
 import { Farm, Barracks, type Building } from '../buildings/index.ts';
+import { play } from '../sfx.ts';
 
 function coordKey(c: AxialCoord): string {
   return `${c.q},${c.r}`;
@@ -137,6 +138,7 @@ export class GameState {
 
   private spend(cost: number, res: Resource = Resource.GOLD): boolean {
     if (!this.canAfford(cost, res)) {
+      play('error');
       return false;
     }
     this.resources[res] -= cost;

--- a/src/game.ts
+++ b/src/game.ts
@@ -15,7 +15,6 @@ import { setupSaunaUI } from './ui/sauna.tsx';
 import { raiderSVG } from './ui/sprites.ts';
 import { resetAutoFrame } from './camera/autoFrame.ts';
 import { setupTopbar } from './ui/topbar.ts';
-import { sfx } from './sfx.ts';
 import { activateSisuPulse, isSisuActive } from './sim/sisu.ts';
 import { setupRightPanel } from './ui/rightPanel.tsx';
 
@@ -34,11 +33,6 @@ const assetPaths: AssetPaths = {
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGPcpKT0n4ECwESJ5lEDRg0YNWAwGQAAM4ACFQNjXqgAAAAASUVORK5CYII=',
     farm:
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGO8tVThPwMFgIkSzaMGjBowasBgMgAA4QYCvtGd17wAAAAASUVORK5CYII='
-  },
-  sounds: {
-    // Minimal silent WAV
-    click:
-      'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YQAAAAA='
   }
 };
 let assets: LoadedAssets;
@@ -176,7 +170,6 @@ window.addEventListener('beforeunload', () => {
 async function start(): Promise<void> {
   const { assets: loaded, failures } = await loadAssets(assetPaths);
   assets = loaded;
-  Object.entries(assets.sounds).forEach(([name, audio]) => sfx.register(name, audio));
   if (failures.length) {
     console.warn('Failed to load assets', failures);
   }

--- a/src/sfx.ts
+++ b/src/sfx.ts
@@ -1,12 +1,56 @@
-export const sfx = {
-  _sounds: new Map<string, HTMLAudioElement>(),
-  register(name: string, audio: HTMLAudioElement): void {
-    this._sounds.set(name, audio);
-  },
-  play(name: string): void {
-    const audio = this._sounds.get(name);
-    if (!audio) return;
-    audio.currentTime = 0;
-    void audio.play();
+type SoundName = 'click' | 'spawn' | 'error' | 'sisu';
+
+const AudioCtx =
+  typeof window !== 'undefined'
+    ? (window.AudioContext || (window as any).webkitAudioContext)
+    : undefined;
+const ctx: AudioContext | null = AudioCtx ? new AudioCtx() : null;
+
+const storage = typeof window !== 'undefined' ? window.localStorage : undefined;
+let muted = storage?.getItem('muted') === 'true';
+
+const buffers: Partial<Record<SoundName, AudioBuffer>> = {};
+
+if (ctx) {
+  buffers.click = createTone([1000], [0.05]);
+  buffers.spawn = createTone([300, 500], [0.1, 0.1]);
+  buffers.error = createTone([200, 150], [0.15, 0.15]);
+  buffers.sisu = createTone([400, 600, 800], [0.1, 0.1, 0.2]);
+}
+
+function createTone(freqs: number[], durations: number[]): AudioBuffer {
+  const sampleRate = ctx!.sampleRate;
+  const total = durations.reduce((a, b) => a + b, 0);
+  const buffer = ctx!.createBuffer(1, Math.floor(sampleRate * total), sampleRate);
+  const data = buffer.getChannelData(0);
+  let offset = 0;
+  for (let i = 0; i < freqs.length; i++) {
+    const len = Math.floor(durations[i] * sampleRate);
+    for (let j = 0; j < len; j++) {
+      const t = j / len;
+      const env = 1 - t; // simple linear fade-out
+      data[offset + j] = Math.sin((2 * Math.PI * freqs[i] * j) / sampleRate) * env;
+    }
+    offset += len;
   }
-};
+  return buffer;
+}
+
+export function play(name: SoundName): void {
+  if (muted || !ctx) return;
+  if (ctx.state === 'suspended') {
+    void ctx.resume();
+  }
+  const buffer = buffers[name];
+  if (!buffer) return;
+  const src = ctx.createBufferSource();
+  src.buffer = buffer;
+  src.connect(ctx.destination);
+  src.start();
+}
+
+export function setMuted(value: boolean): void {
+  muted = value;
+  storage?.setItem('muted', value ? 'true' : 'false');
+}
+

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -1,5 +1,5 @@
 import { eventBus } from '../events';
-import { sfx } from '../sfx';
+import { play, setMuted } from '../sfx.ts';
 import { GameState, Resource } from '../core/GameState.ts';
 
 type Badge = {
@@ -36,6 +36,11 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
   const overlay = document.getElementById('ui-overlay');
   if (!overlay) return () => {};
 
+  overlay.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    if (target.tagName === 'BUTTON') play('click');
+  });
+
   const bar = document.createElement('div');
   bar.id = 'topbar';
   bar.style.display = 'flex';
@@ -58,11 +63,21 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
   sisuBtn.textContent = 'SISU';
   sisuBtn.addEventListener('click', () => {
     eventBus.emit('sisuPulse', {});
-    sfx.play('click');
   });
   bar.appendChild(sisuBtn);
 
+  const muteBtn = document.createElement('button');
+  let muted = localStorage.getItem('muted') === 'true';
+  muteBtn.textContent = muted ? 'Unmute' : 'Mute';
+  muteBtn.addEventListener('click', () => {
+    muted = !muted;
+    setMuted(muted);
+    muteBtn.textContent = muted ? 'Unmute' : 'Mute';
+  });
+  bar.appendChild(muteBtn);
+
   eventBus.on('sisuPulseStart', ({ remaining }) => {
+    play('sisu');
     sisuBtn.disabled = true;
     sisu.container.style.display = 'block';
     sisu.value.textContent = String(remaining);
@@ -95,7 +110,6 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
     setTimeout(() => {
       badge.delta.style.opacity = '0';
     }, 1000);
-    sfx.play('click');
   });
 
   let elapsed = 0;

--- a/src/units/UnitFactory.ts
+++ b/src/units/UnitFactory.ts
@@ -3,6 +3,7 @@ import { GameState, Resource } from '../core/GameState.ts';
 import { Unit } from './Unit.ts';
 import { Soldier, SOLDIER_COST } from './Soldier.ts';
 import { Archer, ARCHER_COST } from './Archer.ts';
+import { play } from '../sfx.ts';
 
 export type UnitType = 'soldier' | 'archer';
 
@@ -20,16 +21,22 @@ export function spawnUnit(
 ): Unit | null {
   const cost = UNIT_COST[type];
   if (!state.canAfford(cost, Resource.GOLD)) {
+    play('error');
     return null;
   }
   state.addResource(Resource.GOLD, -cost);
+  let unit: Unit | null = null;
   switch (type) {
     case 'soldier':
-      return new Soldier(id, coord, faction);
+      unit = new Soldier(id, coord, faction);
+      break;
     case 'archer':
-      return new Archer(id, coord, faction);
-    default:
-      return null;
+      unit = new Archer(id, coord, faction);
+      break;
   }
+  if (unit) {
+    play('spawn');
+  }
+  return unit;
 }
 


### PR DESCRIPTION
## Summary
- implement Web Audio-based sound system with click, spawn, error and sisu effects
- wire UI to play sounds for clicks, unit spawns, failed purchases and Sisu activation
- add persistent mute toggle in top bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7075f118c8330af3f6596f19c0ef7