### PR TITLE
Add demo link checks and contributor guidelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,4 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
+      - run: curl -Lf https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Thank you for considering a contribution!
+
+- Ensure the README's "Live Demo" link points to:
+  https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com
+- Run the full CI workflow locally before pushing:
+  - `npm test`
+  - `npm run build`
+- Open a pull request with your changes.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the repository, update the `name` field in `package.json` so the build step
 continues to point to the right base path.
 
 ## Live Demo
-Deployed on GitHub Pages: https://wasab1kastike.github.io/autobattles4xfinsauna/index.html?utm_source=chatgpt.com
+Deployed on GitHub Pages: https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com
 
 ## Running Tests
 
@@ -56,5 +56,6 @@ npm test
 ## Contributing
 
 Contributions are welcome! Fork the repository, create a branch, make your
-changes, and open a pull request.
+changes, and open a pull request. See [CONTRIBUTING.md](CONTRIBUTING.md) for
+guidelines.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run && node scripts/check-demo-link.js"
   },
   "devDependencies": {
     "jsdom": "^27.0.0",

--- a/scripts/check-demo-link.js
+++ b/scripts/check-demo-link.js
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const readmePath = join(__dirname, '..', 'README.md');
+const readme = readFileSync(readmePath, 'utf8');
+const expected = 'https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com';
+
+if (!readme.includes(expected)) {
+  console.error(`README Live demo link must be ${expected}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- verify README demo link during tests
- check GitHub Pages status in CI
- document demo URL requirement and local test/build steps for contributors

## Testing
- `curl -Lf https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com` (fails with 403 in container)
- `npm test`
- `node scripts/check-demo-link.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c70ae5b2d88330ab7cee8b079e694c