### PR TITLE
feat: ensure demo link serves game

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ npm install
 - `npm run build` – compile TypeScript and bundle the production build.
 - `npm run preview` – preview the built app locally.
 - `npm test` – run the test suite with Vitest.
+- `npm run check:demo` – verify the README demo link and ensure the GitHub Pages
+  deployment responds with a 200 status and contains the game's
+  `<title>Autobattles4xFinsauna</title>` tag.
 
 ## Gameplay
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run && node scripts/check-demo-link.js"
+    "test": "vitest run && node scripts/check-demo-link.js",
+    "check:demo": "node scripts/check-demo-link.js"
   },
   "devDependencies": {
     "jsdom": "^27.0.0",

--- a/scripts/check-demo-link.js
+++ b/scripts/check-demo-link.js
@@ -5,9 +5,30 @@ import { dirname, join } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const readmePath = join(__dirname, '..', 'README.md');
 const readme = readFileSync(readmePath, 'utf8');
-const expected = 'https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com';
+const demoUrl =
+  'https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com';
+const expectedTitle = '<title>Autobattles4xFinsauna</title>';
 
-if (!readme.includes(expected)) {
-  console.error(`README Live demo link must be ${expected}`);
+if (!readme.includes(demoUrl)) {
+  console.error(`README Live demo link must be ${demoUrl}`);
+  process.exit(1);
+}
+
+try {
+  const response = await fetch(demoUrl, { method: 'GET' });
+  if (response.status !== 200) {
+    console.error(`Live demo returned HTTP ${response.status}`);
+    process.exit(1);
+  }
+
+  const html = await response.text();
+  if (!html.includes(expectedTitle)) {
+    console.error(`Live demo HTML must contain ${expectedTitle}`);
+    process.exit(1);
+  }
+
+  console.log('Live demo link is present and returns expected content.');
+} catch (err) {
+  console.error(`Failed to fetch live demo: ${err}`);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- verify demo link uses GET and checks for game title
- expose `check:demo` npm script and document it

## Testing
- `npm run check:demo` *(fails: fetch failed)*
- `npm test` *(fails: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c70c5d27c083309794177f97d150e2