### PR TITLE
Add sprite assets and render map tokens using images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,3 @@ dist-ssr
 *.sln
 *.sw?
 
-# Sprite assets (binary files not tracked)
-public/assets/sprites/*.png
-public/assets/sprites/*.jpg
-public/assets/sprites/*.gif

--- a/public/assets/sprites/README.md
+++ b/public/assets/sprites/README.md
@@ -1,3 +1,4 @@
-Binary sprite assets are not tracked in this repository.
-The game currently relies on inline base64 placeholders defined in code.
-Add real sprite files here locally if desired (they are ignored by git).
+Sprite image files used by the game.
+
+The repository now tracks placeholder SVGs for terrain, buildings and units.
+Custom art can be dropped into this folder to override them.

--- a/public/assets/sprites/archer.svg
+++ b/public/assets/sprites/archer.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#556b2f" />
+  <line x1="16" y1="16" x2="48" y2="48" stroke="#fff" stroke-width="4" />
+  <polygon points="48,48 44,36 36,44" fill="#fff" />
+</svg>

--- a/public/assets/sprites/barracks.svg
+++ b/public/assets/sprites/barracks.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#c0c0c0" />
+  <rect x="8" y="24" width="48" height="24" fill="#808080" />
+  <rect x="24" y="16" width="16" height="8" fill="#606060" />
+</svg>

--- a/public/assets/sprites/city.svg
+++ b/public/assets/sprites/city.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#e0e0e0" />
+  <rect x="10" y="22" width="12" height="30" fill="#a9a9a9" />
+  <rect x="26" y="14" width="12" height="38" fill="#808080" />
+  <rect x="42" y="26" width="12" height="26" fill="#a9a9a9" />
+</svg>

--- a/public/assets/sprites/farm.svg
+++ b/public/assets/sprites/farm.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#a4d67a" />
+  <polygon points="16,48 32,16 48,48" fill="#d2691e" />
+  <rect x="24" y="32" width="16" height="16" fill="#f4a460" />
+</svg>

--- a/public/assets/sprites/forest.svg
+++ b/public/assets/sprites/forest.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#216e24" />
+  <rect x="29" y="34" width="6" height="20" fill="#8b4513" />
+  <circle cx="32" cy="24" r="16" fill="#2e8b57" />
+</svg>

--- a/public/assets/sprites/hills.svg
+++ b/public/assets/sprites/hills.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#d2b48c" />
+  <polygon points="0,64 20,32 40,64" fill="#c2a070" />
+  <polygon points="24,64 44,28 64,64" fill="#b09060" />
+</svg>

--- a/public/assets/sprites/lake.svg
+++ b/public/assets/sprites/lake.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#66b3ff" />
+  <circle cx="32" cy="32" r="20" fill="#1e90ff" />
+</svg>

--- a/public/assets/sprites/mine.svg
+++ b/public/assets/sprites/mine.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#8b4513" />
+  <polygon points="32,10 42,22 22,22" fill="#555" />
+  <rect x="30" y="22" width="4" height="32" fill="#ccc" />
+</svg>

--- a/public/assets/sprites/plains.svg
+++ b/public/assets/sprites/plains.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#a4d67a" />
+</svg>

--- a/public/assets/sprites/raider.svg
+++ b/public/assets/sprites/raider.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#8b0000" />
+  <line x1="18" y1="18" x2="46" y2="46" stroke="#fff" stroke-width="4" />
+  <line x1="46" y1="18" x2="18" y2="46" stroke="#fff" stroke-width="4" />
+</svg>

--- a/public/assets/sprites/soldier.svg
+++ b/public/assets/sprites/soldier.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#4682b4" />
+  <circle cx="32" cy="24" r="12" fill="#fff" />
+  <rect x="28" y="36" width="8" height="16" fill="#fff" />
+</svg>

--- a/src/game.ts
+++ b/src/game.ts
@@ -12,7 +12,6 @@ import { loadAssets } from './loader.ts';
 import type { AssetPaths, LoadedAssets } from './loader.ts';
 import { createSauna } from './sim/sauna.ts';
 import { setupSaunaUI } from './ui/sauna.tsx';
-import { raiderSVG } from './ui/sprites.ts';
 import { resetAutoFrame } from './camera/autoFrame.ts';
 import { setupTopbar } from './ui/topbar.ts';
 import { play } from './sfx.ts';
@@ -26,14 +25,17 @@ const assetPaths: AssetPaths = {
   images: {
     placeholder:
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=',
-    grass:
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGNU6lb6z0ABYKJE86gBowaMGjCYDAAAlL8B7iuXN0wAAAAASUVORK5CYII=',
-    water:
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGOUm/D/PwMFgIkSzaMGjBowasBgMgAAGD4CzKXqJDYAAAAASUVORK5CYII=',
-    'unit-soldier':
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGPcpKT0n4ECwESJ5lEDRg0YNWAwGQAAM4ACFQNjXqgAAAAASUVORK5CYII=',
-    farm:
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHUlEQVR4nGO8tVThPwMFgIkSzaMGjBowasBgMgAA4QYCvtGd17wAAAAASUVORK5CYII='
+    'terrain-plains': '/assets/sprites/plains.svg',
+    'terrain-forest': '/assets/sprites/forest.svg',
+    'terrain-hills': '/assets/sprites/hills.svg',
+    'terrain-lake': '/assets/sprites/lake.svg',
+    'building-farm': '/assets/sprites/farm.svg',
+    'building-barracks': '/assets/sprites/barracks.svg',
+    'building-city': '/assets/sprites/city.svg',
+    'building-mine': '/assets/sprites/mine.svg',
+    'unit-soldier': '/assets/sprites/soldier.svg',
+    'unit-archer': '/assets/sprites/archer.svg',
+    'unit-raider': '/assets/sprites/raider.svg'
   }
 };
 let assets: LoadedAssets;
@@ -96,17 +98,9 @@ function draw(): void {
 function drawUnits(ctx: CanvasRenderingContext2D): void {
   const hexWidth = map.hexSize * Math.sqrt(3);
   const hexHeight = map.hexSize * 2;
-  const size = Math.min(hexWidth, hexHeight);
   for (const unit of units) {
     const { x, y } = axialToPixel(unit.coord, map.hexSize);
-    const img = document.createElementNS(
-      'http://www.w3.org/2000/svg',
-      'image'
-    ) as unknown as SVGImageElement;
-    img.setAttribute(
-      'href',
-      `data:image/svg+xml;utf8,${encodeURIComponent(raiderSVG(size))}`
-    );
+    const img = assets.images[`unit-${unit.type}`] ?? assets.images['placeholder'];
     const maxHealth = (unit as any).maxHealth ?? unit.stats.health;
     if (unit.stats.health / maxHealth < 0.5) {
       ctx.filter = 'saturate(0)';

--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -41,13 +41,13 @@ describe('HexMap', () => {
     } as unknown as CanvasRenderingContext2D;
     const createImg = () => document.createElement('img') as HTMLImageElement;
     const images = {
-      grass: createImg(),
-      barracks: createImg(),
+      'terrain-plains': createImg(),
+      'building-barracks': createImg(),
       placeholder: createImg(),
     };
     map.draw(ctx, images);
     expect(ctx.drawImage).toHaveBeenCalledWith(
-      images.barracks,
+      images['building-barracks'],
       expect.any(Number),
       expect.any(Number),
       expect.any(Number),

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -85,10 +85,10 @@ export class HexMap {
       ctx.save();
       if (tile.isFogged) ctx.globalAlpha *= 0.4;
 
-      this.drawTerrain(ctx, tile.terrain, x + this.hexSize, y + this.hexSize);
+      this.drawTerrain(ctx, images, tile.terrain, x, y);
 
       if (tile.building) {
-        const building = images[tile.building] ?? images['placeholder'];
+        const building = images[`building-${tile.building}`] ?? images['placeholder'];
         ctx.drawImage(building, x, y, hexWidth, hexHeight);
       }
 
@@ -140,41 +140,16 @@ export class HexMap {
 
   private drawTerrain(
     ctx: CanvasRenderingContext2D,
+    images: Record<string, HTMLImageElement>,
     terrain: TerrainId,
     x: number,
     y: number
   ): void {
-    const size = this.hexSize;
-    this.hexPath(ctx, x, y, size);
-    if (terrain === TerrainId.Lake) {
-      ctx.fillStyle = '#3399ff';
-      ctx.fill();
-      return;
-    }
-
-    ctx.fillStyle = '#c2d1a1';
-    ctx.fill();
-    ctx.save();
-    ctx.clip();
-    if (terrain === TerrainId.Forest) {
-      ctx.strokeStyle = '#2e8b57';
-      for (let i = -size; i <= size; i += 4) {
-        ctx.beginPath();
-        ctx.moveTo(x - size, y + i);
-        ctx.lineTo(x + size, y + i);
-        ctx.stroke();
-      }
-    } else if (terrain === TerrainId.Hills) {
-      ctx.fillStyle = '#8b7765';
-      for (let dx = -size; dx <= size; dx += 6) {
-        for (let dy = -size; dy <= size; dy += 6) {
-          ctx.beginPath();
-          ctx.arc(x + dx, y + dy, 1, 0, Math.PI * 2);
-          ctx.fill();
-        }
-      }
-    }
-    ctx.restore();
+    const hexWidth = this.hexSize * Math.sqrt(3);
+    const hexHeight = this.hexSize * 2;
+    const key = `terrain-${TerrainId[terrain].toLowerCase()}`;
+    const img = images[key] ?? images['placeholder'];
+    ctx.drawImage(img, x, y, hexWidth, hexHeight);
   }
 
   private strokeHex(

--- a/src/ui/sprites.ts
+++ b/src/ui/sprites.ts
@@ -1,8 +1,0 @@
-export function raiderSVG(scale: number): string {
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="${scale}" height="${scale}" viewBox="0 0 32 32">
-  <polygon points="16,2 4,30 28,30" fill="#c33" stroke="#000" stroke-width="2" />
-  <circle cx="22" cy="20" r="6" fill="#bbb" stroke="#000" stroke-width="2" />
-</svg>`;
-}
-


### PR DESCRIPTION
## Summary
- add placeholder SVG sprites for terrain, buildings, and units
- register sprite paths in the asset loader
- draw terrain, buildings, and units with their respective sprites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c70af596f08330a4aae0331b775bec