### PR TITLE
feat: expand map dynamically

### DIFF
--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -6,6 +6,7 @@ import { eventBus } from '../events/EventBus';
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import type { HexMap } from '../hexmap.ts';
 import { Farm, Barracks, type Building } from '../buildings/index.ts';
+import { markRevealed } from '../camera/autoFrame.ts';
 
 function coordKey(c: AxialCoord): string {
   return `${c.q},${c.r}`;
@@ -108,8 +109,10 @@ export class GameState {
           this.buildingPlacements.set(key, b);
           const [q, r] = key.split(',').map(Number);
           if (map) {
-            const tile = map.getTile(q, r);
-            tile?.placeBuilding(b.type);
+            const tile = map.ensureTile(q, r);
+            tile.placeBuilding(b.type);
+            tile.reveal();
+            markRevealed({ q, r }, map.hexSize);
           }
           eventBus.emit('buildingPlaced', { building: b, coord: { q, r }, state: this });
         });

--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -54,4 +54,15 @@ describe('HexMap', () => {
       expect.any(Number)
     );
   });
+
+  it('expands bounds when accessing tiles outside initial area', () => {
+    const map = new HexMap(1, 1);
+    const tile = map.getTile(2, -1);
+    expect(tile).toBeInstanceOf(HexTile);
+    let count = 0;
+    map.forEachTile(() => count++);
+    expect(map.width).toBe(3);
+    expect(map.height).toBe(2);
+    expect(count).toBe(6);
+  });
 });


### PR DESCRIPTION
## Summary
- store hex tiles in a Map keyed by coordinates with dynamic bounds
- generate and reveal tiles on demand when exploring or loading state
- render map by iterating over stored tiles and offsetting by current extents
- add regression test for out-of-bounds tile expansion

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c70e99d1408330a76b65747968c3f4