### PR TITLE
Add .nojekyll for GitHub Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Set HTML title to Autobattles4xFinsauna
 - Add built site to `docs/` for GitHub Pages deployment
 - Output builds directly to `docs/` and remove deprecated `dist` directory
+- Add `.nojekyll` to bypass Jekyll on GitHub Pages


### PR DESCRIPTION
## Summary
- add empty `.nojekyll` file so GitHub Pages serves built files without Jekyll processing
- document addition in changelog

## Testing
- `npm test` *(failed: Failed to fetch live demo)*
- `npm run build`
- `curl -I http://localhost:4174/`
- `curl -I https://wasab1kastike.github.io/autobattles4xfinsauna/` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c713d8a5f88330a13ce7e2cb7572f3