### PR TITLE
Add .nojekyll for GitHub Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
 - Set HTML title to Autobattles4xFinsauna
 - Add built site to `docs/` for GitHub Pages deployment
 - Output builds directly to `docs/` and remove deprecated `dist` directory
+- Add `.nojekyll` file so GitHub Pages serves files without Jekyll
+


### PR DESCRIPTION
## Summary
- Add `.nojekyll` file so GitHub Pages serves the site without Jekyll processing
- Document the change in the changelog

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*
- `curl -I http://localhost:4173/ | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68c7143585e88330be6124c8c9ab6d8f