### PR TITLE
feat: add grid-based HUD layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Set HTML title to Autobattles4xFinsauna
 - Add built site to `docs/` for GitHub Pages deployment
 - Output builds directly to `docs/` and remove deprecated `dist` directory
+- Introduce grid-based HUD layout with accessible right panel and keyboard navigation

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -3,9 +3,9 @@ import { describe, it, expect } from 'vitest';
 describe('log function', () => {
   it('caps event log at 100 messages', async () => {
     document.body.innerHTML = `
-      <canvas id="game-canvas"></canvas>
-      <div id="resource-bar"></div>
-      <div id="ui-overlay"></div>
+      <div id="game-container">
+        <canvas id="game-canvas"></canvas>
+      </div>
     `;
 
     const { log } = await import('./game.ts');

--- a/src/index.html
+++ b/src/index.html
@@ -9,9 +9,6 @@
   <body>
     <div id="game-container">
       <canvas id="game-canvas" width="800" height="600"></canvas>
-      <div id="ui-overlay">
-        <div id="resource-bar">Resources: 0</div>
-      </div>
     </div>
     <script type="module" src="/game.ts"></script>
   </body>

--- a/src/style.css
+++ b/src/style.css
@@ -42,38 +42,15 @@ body {
   border: 1px solid #333;
 }
 
-#ui-overlay {
-  pointer-events: none;
+
+.hud {
   position: absolute;
   inset: 0;
-}
-
-#resource-bar {
-  pointer-events: auto;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 4px;
-}
-
-#event-log {
-  pointer-events: auto;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 4px;
-  position: absolute;
-  top: 24px;
-  left: 0;
-  max-height: 100px;
-  width: 200px;
-  overflow-y: auto;
-  font-size: 14px;
-}
-
-#build-menu {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  pointer-events: auto;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 4px;
+  display: grid;
+  grid-template-columns: 300px 1fr 360px;
+  grid-template-rows: auto 1fr;
+  gap: 12px;
+  pointer-events: none;
 }
 
 h1 {

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,0 +1,47 @@
+import { setupRightPanel } from './rightPanel.tsx';
+import { setupSaunaUI } from './sauna.tsx';
+import type { GameState } from '../core/GameState.ts';
+import type { Sauna } from '../sim/sauna.ts';
+
+export function initLayout(state: GameState, sauna: Sauna) {
+  const container = document.getElementById('game-container');
+  if (!container) {
+    throw new Error('game-container not found');
+  }
+
+  const hud = document.createElement('div');
+  hud.className = 'hud';
+
+  const topbarMount = document.createElement('div');
+  topbarMount.style.gridColumn = '1 / 4';
+  topbarMount.style.gridRow = '1';
+  topbarMount.style.pointerEvents = 'auto';
+  hud.appendChild(topbarMount);
+
+  const actionsMount = document.createElement('div');
+  actionsMount.style.gridColumn = '1';
+  actionsMount.style.gridRow = '2';
+  actionsMount.style.pointerEvents = 'auto';
+  hud.appendChild(actionsMount);
+
+  const boardWrapper = document.createElement('div');
+  boardWrapper.style.gridColumn = '2';
+  boardWrapper.style.gridRow = '2';
+  boardWrapper.style.pointerEvents = 'auto';
+  const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
+  boardWrapper.appendChild(canvas);
+  hud.appendChild(boardWrapper);
+
+  const rightMount = document.createElement('div');
+  rightMount.style.gridColumn = '3';
+  rightMount.style.gridRow = '2';
+  rightMount.style.pointerEvents = 'auto';
+  hud.appendChild(rightMount);
+
+  container.appendChild(hud);
+
+  const updateSaunaUI = setupSaunaUI(sauna, actionsMount);
+  const { log, addEvent } = setupRightPanel(state, rightMount);
+
+  return { canvas, topbarMount, updateSaunaUI, log, addEvent };
+}

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -8,30 +8,25 @@ export type GameEvent = {
   buttonText?: string;
 };
 
-export function setupRightPanel(state: GameState): {
+export function setupRightPanel(
+  state: GameState,
+  mount: HTMLElement
+): {
   log: (msg: string) => void;
   addEvent: (ev: GameEvent) => void;
 } {
-  const overlay = document.getElementById('ui-overlay');
-  if (!overlay) {
-    return { log: () => {}, addEvent: () => {} };
-  }
-
   const panel = document.createElement('div');
   panel.id = 'right-panel';
-  panel.style.position = 'absolute';
-  panel.style.top = '0';
-  panel.style.right = '0';
-  panel.style.width = '240px';
   panel.style.height = '100%';
   panel.style.display = 'flex';
   panel.style.flexDirection = 'column';
   panel.style.background = 'rgba(0,0,0,0.5)';
   panel.style.color = '#fff';
 
-  overlay.appendChild(panel);
+  mount.appendChild(panel);
 
   const tabBar = document.createElement('div');
+  tabBar.setAttribute('role', 'tablist');
   tabBar.style.display = 'flex';
   panel.appendChild(tabBar);
 
@@ -53,23 +48,50 @@ export function setupRightPanel(state: GameState): {
     Log: logTab
   };
 
-  function show(tab: string): void {
-    for (const [name, el] of Object.entries(tabs)) {
-      el.style.display = name === tab ? 'block' : 'none';
-    }
-    for (const btn of tabBar.children) {
-      const b = btn as HTMLButtonElement;
-      b.disabled = b.textContent === tab;
-    }
+  const tabButtons: HTMLButtonElement[] = [];
+  const names = Object.keys(tabs);
+  let active = 0;
+
+  function show(index: number): void {
+    active = index;
+    names.forEach((name, i) => {
+      const selected = i === index;
+      const panelEl = tabs[name];
+      panelEl.hidden = !selected;
+      panelEl.setAttribute('role', 'tabpanel');
+      panelEl.setAttribute('aria-selected', String(selected));
+      const btn = tabButtons[i];
+      btn.setAttribute('aria-selected', String(selected));
+      btn.tabIndex = selected ? 0 : -1;
+    });
+    tabButtons[index].focus();
   }
 
-  for (const name of Object.keys(tabs)) {
+  names.forEach((name, i) => {
     const btn = document.createElement('button');
     btn.textContent = name;
-    btn.addEventListener('click', () => show(name));
+    btn.setAttribute('role', 'tab');
+    btn.tabIndex = i === 0 ? 0 : -1;
+    btn.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
+    btn.addEventListener('click', () => show(i));
     tabBar.appendChild(btn);
-    content.appendChild(tabs[name]);
-  }
+    tabButtons.push(btn);
+
+    const panelEl = tabs[name];
+    panelEl.setAttribute('role', 'tabpanel');
+    panelEl.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
+    panelEl.hidden = i !== 0;
+    content.appendChild(panelEl);
+  });
+
+  tabBar.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      const delta = e.key === 'ArrowRight' ? 1 : -1;
+      const next = (active + delta + names.length) % names.length;
+      show(next);
+      e.preventDefault();
+    }
+  });
 
   // --- Policies ---
   type PolicyDef = {
@@ -191,7 +213,7 @@ export function setupRightPanel(state: GameState): {
     }
   }
 
-  show('Policies');
+  show(0);
   return { log, addEvent };
 }
 

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -1,17 +1,11 @@
 import type { Sauna } from '../sim/sauna.ts';
 
-export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
-  const overlay = document.getElementById('ui-overlay');
-  if (!overlay) return () => {};
-
+export function setupSaunaUI(sauna: Sauna, mount: HTMLElement): (dt: number) => void {
   const btn = document.createElement('button');
   btn.textContent = 'Sauna \u2668\ufe0f';
-  overlay.appendChild(btn);
+  mount.appendChild(btn);
 
   const card = document.createElement('div');
-  card.style.position = 'absolute';
-  card.style.left = '0';
-  card.style.top = '0';
   card.style.background = 'rgba(0,0,0,0.7)';
   card.style.color = '#fff';
   card.style.padding = '8px';
@@ -39,7 +33,7 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   label.appendChild(document.createTextNode(' Rally to Front'));
   card.appendChild(label);
 
-  overlay.appendChild(card);
+  mount.appendChild(card);
 
   btn.addEventListener('click', () => {
     card.style.display = card.style.display === 'none' ? 'block' : 'none';

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -32,15 +32,15 @@ function createBadge(label: string): Badge {
   return { container, value: valueSpan, delta: deltaSpan };
 }
 
-export function setupTopbar(state: GameState): (deltaMs: number) => void {
-  const overlay = document.getElementById('ui-overlay');
-  if (!overlay) return () => {};
-
+export function setupTopbar(
+  state: GameState,
+  mount: HTMLElement
+): (deltaMs: number) => void {
   const bar = document.createElement('div');
   bar.id = 'topbar';
   bar.style.display = 'flex';
   bar.style.alignItems = 'center';
-  overlay.appendChild(bar);
+  mount.appendChild(bar);
 
   const saunakunnia = createBadge('Saunakunnia');
   const sisu = createBadge('SISU🔥');


### PR DESCRIPTION
## Summary
- implement HUD grid layout and move sauna/right panel into dedicated layout initializer
- add accessible right panel tabs with keyboard navigation
- refactor topbar and sauna UI to mount through new layout

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c714103144833092c2ba26742ba475