### PR TITLE
test: add asset path checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Add built site to `docs/` for GitHub Pages deployment
 - Output builds directly to `docs/` and remove deprecated `dist` directory
 - Add `.nojekyll` to bypass Jekyll on GitHub Pages
+- Check for absolute `/assets/` paths during tests

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run && node scripts/check-demo-link.js",
-    "check:demo": "node scripts/check-demo-link.js"
+    "test": "vitest run && node scripts/check-demo-link.js && node scripts/check-asset-paths.js",
+    "check:demo": "node scripts/check-demo-link.js",
+    "check:assets": "node scripts/check-asset-paths.js"
   },
   "devDependencies": {
     "jsdom": "^27.0.0",

--- a/scripts/check-asset-paths.js
+++ b/scripts/check-asset-paths.js
@@ -1,0 +1,38 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcDir = join(__dirname, '..', 'src');
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(fullPath);
+    } else {
+      yield fullPath;
+    }
+  }
+}
+
+const offending = [];
+for (const file of walk(srcDir)) {
+  const content = readFileSync(file, 'utf8');
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    if (/['"]\/assets\//.test(line)) {
+      offending.push(`${relative(srcDir, file)}:${idx + 1}`);
+    }
+  });
+}
+
+if (offending.length) {
+  console.error('✗ Found absolute /assets/ paths in the following files:');
+  for (const entry of offending) {
+    console.error(`  - ${entry}`);
+  }
+  process.exit(1);
+} else {
+  console.log('✓ No absolute /assets/ paths found.');
+}


### PR DESCRIPTION
## Summary
- check for absolute /assets/ paths in src files
- run the asset path check during `npm test`

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c7158b44d48330a2ce640cddfcd37a