### PR TITLE
Ensure GitHub Pages build retains .nojekyll file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Output builds directly to `docs/` and remove deprecated `dist` directory
 - Add `.nojekyll` to bypass Jekyll on GitHub Pages
 - Resolve sprite paths using `import.meta.env.BASE_URL` so builds work from repository subdirectory
+- Restore `.nojekyll` automatically after production builds

--- a/README.md
+++ b/README.md
@@ -34,14 +34,12 @@ npm install
 
 ## Deployment
 
-Run the production build and copy the output to the `docs/` directory to
-publish the site via GitHub Pages:
+Run the production build to publish the site via GitHub Pages. The build
+outputs directly to the `docs/` directory and automatically adds a
+`.nojekyll` file:
 
 ```bash
 npm run build
-cp -R dist docs
-cp dist/index.html docs/404.html
-touch docs/.nojekyll
 ```
 
 Push the updated `docs/` folder to `main` and configure GitHub Pages to deploy

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "postbuild": "touch docs/.nojekyll",
     "preview": "vite preview",
     "test": "vitest run && node scripts/check-demo-link.js",
     "check:demo": "node scripts/check-demo-link.js"


### PR DESCRIPTION
## Summary
- Automatically recreate `.nojekyll` after production builds so GitHub Pages serves bundled assets correctly
- Document simplified deployment process that outputs directly to `docs/`
- Note auto-restoration of `.nojekyll` in changelog

## Testing
- `npm run build`
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c71627878c833090b4ee90e220413b