### PR TITLE
refactor: add hud layout and accessible right panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,5 @@
 - Output builds directly to `docs/` and remove deprecated `dist` directory
 - Add `.nojekyll` to bypass Jekyll on GitHub Pages
 - Resolve sprite paths using `import.meta.env.BASE_URL` so builds work from repository subdirectory
+- Implement HUD grid layout with left actions, board, and right panel
+- Refactor right panel to accessible tablist with keyboard navigation

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -2,12 +2,6 @@ import { describe, it, expect } from 'vitest';
 
 describe('log function', () => {
   it('caps event log at 100 messages', async () => {
-    document.body.innerHTML = `
-      <canvas id="game-canvas"></canvas>
-      <div id="resource-bar"></div>
-      <div id="ui-overlay"></div>
-    `;
-
     const { log } = await import('./game.ts');
 
     for (let i = 1; i <= 150; i++) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -16,9 +16,9 @@ import { setupTopbar } from './ui/topbar.ts';
 import { play } from './sfx.ts';
 import { activateSisuPulse, isSisuActive } from './sim/sisu.ts';
 import { setupRightPanel } from './ui/rightPanel.tsx';
-
-const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
-const resourceBar = document.getElementById('resource-bar')!;
+import { initLayout } from './ui/layout.ts';
+const { canvas, topbar: topbarRoot, left: leftRoot, right: rightRoot } =
+  initLayout();
 
 const asset = (p: string) => import.meta.env.BASE_URL + p;
 const assetPaths: AssetPaths = {
@@ -67,9 +67,9 @@ const sauna = createSauna({
   r: Math.floor(map.height / 2)
 });
 map.revealAround(sauna.pos, 3);
-const updateSaunaUI = setupSaunaUI(sauna);
-const updateTopbar = setupTopbar(state);
-const { log, addEvent } = setupRightPanel(state);
+const updateSaunaUI = setupSaunaUI(sauna, leftRoot);
+const updateTopbar = setupTopbar(state, topbarRoot);
+const { log, addEvent } = setupRightPanel(state, rightRoot);
 eventBus.on('sisuPulse', () => activateSisuPulse(state, units));
 eventBus.on('sisuPulseStart', () => play('sisu'));
 
@@ -121,8 +121,7 @@ canvas.addEventListener('click', (e) => {
   draw();
 });
 
-const onResourceChanged = ({ resource, total, amount }) => {
-  resourceBar.textContent = `Resources: ${total}`;
+const onResourceChanged = ({ resource, amount }) => {
   const sign = amount > 0 ? '+' : '';
   log(`${resource}: ${sign}${amount}`);
 };
@@ -154,7 +153,6 @@ async function start(): Promise<void> {
   if (failures.length) {
     console.warn('Failed to load assets', failures);
   }
-  resourceBar.textContent = `Resources: ${state.getResource(Resource.GOLD)}`;
   draw();
   let last = performance.now();
   function gameLoop(now: number) {

--- a/src/index.html
+++ b/src/index.html
@@ -7,12 +7,6 @@
     <title>Autobattles4xFinsauna</title>
   </head>
   <body>
-    <div id="game-container">
-      <canvas id="game-canvas" width="800" height="600"></canvas>
-      <div id="ui-overlay">
-        <div id="resource-bar">Resources: 0</div>
-      </div>
-    </div>
     <script type="module" src="/game.ts"></script>
   </body>
 </html>

--- a/src/style.css
+++ b/src/style.css
@@ -27,53 +27,26 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
 
-#game-container {
-  position: relative;
+.hud {
+  display: grid;
+  grid-template-columns: 300px 1fr 360px;
+  grid-template-rows: auto 1fr;
+  gap: 12px;
+  width: 100vw;
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 12px;
 }
 
 #game-canvas {
   display: block;
   border: 1px solid #333;
-}
-
-#ui-overlay {
-  pointer-events: none;
-  position: absolute;
-  inset: 0;
-}
-
-#resource-bar {
-  pointer-events: auto;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 4px;
-}
-
-#event-log {
-  pointer-events: auto;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 4px;
-  position: absolute;
-  top: 24px;
-  left: 0;
-  max-height: 100px;
-  width: 200px;
-  overflow-y: auto;
-  font-size: 14px;
-}
-
-#build-menu {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  pointer-events: auto;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 4px;
+  width: 100%;
+  height: 100%;
 }
 
 h1 {

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,0 +1,38 @@
+export function initLayout(): {
+  canvas: HTMLCanvasElement;
+  topbar: HTMLDivElement;
+  left: HTMLDivElement;
+  right: HTMLDivElement;
+} {
+  const hud = document.createElement('div');
+  hud.className = 'hud';
+  document.body.appendChild(hud);
+
+  const topbar = document.createElement('div');
+  topbar.style.gridColumn = '1 / 4';
+  topbar.style.gridRow = '1';
+  hud.appendChild(topbar);
+
+  const left = document.createElement('div');
+  left.style.gridColumn = '1';
+  left.style.gridRow = '2';
+  hud.appendChild(left);
+
+  const board = document.createElement('div');
+  board.style.gridColumn = '2';
+  board.style.gridRow = '2';
+  hud.appendChild(board);
+
+  const right = document.createElement('div');
+  right.style.gridColumn = '3';
+  right.style.gridRow = '2';
+  hud.appendChild(right);
+
+  const canvas = document.createElement('canvas');
+  canvas.id = 'game-canvas';
+  canvas.width = 800;
+  canvas.height = 600;
+  board.appendChild(canvas);
+
+  return { canvas, topbar, left, right };
+}

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -1,17 +1,14 @@
 import type { Sauna } from '../sim/sauna.ts';
 
-export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
-  const overlay = document.getElementById('ui-overlay');
-  if (!overlay) return () => {};
-
+export function setupSaunaUI(
+  sauna: Sauna,
+  parent: HTMLElement
+): (dt: number) => void {
   const btn = document.createElement('button');
   btn.textContent = 'Sauna \u2668\ufe0f';
-  overlay.appendChild(btn);
+  parent.appendChild(btn);
 
   const card = document.createElement('div');
-  card.style.position = 'absolute';
-  card.style.left = '0';
-  card.style.top = '0';
   card.style.background = 'rgba(0,0,0,0.7)';
   card.style.color = '#fff';
   card.style.padding = '8px';
@@ -39,7 +36,7 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   label.appendChild(document.createTextNode(' Rally to Front'));
   card.appendChild(label);
 
-  overlay.appendChild(card);
+  parent.appendChild(card);
 
   btn.addEventListener('click', () => {
     card.style.display = card.style.display === 'none' ? 'block' : 'none';

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -32,15 +32,15 @@ function createBadge(label: string): Badge {
   return { container, value: valueSpan, delta: deltaSpan };
 }
 
-export function setupTopbar(state: GameState): (deltaMs: number) => void {
-  const overlay = document.getElementById('ui-overlay');
-  if (!overlay) return () => {};
-
+export function setupTopbar(
+  state: GameState,
+  parent: HTMLElement
+): (deltaMs: number) => void {
   const bar = document.createElement('div');
   bar.id = 'topbar';
   bar.style.display = 'flex';
   bar.style.alignItems = 'center';
-  overlay.appendChild(bar);
+  parent.appendChild(bar);
 
   const saunakunnia = createBadge('Saunakunnia');
   const sisu = createBadge('SISU🔥');


### PR DESCRIPTION
## Summary
- build HUD grid layout with left actions, board, and right panel containers
- refactor right panel tabs for accessibility and keyboard navigation
- initialize layout before other UI elements

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c716a6d4788330a3dc3e2f0e5b1689