### PR TITLE
test: check for asset paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Output builds directly to `docs/` and remove deprecated `dist` directory
 - Add `.nojekyll` to bypass Jekyll on GitHub Pages
 - Resolve sprite paths using `import.meta.env.BASE_URL` so builds work from repository subdirectory
+- Add script to fail tests when URLs start with `/assets/`

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run && node scripts/check-demo-link.js",
-    "check:demo": "node scripts/check-demo-link.js"
+    "test": "vitest run && node scripts/check-demo-link.js && node scripts/check-asset-paths.js",
+    "check:demo": "node scripts/check-demo-link.js",
+    "check:assets": "node scripts/check-asset-paths.js"
   },
   "devDependencies": {
     "jsdom": "^27.0.0",

--- a/scripts/check-asset-paths.js
+++ b/scripts/check-asset-paths.js
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcDir = join(__dirname, '..', 'src');
+
+const red = '\x1b[31m';
+const green = '\x1b[32m';
+const reset = '\x1b[0m';
+
+function scanDir(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  let results = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results = results.concat(scanDir(fullPath));
+    } else {
+      const lines = readFileSync(fullPath, 'utf8').split(/\r?\n/);
+      lines.forEach((line, idx) => {
+        if (
+          line.includes("'/assets/") ||
+          line.includes('"/assets/') ||
+          line.includes('`/assets/')
+        ) {
+          results.push(`${fullPath}:${idx + 1}: ${line.trim()}`);
+        }
+      });
+    }
+  }
+  return results;
+}
+
+const matches = scanDir(srcDir);
+
+if (matches.length > 0) {
+  console.error(`${red}Found forbidden /assets/ URLs:${reset}`);
+  for (const m of matches) {
+    console.error(`  ${m}`);
+  }
+  process.exit(1);
+}
+
+console.log(`${green}No forbidden /assets/ URLs found.${reset}`);


### PR DESCRIPTION
## Summary
- add check-asset-paths script to block `/assets/` URLs in source
- run asset path check during `npm test`
- document new asset path check in changelog

## Testing
- `node scripts/check-asset-paths.js`
- `npm test` *(fails: Failed to fetch live demo)*

------
https://chatgpt.com/codex/tasks/task_e_68c71681b2748330b3d6386c3038d106