### PR TITLE
chore: add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,28 @@
+name: Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci && npm run build
+      - run: |
+          rm -rf docs
+          cp -R dist docs
+          cp dist/index.html docs/404.html
+          touch docs/.nojekyll
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: chore: update docs
+          file_pattern: docs/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 - Set HTML title to Autobattles4xFinsauna
-- Add built site to `docs/` for GitHub Pages deployment
-- Output builds directly to `docs/` and remove deprecated `dist` directory
 - Add `.nojekyll` to bypass Jekyll on GitHub Pages
 - Resolve sprite paths using `import.meta.env.BASE_URL` so builds work from repository subdirectory
 - Restore `.nojekyll` automatically after production builds
+- Build outputs to `dist/` and workflow publishes to `docs/`
+- Add workflow to build and publish `docs/` on pushes to `main`
+- Set explicit Vite base path for GitHub Pages

--- a/README.md
+++ b/README.md
@@ -34,23 +34,17 @@ npm install
 
 ## Deployment
 
-Run the production build to publish the site via GitHub Pages. The build
-outputs directly to the `docs/` directory and automatically adds a
-`.nojekyll` file:
+Pushing to `main` runs a workflow that builds the app and commits the result to
+the `docs/` folder so GitHub Pages serves the game. In the repository settings
+set **Pages → Source** to `main` and `/docs`.
+
+To build locally:
 
 ```bash
 npm run build
 ```
 
-Push the updated `docs/` folder to `main` and configure GitHub Pages to deploy
-from the `docs` directory. The site will then be available at:
-
-https://<your-github-username>.github.io/autobattles4xfinsauna/
-
-The Vite configuration automatically sets the correct base path for the build
-using the repository name. If you fork or rename the repository, update the
-`name` field in `package.json` so the build continues to point to the right base
-path.
+The production files are written to `dist/`.
 
 ## Live Demo
 Deployed on GitHub Pages: https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,14 @@
 import { defineConfig } from 'vite';
-import pkg from './package.json' assert { type: 'json' };
-const { name: repoName } = pkg;
 
 export default defineConfig(({ command }) => ({
   root: 'src',
-  // Use the repository name as the base path for production builds so that
-  // assets resolve correctly on GitHub Pages deployments. In development we
-  // keep the base at '/' to match the local dev server.
-  base: command === 'build' ? `/${repoName}/` : '/',
+  // Use the repository name as the base path for production builds so assets
+  // resolve correctly on GitHub Pages deployments. In development we keep the
+  // base at '/' to match the local dev server.
+  base: command === 'build' ? '/autobattles4xfinsauna/' : '/',
   publicDir: '../public',
   build: {
-    outDir: '../docs',
+    outDir: '../dist',
     emptyOutDir: true,
   },
 }));


### PR DESCRIPTION
## Summary
- add workflow to build app and publish to `docs` on pushes to `main`
- fix Vite base path for GitHub Pages
- document Pages source settings in README

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7187df4c48330af28b5e5e48f4ece