### PR TITLE
fix: serve game instead of README on GitHub Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Add `verify-pages` CI workflow to validate Pages builds
 - Publish `dist/` to `docs/` only after verification succeeds
 - Remove legacy Pages deployment workflow
+- Redirect project root to `docs/` so GitHub Pages serves the game

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Autobattles4xFinsauna</title>
+    <script>window.location.replace('./docs/');</script>
+    <style>
+      body {
+        margin: 0;
+        height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background: #000;
+        color: #fff;
+        font-family: sans-serif;
+      }
+      a { color: #9cf; }
+    </style>
+  </head>
+  <body>
+    <p>Loading the <a href="docs/">game</a>...</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Redirect root index to docs so GitHub Pages loads the game
- Record root redirect in changelog

## Testing
- `npm test` *(fails: Failed to fetch live demo)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7dd344d108330a7abbbac1a366a1d