### PR TITLE
refactor: grid HUD layout and accessible panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Add `verify-pages` CI workflow to validate Pages builds
 - Publish `dist/` to `docs/` only after verification succeeds
 - Remove legacy Pages deployment workflow
+- Introduce grid-based HUD layout with accessible right panel tabs

--- a/src/index.html
+++ b/src/index.html
@@ -7,12 +7,6 @@
     <title>Autobattles4xFinsauna</title>
   </head>
   <body>
-    <div id="game-container">
-      <canvas id="game-canvas" width="800" height="600"></canvas>
-      <div id="ui-overlay">
-        <div id="resource-bar">Resources: 0</div>
-      </div>
-    </div>
     <script type="module" src="/game.ts"></script>
   </body>
 </html>

--- a/src/style.css
+++ b/src/style.css
@@ -25,46 +25,16 @@ a:hover {
   color: #535bf2;
 }
 
+
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-#game-container {
-  position: relative;
 }
 
 #game-canvas {
   display: block;
   border: 1px solid #333;
-}
-
-#ui-overlay {
-  pointer-events: none;
-  position: absolute;
-  inset: 0;
-}
-
-#resource-bar {
-  pointer-events: auto;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 4px;
-}
-
-#event-log {
-  pointer-events: auto;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 4px;
-  position: absolute;
-  top: 24px;
-  left: 0;
-  max-height: 100px;
-  width: 200px;
-  overflow-y: auto;
-  font-size: 14px;
 }
 
 #build-menu {

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,0 +1,61 @@
+import { GameState } from '../core/GameState.ts';
+import type { Sauna } from '../sim/sauna.ts';
+import { setupSaunaUI } from './sauna.tsx';
+import { setupRightPanel, GameEvent } from './rightPanel.tsx';
+
+export function initLayout(
+  state: GameState,
+  sauna: Sauna
+): {
+  canvas: HTMLCanvasElement;
+  updateSaunaUI: (dt: number) => void;
+  log: (msg: string) => void;
+  addEvent: (ev: GameEvent) => void;
+} {
+  let overlay = document.getElementById('ui-overlay') as HTMLDivElement | null;
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'ui-overlay';
+    document.body.appendChild(overlay);
+  }
+
+  overlay.classList.add('hud');
+  overlay.style.display = 'grid';
+  overlay.style.gridTemplateColumns = '300px 1fr 360px';
+  overlay.style.gridTemplateRows = 'auto 1fr';
+  overlay.style.gap = '12px';
+  overlay.style.height = '100vh';
+
+  const left = document.createElement('div');
+  left.id = 'left-actions';
+  left.style.gridColumn = '1';
+  left.style.gridRow = '2';
+  left.style.position = 'relative';
+  overlay.appendChild(left);
+
+  const board = document.createElement('div');
+  board.id = 'board-wrapper';
+  board.style.gridColumn = '2';
+  board.style.gridRow = '2';
+  overlay.appendChild(board);
+
+  let canvas = document.getElementById('game-canvas') as HTMLCanvasElement | null;
+  if (!canvas) {
+    canvas = document.createElement('canvas');
+    canvas.id = 'game-canvas';
+    canvas.width = 800;
+    canvas.height = 600;
+  }
+  board.appendChild(canvas);
+
+  const right = document.createElement('div');
+  right.id = 'right-panel';
+  right.style.gridColumn = '3';
+  right.style.gridRow = '2';
+  overlay.appendChild(right);
+
+  const updateSaunaUI = setupSaunaUI(sauna, left);
+  const { log, addEvent } = setupRightPanel(state, right);
+
+  return { canvas, updateSaunaUI, log, addEvent };
+}

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -1,7 +1,7 @@
 import type { Sauna } from '../sim/sauna.ts';
 
-export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
-  const overlay = document.getElementById('ui-overlay');
+export function setupSaunaUI(sauna: Sauna, mount?: HTMLElement): (dt: number) => void {
+  const overlay = mount ?? document.getElementById('ui-overlay');
   if (!overlay) return () => {};
 
   const btn = document.createElement('button');

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -40,6 +40,8 @@ export function setupTopbar(state: GameState): (deltaMs: number) => void {
   bar.id = 'topbar';
   bar.style.display = 'flex';
   bar.style.alignItems = 'center';
+  bar.style.gridColumn = '1 / span 3';
+  bar.style.gridRow = '1';
   overlay.appendChild(bar);
 
   const saunakunnia = createBadge('Saunakunnia');


### PR DESCRIPTION
## Summary
- create `initLayout` to build HUD grid and mount canvas, left actions, and right panel
- refactor right panel tabs with ARIA roles and arrow-key navigation
- streamline top bar placement and remove legacy overlay markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7dce3f35c8330967908deab5c5f7c