### PR TITLE
feat: improve canvas resizing for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,5 @@
 - Publish `dist/` to `docs/` only after verification succeeds
 - Remove legacy Pages deployment workflow
 - Redirect project root to `docs/` so GitHub Pages serves the game
+- Improve mobile scaling by resizing canvas to viewport and device pixel ratio
+

--- a/src/game.ts
+++ b/src/game.ts
@@ -20,6 +20,16 @@ import { setupRightPanel } from './ui/rightPanel.tsx';
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const resourceBar = document.getElementById('resource-bar')!;
 
+function resizeCanvas(): void {
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = window.innerWidth * dpr;
+  canvas.height = window.innerHeight * dpr;
+  draw();
+}
+
+window.addEventListener('resize', resizeCanvas);
+resizeCanvas();
+
 const asset = (p: string) => import.meta.env.BASE_URL + p;
 const assetPaths: AssetPaths = {
   images: {
@@ -88,7 +98,9 @@ let selected: AxialCoord | null = null;
 function draw(): void {
   const ctx = canvas.getContext('2d');
   if (!ctx || !assets) return;
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const dpr = window.devicePixelRatio || 1;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
   map.draw(ctx, assets.images, selected ?? undefined);
   drawUnits(ctx);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="game-container">
-      <canvas id="game-canvas" width="800" height="600"></canvas>
+      <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">
         <div id="resource-bar">Resources: 0</div>
       </div>

--- a/src/style.css
+++ b/src/style.css
@@ -39,6 +39,8 @@ body {
 
 #game-canvas {
   display: block;
+  width: 100vw;
+  height: 100vh;
   border: 1px solid #333;
 }
 


### PR DESCRIPTION
## Summary
- resize canvas according to viewport and device pixel ratio
- scale CSS canvas to full viewport
- document mobile scaling improvements

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7dfd39ef48330884d24cd4018cedc