### PR TITLE
feat: improve high-DPI canvas support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@
 - Remove legacy Pages deployment workflow
 - Redirect project root to `docs/` so GitHub Pages serves the game
 - Improve mobile scaling by resizing canvas to viewport and device pixel ratio
+- Improve high-DPI rendering by scaling canvas to `devicePixelRatio`
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -22,8 +22,15 @@ const resourceBar = document.getElementById('resource-bar')!;
 
 function resizeCanvas(): void {
   const dpr = window.devicePixelRatio || 1;
+  canvas.style.width = `${window.innerWidth}px`;
+  canvas.style.height = `${window.innerHeight}px`;
   canvas.width = window.innerWidth * dpr;
   canvas.height = window.innerHeight * dpr;
+  const ctx = canvas.getContext('2d');
+  if (ctx) {
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(dpr, dpr);
+  }
   draw();
 }
 
@@ -99,7 +106,6 @@ function draw(): void {
   const ctx = canvas.getContext('2d');
   if (!ctx || !assets) return;
   const dpr = window.devicePixelRatio || 1;
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
   map.draw(ctx, assets.images, selected ?? undefined);
   drawUnits(ctx);


### PR DESCRIPTION
## Summary
- scale canvas and context to devicePixelRatio for sharper rendering on high-DPI screens
- log high-DPI support in changelog

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7ef5b4288833081a457d1f46d17a2