### PR TITLE
feat: expose unit max health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,5 @@
 - Improve mobile scaling by resizing canvas to viewport and device pixel ratio
 - Improve high-DPI rendering by scaling canvas to `devicePixelRatio`
 - Add responsive layout and media queries for mobile UI components
+- Add `getMaxHealth` method to `Unit` and use it in game rendering
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -117,7 +117,7 @@ function drawUnits(ctx: CanvasRenderingContext2D): void {
   for (const unit of units) {
     const { x, y } = axialToPixel(unit.coord, map.hexSize);
     const img = assets.images[`unit-${unit.type}`] ?? assets.images['placeholder'];
-    const maxHealth = (unit as any).maxHealth ?? unit.stats.health;
+    const maxHealth = unit.getMaxHealth();
     if (unit.stats.health / maxHealth < 0.5) {
       ctx.filter = 'saturate(0)';
     }

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -65,6 +65,11 @@ export class Unit {
     return !this.alive;
   }
 
+  /** Return the unit's maximum health. */
+  getMaxHealth(): number {
+    return this.maxHealth;
+  }
+
   distanceTo(coord: AxialCoord): number {
     return hexDistance(this.coord, coord);
   }


### PR DESCRIPTION
## Summary
- expose unit max health via `getMaxHealth`
- draw units based on `getMaxHealth`
- document getter in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c814a6b1088330933b863788239c90