### PR TITLE
feat: add typed event payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,5 @@
 - Improve mobile scaling by resizing canvas to viewport and device pixel ratio
 - Improve high-DPI rendering by scaling canvas to `devicePixelRatio`
 - Add responsive layout and media queries for mobile UI components
+- Add typed interfaces for event payloads and annotate game listeners
 

--- a/src/buildings/effects.ts
+++ b/src/buildings/effects.ts
@@ -1,24 +1,10 @@
-import { eventBus } from '../events/EventBus.ts';
-import type { AxialCoord } from '../hex/HexUtils.ts';
-import type { GameState } from '../core/GameState.ts';
+import { eventBus } from '../events';
 import { Resource } from '../core/GameState.ts';
 import { Farm } from './Farm.ts';
 import { Barracks } from './Barracks.ts';
-import type { Building } from './Building.ts';
+import type { BuildingPlacedEvent, BuildingRemovedEvent } from '../events';
 
-export type BuildingPlacedPayload = {
-  building: Building;
-  coord: AxialCoord;
-  state: GameState;
-};
-
-export type BuildingRemovedPayload = {
-  building: Building;
-  coord: AxialCoord;
-  state: GameState;
-};
-
-const onBuildingPlaced = ({ building, coord, state }: BuildingPlacedPayload): void => {
+const onBuildingPlaced = ({ building, coord, state }: BuildingPlacedEvent): void => {
   if (building instanceof Farm) {
     state.modifyPassiveGeneration(Resource.GOLD, building.foodPerTick);
   } else if (building instanceof Barracks) {
@@ -29,12 +15,12 @@ const onBuildingPlaced = ({ building, coord, state }: BuildingPlacedPayload): vo
   }
 };
 
-const onBuildingRemoved = ({ building, state }: BuildingRemovedPayload): void => {
+const onBuildingRemoved = ({ building, state }: BuildingRemovedEvent): void => {
   if (building instanceof Farm) {
     state.modifyPassiveGeneration(Resource.GOLD, -building.foodPerTick);
   }
 };
 
 // register listeners for building effects
-eventBus.on<BuildingPlacedPayload>('buildingPlaced', onBuildingPlaced);
-eventBus.on<BuildingRemovedPayload>('buildingRemoved', onBuildingRemoved);
+eventBus.on<BuildingPlacedEvent>('buildingPlaced', onBuildingPlaced);
+eventBus.on<BuildingRemovedEvent>('buildingRemoved', onBuildingRemoved);

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,4 +1,5 @@
 export { eventBus } from './EventBus';
+export type * from './types.ts';
 
 // register policy listeners
 import './policies';

--- a/src/events/policies.ts
+++ b/src/events/policies.ts
@@ -1,21 +1,19 @@
 import { eventBus } from './EventBus';
-import type { GameState } from '../core/GameState';
 import { Resource } from '../core/GameState';
+import type { PolicyAppliedEvent } from './types.ts';
 
-type PolicyPayload = { policy: string; state: GameState };
-
-const applyEco = ({ policy, state }: PolicyPayload): void => {
+const applyEco = ({ policy, state }: PolicyAppliedEvent): void => {
   if (policy !== 'eco') return;
   // Increase gold generation by 1 when eco policy applied
   state.modifyPassiveGeneration(Resource.GOLD, 1);
   eventBus.off('policyApplied', applyEco);
 };
 
-const applyTemperance = ({ policy, state }: PolicyPayload): void => {
+const applyTemperance = ({ policy, state }: PolicyAppliedEvent): void => {
   if (policy !== 'temperance') return;
   state.nightWorkSpeedMultiplier *= 1.05;
   eventBus.off('policyApplied', applyTemperance);
 };
 
-eventBus.on<PolicyPayload>('policyApplied', applyEco);
-eventBus.on<PolicyPayload>('policyApplied', applyTemperance);
+eventBus.on<PolicyAppliedEvent>('policyApplied', applyEco);
+eventBus.on<PolicyAppliedEvent>('policyApplied', applyTemperance);

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,0 +1,52 @@
+import type { Resource, GameState } from '../core/GameState.ts';
+import type { Building } from '../buildings/Building.ts';
+import type { AxialCoord } from '../hex/HexUtils.ts';
+
+export interface ResourceChangedEvent {
+  resource: Resource;
+  amount: number;
+  total: number;
+}
+
+export interface PolicyAppliedEvent {
+  policy: string;
+  state: GameState;
+}
+
+export interface BuildingPlacedEvent {
+  building: Building;
+  coord: AxialCoord;
+  state: GameState;
+}
+
+export interface BuildingRemovedEvent {
+  building: Building;
+  coord: AxialCoord;
+  state: GameState;
+}
+
+export interface UnitDamagedEvent {
+  attackerId?: string;
+  targetId: string;
+  amount: number;
+  remainingHealth: number;
+}
+
+export interface UnitDiedEvent {
+  unitId: string;
+  attackerId?: string;
+}
+
+export interface SisuPulseEvent {}
+
+export interface SisuPulseStartEvent {
+  remaining: number;
+}
+
+export interface SisuPulseTickEvent {
+  remaining: number;
+}
+
+export interface SisuPulseEndEvent {}
+
+export interface SisuCooldownEndEvent {}

--- a/src/game.ts
+++ b/src/game.ts
@@ -7,6 +7,11 @@ import type { AxialCoord } from './hex/HexUtils.ts';
 import { Unit, spawnUnit } from './unit.ts';
 import type { UnitType } from './unit.ts';
 import { eventBus } from './events';
+import type {
+  ResourceChangedEvent,
+  PolicyAppliedEvent,
+  UnitDiedEvent
+} from './events';
 import { loadAssets } from './loader.ts';
 import type { AssetPaths, LoadedAssets } from './loader.ts';
 import { createSauna } from './sim/sauna.ts';
@@ -139,19 +144,19 @@ canvas.addEventListener('click', (e) => {
   draw();
 });
 
-const onResourceChanged = ({ resource, total, amount }) => {
+const onResourceChanged = ({ resource, total, amount }: ResourceChangedEvent): void => {
   resourceBar.textContent = `Resources: ${total}`;
   const sign = amount > 0 ? '+' : '';
   log(`${resource}: ${sign}${amount}`);
 };
 eventBus.on('resourceChanged', onResourceChanged);
 
-const onPolicyApplied = ({ policy }) => {
+const onPolicyApplied = ({ policy }: PolicyAppliedEvent): void => {
   log(`Policy applied: ${policy}`);
 };
 eventBus.on('policyApplied', onPolicyApplied);
 
-const onUnitDied = ({ unitId }: { unitId: string }) => {
+const onUnitDied = ({ unitId }: UnitDiedEvent): void => {
   const idx = units.findIndex((u) => u.id === unitId);
   if (idx !== -1) {
     units.splice(idx, 1);


### PR DESCRIPTION
## Summary
- define interfaces for event payloads
- annotate game listeners with new types
- document event typing in changelog

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'get'))*


------
https://chatgpt.com/codex/tasks/task_e_68c814aa13608330aa2508a49ec964b0