### PR TITLE
feat: add safe audio initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,5 @@
 - Improve high-DPI rendering by scaling canvas to `devicePixelRatio`
 - Add responsive layout and media queries for mobile UI components
 - Add `getMaxHealth` method to `Unit` and use it in game rendering
+- Gracefully fall back when Web Audio API is unavailable and resume audio on first interaction
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -13,7 +13,7 @@ import { createSauna } from './sim/sauna.ts';
 import { setupSaunaUI } from './ui/sauna.tsx';
 import { resetAutoFrame } from './camera/autoFrame.ts';
 import { setupTopbar } from './ui/topbar.ts';
-import { play } from './sfx.ts';
+import { playSafe } from './sfx.ts';
 import { activateSisuPulse, isSisuActive } from './sim/sisu.ts';
 import { setupRightPanel } from './ui/rightPanel.tsx';
 
@@ -88,7 +88,7 @@ const updateSaunaUI = setupSaunaUI(sauna);
 const updateTopbar = setupTopbar(state);
 const { log, addEvent } = setupRightPanel(state);
 eventBus.on('sisuPulse', () => activateSisuPulse(state, units));
-eventBus.on('sisuPulseStart', () => play('sisu'));
+eventBus.on('sisuPulseStart', () => playSafe('sisu'));
 
 function spawn(type: UnitType, coord: AxialCoord): void {
   const id = `u${units.length + 1}`;

--- a/src/units/UnitFactory.ts
+++ b/src/units/UnitFactory.ts
@@ -3,7 +3,7 @@ import { GameState, Resource } from '../core/GameState.ts';
 import { Unit } from './Unit.ts';
 import { Soldier, SOLDIER_COST } from './Soldier.ts';
 import { Archer, ARCHER_COST } from './Archer.ts';
-import { play } from '../sfx.ts';
+import { playSafe } from '../sfx.ts';
 
 export type UnitType = 'soldier' | 'archer';
 
@@ -21,7 +21,7 @@ export function spawnUnit(
 ): Unit | null {
   const cost = UNIT_COST[type];
   if (!state.canAfford(cost, Resource.GOLD)) {
-    play('error');
+    playSafe('error');
     return null;
   }
   state.addResource(Resource.GOLD, -cost);
@@ -37,7 +37,7 @@ export function spawnUnit(
       unit = null;
   }
   if (unit) {
-    play('spawn');
+    playSafe('spawn');
   }
   return unit;
 }


### PR DESCRIPTION
## Summary
- replace direct AudioContext usage with safe helpers
- resume suspended audio on first pointer interaction
- fall back gracefully when Web Audio API unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c81d56e4908330b0de5af06f1b75d1