### PR TITLE
Add noscript fallback for disabled JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,5 @@
 - Improve high-DPI rendering by scaling canvas to `devicePixelRatio`
 - Add responsive layout and media queries for mobile UI components
 - Add `getMaxHealth` method to `Unit` and use it in game rendering
+- Add noscript message in index to guide users when JavaScript is disabled
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     <link rel="stylesheet" crossorigin href="/autobattles4xfinsauna/assets/index-BrShhiro.css">
   </head>
   <body>
+    <p>Loading...</p>
+    <noscript><p>JavaScript is required. Open <a href="docs/">docs/</a>.</p></noscript>
     <div id="game-container">
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,8 @@
     <title>Autobattles4xFinsauna</title>
   </head>
   <body>
+    <p>Loading...</p>
+    <noscript><p>JavaScript is required. Open <a href="docs/">docs/</a>.</p></noscript>
     <div id="game-container">
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">


### PR DESCRIPTION
## Summary
- add noscript notice directing users to docs when JavaScript is disabled
- log accessibility improvement in changelog

## Testing
- `npm test` (fails: Failed to fetch live demo)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c81d5bfa58833089362bd659c88856