### PR TITLE
ci: guard against bare asset paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
         run: |
           grep -q "/autobattles4xfinsauna/" dist/index.html || (echo "❌ Missing correct base path in index.html" && exit 1)
 
+      # Guard against bare asset paths without the base prefix
+      - name: Check for bare asset paths
+        run: |
+          grep -q 'href="assets/' dist/index.html && (echo "❌ Found href=\"assets/\" in index.html" && exit 1)
+          grep -q 'src="assets/' dist/index.html && (echo "❌ Found src=\"assets/\" in index.html" && exit 1)
+
       # Verify that all referenced JS/CSS files actually exist
       - name: Verify asset files exist
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fail Pages build when bare `assets/` URLs are detected in `dist/index.html`
 - Use relative asset paths in root index and rebuild bundles
 - Set Vite `base` to `./` and rebuild docs with relative asset paths
 - Serve game directly from repository root and drop `docs/` redirect


### PR DESCRIPTION
## Summary
- fail CI if `dist/index.html` references bare `assets/` URLs
- document deployment guard

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c81f1d690c8330a95ad17a8c26060a