### PR TITLE
Add noscript fallback message for non-JS users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Set Vite `base` to `./` and rebuild docs with relative asset paths
+- Provide noscript fallback linking to documentation when JavaScript is disabled
 - Serve game directly from repository root and drop `docs/` redirect
 - Refresh documentation with latest build output
 - Clear corrupted game state from localStorage and warn when load fails

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     <link rel="stylesheet" crossorigin href="/autobattles4xfinsauna/assets/index-BrShhiro.css">
   </head>
   <body>
+    <p>Loading…</p>
+    <noscript><p>JavaScript is required. Open <a href="docs/">docs/</a>.</p></noscript>
     <div id="game-container">
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">


### PR DESCRIPTION
## Summary
- warn users without JavaScript and link to docs
- document noscript accessibility improvement in changelog

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c81e8f99888330861ea7e32fcd2933