### PR TITLE
docs: add custom 404 page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Include custom 404 page for GitHub Pages
 - Fail Pages build when bare `assets/` URLs are detected in `dist/index.html`
 - Use relative asset paths in root index and rebuild bundles
 - Set Vite `base` to `./` and rebuild docs with relative asset paths

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Autobattles4xFinsauna</title>
+    <script type="module" crossorigin src="./assets/index-Dwkte96a.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-BrShhiro.css">
+  </head>
+  <body>
+    <div id="game-container">
+      <canvas id="game-canvas"></canvas>
+      <div id="ui-overlay">
+        <div id="resource-bar">Resources: 0</div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/404.html` so GitHub Pages uses a custom 404 fallback
- document the new 404 page in the changelog

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8200e4dd483308e256ec5b6d4dc30