### PR TITLE
feat: display asset load errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,4 +27,5 @@
 - Add responsive layout and media queries for mobile UI components
 - Add `getMaxHealth` method to `Unit` and use it in game rendering
 - Gracefully fall back when Web Audio API is unavailable and resume audio on first interaction
+- Display a styled error overlay when asset loading fails
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -16,6 +16,7 @@ import { setupTopbar } from './ui/topbar.ts';
 import { playSafe } from './sfx.ts';
 import { activateSisuPulse, isSisuActive } from './sim/sisu.ts';
 import { setupRightPanel } from './ui/rightPanel.tsx';
+import { showError } from './ui/overlay.ts';
 
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const resourceBar = document.getElementById('resource-bar')!;
@@ -171,6 +172,7 @@ async function start(): Promise<void> {
   assets = loaded;
   if (failures.length) {
     console.warn('Failed to load assets', failures);
+    showError(failures);
   }
   resourceBar.textContent = `Resources: ${state.getResource(Resource.GOLD)}`;
   draw();

--- a/src/ui/overlay.ts
+++ b/src/ui/overlay.ts
@@ -1,0 +1,48 @@
+export function showError(messages: string[]): void {
+  const overlay = document.getElementById('ui-overlay');
+  if (!overlay) return;
+
+  const blocker = document.createElement('div');
+  blocker.id = 'error-overlay';
+  blocker.style.position = 'absolute';
+  blocker.style.inset = '0';
+  blocker.style.background = 'rgba(0, 0, 0, 0.75)';
+  blocker.style.display = 'flex';
+  blocker.style.alignItems = 'center';
+  blocker.style.justifyContent = 'center';
+  blocker.style.pointerEvents = 'auto';
+  blocker.style.zIndex = '1000';
+
+  const panel = document.createElement('div');
+  panel.className = 'card';
+  panel.style.background = 'rgba(20, 20, 20, 0.9)';
+  panel.style.color = 'white';
+  panel.style.maxWidth = '80%';
+  panel.style.textAlign = 'center';
+  panel.style.padding = 'var(--gap-lg)';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Asset load errors';
+  panel.appendChild(title);
+
+  const list = document.createElement('ul');
+  list.style.textAlign = 'left';
+  list.style.margin = 'var(--gap-md) 0';
+  for (const msg of messages) {
+    const li = document.createElement('li');
+    li.textContent = msg;
+    list.appendChild(li);
+  }
+  panel.appendChild(list);
+
+  const button = document.createElement('button');
+  button.textContent = 'Reload';
+  button.className = 'btn';
+  button.addEventListener('click', () => {
+    location.reload();
+  });
+  panel.appendChild(button);
+
+  blocker.appendChild(panel);
+  overlay.appendChild(blocker);
+}


### PR DESCRIPTION
## Summary
- overlay game UI with a polished error panel when assets fail to load
- surface asset load failures from `game.ts`
- note error overlay in changelog

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'get'))*


------
https://chatgpt.com/codex/tasks/task_e_68c8203f71148330be51eb5b08d82c37