### PR TITLE
refactor: import sprites directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Import sprite URLs directly and drop `asset()` helper
 - Include custom 404 page for GitHub Pages
 - Fail Pages build when bare `assets/` URLs are detected in `dist/index.html`
 - Use relative asset paths in root index and rebuild bundles

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,4 +1,15 @@
 import './style.css';
+import plains from '../assets/sprites/plains.svg';
+import forest from '../assets/sprites/forest.svg';
+import hills from '../assets/sprites/hills.svg';
+import lake from '../assets/sprites/lake.svg';
+import farm from '../assets/sprites/farm.svg';
+import barracks from '../assets/sprites/barracks.svg';
+import city from '../assets/sprites/city.svg';
+import mine from '../assets/sprites/mine.svg';
+import soldier from '../assets/sprites/soldier.svg';
+import archer from '../assets/sprites/archer.svg';
+import raider from '../assets/sprites/raider.svg';
 import { GameState, Resource } from './core/GameState.ts';
 import { GameClock } from './core/GameClock.ts';
 import { HexMap } from './hexmap.ts';
@@ -57,22 +68,21 @@ export function init(): void {
   }
 }
 
-const asset = (p: string) => import.meta.env.BASE_URL + p;
 const assetPaths: AssetPaths = {
   images: {
     placeholder:
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=',
-    'terrain-plains': asset('assets/sprites/plains.svg'),
-    'terrain-forest': asset('assets/sprites/forest.svg'),
-    'terrain-hills': asset('assets/sprites/hills.svg'),
-    'terrain-lake': asset('assets/sprites/lake.svg'),
-    'building-farm': asset('assets/sprites/farm.svg'),
-    'building-barracks': asset('assets/sprites/barracks.svg'),
-    'building-city': asset('assets/sprites/city.svg'),
-    'building-mine': asset('assets/sprites/mine.svg'),
-    'unit-soldier': asset('assets/sprites/soldier.svg'),
-    'unit-archer': asset('assets/sprites/archer.svg'),
-    'unit-raider': asset('assets/sprites/raider.svg')
+    'terrain-plains': plains,
+    'terrain-forest': forest,
+    'terrain-hills': hills,
+    'terrain-lake': lake,
+    'building-farm': farm,
+    'building-barracks': barracks,
+    'building-city': city,
+    'building-mine': mine,
+    'unit-soldier': soldier,
+    'unit-archer': archer,
+    'unit-raider': raider
   }
 };
 let assets: LoadedAssets;


### PR DESCRIPTION
## Summary
- remove asset() helper in game and import sprite paths directly
- update assetPaths.images to use imported sprites
- document change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c82655f6448330b91c836a1ea97229