### PR TITLE
Filter invalid building types during state load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,4 +30,5 @@
 - Gracefully fall back when Web Audio API is unavailable and resume audio on first interaction
 - Display a styled error overlay when asset loading fails
 - Defer game initialization until DOMContentLoaded via exported `init()`
+- Filter unknown building types from saved building counts during load
 

--- a/src/core/GameState.test.ts
+++ b/src/core/GameState.test.ts
@@ -128,4 +128,18 @@ describe('GameState', () => {
     expect(state.getBuildingAt({ q: 0, r: 0 })).toBeUndefined();
     expect(map.getTile(0, 0)?.building).toBeNull();
   });
+
+  it('filters invalid building counts when loading', () => {
+    const serialized = {
+      resources: { [Resource.GOLD]: 0 },
+      lastSaved: 0,
+      buildings: { farm: 2, mystery: 3 }
+    };
+    localStorage.setItem('gameState', JSON.stringify(serialized));
+
+    const state = new GameState(1000);
+    state.load();
+
+    expect((state as any).buildings).toEqual({ farm: 2 });
+  });
 });

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -99,7 +99,13 @@ export class GameState {
       return;
     }
     this.resources = { ...this.resources, ...data.resources };
-    this.buildings = { ...(data.buildings ?? {}) };
+    const validBuildings: Record<string, number> = {};
+    Object.entries(data.buildings ?? {}).forEach(([type, count]) => {
+      if (type in BUILDING_FACTORIES) {
+        validBuildings[type] = count;
+      }
+    });
+    this.buildings = { ...this.buildings, ...validBuildings };
     this.buildingPlacements.clear();
     if (data.buildingPlacements) {
       Object.entries(data.buildingPlacements).forEach(([key, type]) => {


### PR DESCRIPTION
## Summary
- Preserve only valid building counts when loading game state
- Cover invalid building counts with unit test
- Document change in changelog

## Testing
- `npm test` (failed: Failed to fetch live demo: TypeError: fetch failed)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c82662e95483309cd8e15e0ddf6d82