### PR TITLE
Rebuild docs with hashed assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Rebuild docs with latest hashed assets
 - Include custom 404 page for GitHub Pages
 - Fail Pages build when bare `assets/` URLs are detected in `dist/index.html`
 - Use relative asset paths in root index and rebuild bundles

--- a/docs/404.html
+++ b/docs/404.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/autobattles4xfinsauna/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Autobattles4xFinsauna</title>
-    <script type="module" crossorigin src="./assets/index-PCGPxpl0.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-BrShhiro.css">
+    <script type="module" crossorigin src="/autobattles4xfinsauna/assets/index-PCGPxpl0.js"></script>
+    <link rel="stylesheet" crossorigin href="/autobattles4xfinsauna/assets/index-BrShhiro.css">
   </head>
   <body>
     <div id="game-container">


### PR DESCRIPTION
## Summary
- Rebuild documentation and copy fresh build output into `docs`.
- Update 404 page and changelog to note refreshed hashed assets.

## Testing
- `npm run build`
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c8266501dc83309a6e494d81be5052