### PR TITLE
feat: filter invalid building counts on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Refresh documentation with latest build output
 - Clear corrupted game state from localStorage and warn when load fails
 - Load game state via `safeLoadJSON` and ignore unknown building types
+- Filter out invalid building types when restoring building counts
 - Rebuild docs with relative asset paths so GitHub Pages loads CSS and JS correctly
 - Set HTML title to Autobattles4xFinsauna
 - Add `.nojekyll` to bypass Jekyll on GitHub Pages

--- a/src/core/GameState.test.ts
+++ b/src/core/GameState.test.ts
@@ -116,8 +116,8 @@ describe('GameState', () => {
     const serialized = {
       resources: { [Resource.GOLD]: 0 },
       lastSaved: 0,
-      buildings: { mystery: 1 },
-      buildingPlacements: { '0,0': 'mystery' }
+      buildings: { mystery: 1, farm: 2 },
+      buildingPlacements: { '0,0': 'mystery', '1,1': 'farm' }
     };
     localStorage.setItem('gameState', JSON.stringify(serialized));
 
@@ -127,5 +127,8 @@ describe('GameState', () => {
 
     expect(state.getBuildingAt({ q: 0, r: 0 })).toBeUndefined();
     expect(map.getTile(0, 0)?.building).toBeNull();
+    expect((state as any).buildings['mystery']).toBeUndefined();
+    expect((state as any).buildings['farm']).toBe(2);
+    expect(map.getTile(1, 1)?.building).toBe('farm');
   });
 });

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -99,7 +99,13 @@ export class GameState {
       return;
     }
     this.resources = { ...this.resources, ...data.resources };
-    this.buildings = { ...(data.buildings ?? {}) };
+    const validBuildings: Record<string, number> = {};
+    Object.entries(data.buildings ?? {}).forEach(([type, count]) => {
+      if (BUILDING_FACTORIES[type]) {
+        validBuildings[type] = count;
+      }
+    });
+    this.buildings = validBuildings;
     this.buildingPlacements.clear();
     if (data.buildingPlacements) {
       Object.entries(data.buildingPlacements).forEach(([key, type]) => {


### PR DESCRIPTION
## Summary
- filter out building types not defined in `BUILDING_FACTORIES` when loading game state
- ensure invalid building entries are skipped during load tests
- record change in changelog

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8290e00348330adb9df994e47bc9b