### PR TITLE
chore: use root base path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Set Vite `base` to `/` for root-based asset paths
 - Import sprite URLs directly and drop `asset()` helper
 - Include custom 404 page for GitHub Pages
 - Fail Pages build when bare `assets/` URLs are detected in `dist/index.html`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,9 @@ import { defineConfig } from 'vite';
 // Vite configuration
 export default defineConfig({
   root: 'src',
-  // Use a relative base path so built assets resolve no matter where the site
-  // is hosted. This allows GitHub Pages and local previews to load assets
-  // correctly without needing the repository name in the URL.
-  base: './',
+  // Use an absolute base path so assets resolve from the site root
+  // regardless of the hosting environment.
+  base: '/',
   publicDir: '../public',
   build: {
     outDir: '../dist',


### PR DESCRIPTION
## Summary
- use absolute base path in Vite config for root-level hosting
- document root base path configuration

## Testing
- `npm run build`
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c829c37bc48330ab6f2508bd612b45