### PR TITLE
feat: use root base path for assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Set Vite `base` to `/` for root-based asset paths
 - Regenerate docs with latest build output and hashed assets
 - Import sprite URLs directly and drop `asset()` helper
 - Include custom 404 page for GitHub Pages

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,9 @@ import { defineConfig } from 'vite';
 // Vite configuration
 export default defineConfig({
   root: 'src',
-  // Use a relative base path so built assets resolve no matter where the site
-  // is hosted. This allows GitHub Pages and local previews to load assets
-  // correctly without needing the repository name in the URL.
-  base: './',
+  // Use an absolute base path so built assets resolve from the site root.
+  // This ensures asset URLs remain correct in production deployments.
+  base: '/',
   publicDir: '../public',
   build: {
     outDir: '../dist',


### PR DESCRIPTION
## Summary
- set Vite `base` to `/` so production builds resolve assets from the site root
- document the base-path change in the changelog

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c82b0375248330b99a2a4a7414b73a