### PR TITLE
chore: use Node 18 for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,4 +35,5 @@
 - Display a styled error overlay when asset loading fails
 - Defer game initialization until DOMContentLoaded via exported `init()`
 - Add workflow to deploy docs from `dist/` on pushes to `main`
+- Switch deployment workflow to Node.js 18
 


### PR DESCRIPTION
## Summary
- use Node.js 18 in deploy workflow
- document Node 18 deployment in changelog

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c82d7823588330b910e4c177146eb5