### PR TITLE
docs: add 404 page with matching base path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Copy built 404 page into docs for consistent asset paths
 - Set Vite `base` to `/autobattles4xfinsauna/` and regenerate `docs/` build output
 - Set Vite `base` to `/` for root-based asset paths
 - Regenerate docs with latest build output and hashed assets

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/autobattles4xfinsauna/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Autobattles4xFinsauna</title>
+    <script type="module" crossorigin src="/autobattles4xfinsauna/assets/index-D8I-R9vB.js"></script>
+    <link rel="stylesheet" crossorigin href="/autobattles4xfinsauna/assets/index-BrShhiro.css">
+  </head>
+  <body>
+    <div id="game-container">
+      <canvas id="game-canvas"></canvas>
+      <div id="ui-overlay">
+        <div id="resource-bar">Resources: 0</div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add built 404 page to docs with consistent asset base path
- document 404 page addition in changelog

## Testing
- `npm test` *(fails: Failed to fetch live demo)*

------
https://chatgpt.com/codex/tasks/task_e_68c82d79a9d48330875524ae0d2a2c7e