### PR TITLE
refactor: split ui init and renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Refactor game initialization and rendering helpers into dedicated `ui` and `render` modules
 - Include `404.html` in `docs/` and refresh build output
 - Set Vite `base` to `/autobattles4xfinsauna/` and regenerate `docs/` build output
 - Set Vite `base` to `/` for root-based asset paths

--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,7 @@
       </div>
     </div>
     <script type="module">
-      import { init } from '/game.ts';
+      import { init } from '/ui/init.ts';
       window.addEventListener('DOMContentLoaded', init);
     </script>
   </body>

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1,0 +1,44 @@
+import type { AxialCoord } from '../hex/HexUtils.ts';
+import { axialToPixel } from '../hex/HexUtils.ts';
+import type { HexMap } from '../hexmap.ts';
+import type { LoadedAssets } from '../loader.ts';
+import type { Unit } from '../unit.ts';
+import { isSisuActive } from '../sim/sisu.ts';
+
+export function draw(
+  ctx: CanvasRenderingContext2D,
+  map: HexMap,
+  assets: LoadedAssets['images'],
+  units: Unit[],
+  selected: AxialCoord | null
+): void {
+  const dpr = window.devicePixelRatio || 1;
+  ctx.clearRect(0, 0, ctx.canvas.width / dpr, ctx.canvas.height / dpr);
+  map.draw(ctx, assets, selected ?? undefined);
+  drawUnits(ctx, map, assets, units);
+}
+
+export function drawUnits(
+  ctx: CanvasRenderingContext2D,
+  map: HexMap,
+  assets: LoadedAssets['images'],
+  units: Unit[]
+): void {
+  const hexWidth = map.hexSize * Math.sqrt(3);
+  const hexHeight = map.hexSize * 2;
+  for (const unit of units) {
+    const { x, y } = axialToPixel(unit.coord, map.hexSize);
+    const img = assets[`unit-${unit.type}`] ?? assets['placeholder'];
+    const maxHealth = unit.getMaxHealth();
+    if (unit.stats.health / maxHealth < 0.5) {
+      ctx.filter = 'saturate(0)';
+    }
+    ctx.drawImage(img, x, y, hexWidth, hexHeight);
+    ctx.filter = 'none';
+    if (isSisuActive() && unit.faction === 'player') {
+      ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x, y, hexWidth, hexHeight);
+    }
+  }
+}

--- a/src/ui/init.ts
+++ b/src/ui/init.ts
@@ -1,0 +1,38 @@
+import '../style.css';
+import { setupGame, start, handleCanvasClick, draw, cleanup } from '../game.ts';
+
+export function init(): void {
+  const canvas = document.getElementById('game-canvas') as HTMLCanvasElement | null;
+  const resourceBar = document.getElementById('resource-bar');
+  if (!canvas || !resourceBar) {
+    return;
+  }
+
+  setupGame(canvas, resourceBar);
+
+  function resizeCanvas(): void {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.style.width = `${window.innerWidth}px`;
+    canvas.style.height = `${window.innerHeight}px`;
+    canvas.width = window.innerWidth * dpr;
+    canvas.height = window.innerHeight * dpr;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.scale(dpr, dpr);
+    }
+    draw();
+  }
+
+  window.addEventListener('resize', resizeCanvas);
+  canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    handleCanvasClick(e.clientX - rect.left, e.clientY - rect.top);
+  });
+  window.addEventListener('beforeunload', cleanup);
+
+  resizeCanvas();
+  if (!import.meta.vitest) {
+    start();
+  }
+}


### PR DESCRIPTION
## Summary
- move UI initialization to new module
- extract rendering helpers into renderer module
- adjust game to use new modules and update index

## Testing
- `npm test` *(fails: Failed to fetch live demo: TypeError: fetch failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8303755fc8330b44299acfe8e81da