### PR TITLE
refactor: share hex dimension helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Share hex dimension calculations through a reusable helper used by map and unit rendering
 - Refactor game initialization and rendering helpers into dedicated `ui` and `render` modules
 - Include `404.html` in `docs/` and refresh build output
 - Set Vite `base` to `/autobattles4xfinsauna/` and regenerate `docs/` build output

--- a/src/hex/HexDimensions.ts
+++ b/src/hex/HexDimensions.ts
@@ -1,0 +1,21 @@
+export interface HexDimensions {
+  width: number;
+  height: number;
+}
+
+const HEX_WIDTH_RATIO = Math.sqrt(3);
+const HEX_HEIGHT_RATIO = 2;
+
+/**
+ * Derive the rendered width and height for a flat-topped hexagon.
+ *
+ * Every hex is rendered as a rectangle that contains the pointy corners of the
+ * hexagonal sprite. For a given side length (`hexSize`), the width equals
+ * `hexSize * sqrt(3)` and the height equals `hexSize * 2`.
+ */
+export function getHexDimensions(hexSize: number): HexDimensions {
+  return {
+    width: hexSize * HEX_WIDTH_RATIO,
+    height: hexSize * HEX_HEIGHT_RATIO,
+  };
+}

--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 import { HexMap } from './hexmap.ts';
 import { HexTile } from './hex/HexTile.ts';
+import { getHexDimensions } from './hex/HexDimensions.ts';
 
 describe('HexMap', () => {
+  it('derives sprite dimensions for a given hex size', () => {
+    const size = 32;
+    const { width, height } = getHexDimensions(size);
+    expect(width).toBeCloseTo(size * Math.sqrt(3));
+    expect(height).toBe(size * 2);
+  });
+
   it('generates a grid of tiles', () => {
     const map = new HexMap(3, 3);
     let count = 0;

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -2,6 +2,7 @@ import type { AxialCoord } from './hex/HexUtils.ts';
 import { axialToPixel, getNeighbors as axialNeighbors } from './hex/HexUtils.ts';
 import { HexTile } from './hex/HexTile.ts';
 import { TerrainId, terrainAt } from './map/terrain.ts';
+import { getHexDimensions } from './hex/HexDimensions.ts';
 import { markRevealed, autoFrame, tweenCamera } from './camera/autoFrame.ts';
 
 /** Simple hex map composed of tiles in axial coordinates. */
@@ -114,8 +115,7 @@ export class HexMap {
     images: Record<string, HTMLImageElement>,
     selected?: AxialCoord
   ): void {
-    const hexWidth = this.hexSize * Math.sqrt(3);
-    const hexHeight = this.hexSize * 2;
+    const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
     const origin = axialToPixel({ q: this.minQ, r: this.minR }, this.hexSize);
     for (const [key, tile] of this.tiles) {
       const [q, r] = key.split(',').map(Number);
@@ -185,8 +185,7 @@ export class HexMap {
     x: number,
     y: number
   ): void {
-    const hexWidth = this.hexSize * Math.sqrt(3);
-    const hexHeight = this.hexSize * 2;
+    const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
     const key = `terrain-${TerrainId[terrain].toLowerCase()}`;
     const img = images[key] ?? images['placeholder'];
     ctx.drawImage(img, x, y, hexWidth, hexHeight);

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1,5 +1,6 @@
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import { axialToPixel } from '../hex/HexUtils.ts';
+import { getHexDimensions } from '../hex/HexDimensions.ts';
 import type { HexMap } from '../hexmap.ts';
 import type { LoadedAssets } from '../loader.ts';
 import type { Unit } from '../unit.ts';
@@ -24,8 +25,7 @@ export function drawUnits(
   assets: LoadedAssets['images'],
   units: Unit[]
 ): void {
-  const hexWidth = map.hexSize * Math.sqrt(3);
-  const hexHeight = map.hexSize * 2;
+  const { width: hexWidth, height: hexHeight } = getHexDimensions(map.hexSize);
   for (const unit of units) {
     const { x, y } = axialToPixel(unit.coord, map.hexSize);
     const img = assets[`unit-${unit.type}`] ?? assets['placeholder'];


### PR DESCRIPTION
## Summary
- add a reusable helper to derive hex sprite dimensions
- reuse the helper for map terrain and unit rendering
- cover the helper in unit tests and note the change in the changelog

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c83eafd16c8330bb730e020bb86ad7