### PR TITLE
Extract hex map rendering responsibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Move hex map rendering into a dedicated `HexMapRenderer` to separate presentation from tile management
 - Share hex dimension calculations through a reusable helper used by map and unit rendering
 - Refactor game initialization and rendering helpers into dedicated `ui` and `render` modules
 - Include `404.html` in `docs/` and refresh build output

--- a/src/game.ts
+++ b/src/game.ts
@@ -28,6 +28,7 @@ import { activateSisuPulse } from './sim/sisu.ts';
 import { setupRightPanel } from './ui/rightPanel.tsx';
 import { showError } from './ui/overlay.ts';
 import { draw as render } from './render/renderer.ts';
+import { HexMapRenderer } from './render/HexMapRenderer.ts';
 
 let canvas: HTMLCanvasElement;
 let resourceBar: HTMLElement;
@@ -62,6 +63,7 @@ const assetPaths: AssetPaths = {
 let assets: LoadedAssets;
 
 const map = new HexMap(10, 10, 32);
+const mapRenderer = new HexMapRenderer(map);
 // Ensure all tiles start fogged
 map.forEachTile((t) => t.setFogged(true));
 resetAutoFrame();
@@ -109,7 +111,7 @@ let selected: AxialCoord | null = null;
 export function draw(): void {
   const ctx = canvas.getContext('2d');
   if (!ctx || !assets) return;
-  render(ctx, map, assets.images, units, selected);
+  render(ctx, mapRenderer, assets.images, units, selected);
 }
 
 const onResourceChanged = ({ resource, total, amount }) => {

--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { HexMap } from './hexmap.ts';
 import { HexTile } from './hex/HexTile.ts';
 import { getHexDimensions } from './hex/HexDimensions.ts';
+import { HexMapRenderer } from './render/HexMapRenderer.ts';
 
 describe('HexMap', () => {
   it('derives sprite dimensions for a given hex size', () => {
@@ -53,7 +54,8 @@ describe('HexMap', () => {
       'building-barracks': createImg(),
       placeholder: createImg(),
     };
-    map.draw(ctx, images);
+    const renderer = new HexMapRenderer(map);
+    renderer.draw(ctx, images);
     expect(ctx.drawImage).toHaveBeenCalledWith(
       images['building-barracks'],
       expect.any(Number),

--- a/src/render/HexMapRenderer.ts
+++ b/src/render/HexMapRenderer.ts
@@ -1,0 +1,105 @@
+import type { AxialCoord } from '../hex/HexUtils.ts';
+import { axialToPixel } from '../hex/HexUtils.ts';
+import { getHexDimensions } from '../hex/HexDimensions.ts';
+import type { HexMap } from '../hexmap.ts';
+import { TerrainId } from '../map/terrain.ts';
+
+export class HexMapRenderer {
+  constructor(private readonly mapRef: HexMap) {}
+
+  get hexSize(): number {
+    return this.mapRef.hexSize;
+  }
+
+  draw(
+    ctx: CanvasRenderingContext2D,
+    images: Record<string, HTMLImageElement>,
+    selected?: AxialCoord
+  ): void {
+    const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
+    const origin = axialToPixel({ q: this.mapRef.minQ, r: this.mapRef.minR }, this.hexSize);
+    for (const [key, tile] of this.mapRef.tiles) {
+      const [q, r] = key.split(',').map(Number);
+      const { x, y } = axialToPixel({ q, r }, this.hexSize);
+      const drawX = x - origin.x;
+      const drawY = y - origin.y;
+      ctx.save();
+      if (tile.isFogged) ctx.globalAlpha *= 0.4;
+
+      this.drawTerrain(ctx, images, tile.terrain, drawX, drawY, hexWidth, hexHeight);
+
+      if (tile.building) {
+        const building = images[`building-${tile.building}`] ?? images['placeholder'];
+        ctx.drawImage(building, drawX, drawY, hexWidth, hexHeight);
+      }
+
+      const isSelected = selected && q === selected.q && r === selected.r;
+      this.strokeHex(
+        ctx,
+        drawX + this.hexSize,
+        drawY + this.hexSize,
+        this.hexSize,
+        Boolean(isSelected)
+      );
+      ctx.restore();
+    }
+  }
+
+  drawToCanvas(
+    canvas: HTMLCanvasElement,
+    images: Record<string, HTMLImageElement>,
+    selected?: AxialCoord
+  ): void {
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas 2D context not available');
+    }
+    this.draw(ctx, images, selected);
+  }
+
+  private drawTerrain(
+    ctx: CanvasRenderingContext2D,
+    images: Record<string, HTMLImageElement>,
+    terrain: TerrainId,
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ): void {
+    const key = `terrain-${TerrainId[terrain].toLowerCase()}`;
+    const img = images[key] ?? images['placeholder'];
+    ctx.drawImage(img, x, y, width, height);
+  }
+
+  private strokeHex(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    size: number,
+    selected = false
+  ): void {
+    this.hexPath(ctx, x, y, size);
+    ctx.strokeStyle = selected ? '#ff0000' : '#000000';
+    ctx.stroke();
+  }
+
+  private hexPath(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    size: number
+  ): void {
+    ctx.beginPath();
+    for (let i = 0; i < 6; i++) {
+      const angle = (Math.PI / 180) * (60 * i - 30);
+      const px = x + size * Math.cos(angle);
+      const py = y + size * Math.sin(angle);
+      if (i === 0) {
+        ctx.moveTo(px, py);
+      } else {
+        ctx.lineTo(px, py);
+      }
+    }
+    ctx.closePath();
+  }
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1,33 +1,33 @@
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import { axialToPixel } from '../hex/HexUtils.ts';
 import { getHexDimensions } from '../hex/HexDimensions.ts';
-import type { HexMap } from '../hexmap.ts';
 import type { LoadedAssets } from '../loader.ts';
 import type { Unit } from '../unit.ts';
 import { isSisuActive } from '../sim/sisu.ts';
+import { HexMapRenderer } from './HexMapRenderer.ts';
 
 export function draw(
   ctx: CanvasRenderingContext2D,
-  map: HexMap,
+  mapRenderer: HexMapRenderer,
   assets: LoadedAssets['images'],
   units: Unit[],
   selected: AxialCoord | null
 ): void {
   const dpr = window.devicePixelRatio || 1;
   ctx.clearRect(0, 0, ctx.canvas.width / dpr, ctx.canvas.height / dpr);
-  map.draw(ctx, assets, selected ?? undefined);
-  drawUnits(ctx, map, assets, units);
+  mapRenderer.draw(ctx, assets, selected ?? undefined);
+  drawUnits(ctx, mapRenderer, assets, units);
 }
 
 export function drawUnits(
   ctx: CanvasRenderingContext2D,
-  map: HexMap,
+  mapRenderer: HexMapRenderer,
   assets: LoadedAssets['images'],
   units: Unit[]
 ): void {
-  const { width: hexWidth, height: hexHeight } = getHexDimensions(map.hexSize);
+  const { width: hexWidth, height: hexHeight } = getHexDimensions(mapRenderer.hexSize);
   for (const unit of units) {
-    const { x, y } = axialToPixel(unit.coord, map.hexSize);
+    const { x, y } = axialToPixel(unit.coord, mapRenderer.hexSize);
     const img = assets[`unit-${unit.type}`] ?? assets['placeholder'];
     const maxHealth = unit.getMaxHealth();
     if (unit.stats.health / maxHealth < 0.5) {


### PR DESCRIPTION
## Summary
- move HexMap canvas drawing helpers into a dedicated `HexMapRenderer`
- adjust the game renderer and tests to use the new renderer class
- document the rendering split in the changelog

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c83f9acb8083308d8cfbdf926fbdf3