### PR TITLE
Guard canvas state during unit rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Safeguard unit rendering by bracketing canvas state changes with `save()`/`restore()`
 - Move hex map rendering into a dedicated `HexMapRenderer` to separate presentation from tile management
 - Share hex dimension calculations through a reusable helper used by map and unit rendering
 - Refactor game initialization and rendering helpers into dedicated `ui` and `render` modules

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -30,15 +30,16 @@ export function drawUnits(
     const { x, y } = axialToPixel(unit.coord, mapRenderer.hexSize);
     const img = assets[`unit-${unit.type}`] ?? assets['placeholder'];
     const maxHealth = unit.getMaxHealth();
+    ctx.save();
     if (unit.stats.health / maxHealth < 0.5) {
       ctx.filter = 'saturate(0)';
     }
     ctx.drawImage(img, x, y, hexWidth, hexHeight);
-    ctx.filter = 'none';
     if (isSisuActive() && unit.faction === 'player') {
       ctx.strokeStyle = 'rgba(255,255,255,0.5)';
       ctx.lineWidth = 2;
       ctx.strokeRect(x, y, hexWidth, hexHeight);
     }
+    ctx.restore();
   }
 }


### PR DESCRIPTION
## Summary
- wrap per-unit drawing in `ctx.save()`/`ctx.restore()` to keep filters and stroke styles from leaking between units
- record the rendering safeguard in the changelog

## Testing
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68c840a977ec8330afd4217c974b60bd