### PR TITLE
Refresh terrain rendering with palette-driven icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Render hex tiles using a palette-driven gradient fill, cached SVG terrain icons,
+  and highlight styling shared with the `.tile-highlight` class
 - Introduce a glassmorphism-inspired HUD styling system with shared color tokens,
   tooltip affordances, and tile highlight treatments
 - Establish a `main.ts` rendering entry point that drives canvas resizing,

--- a/index.html
+++ b/index.html
@@ -95,10 +95,10 @@
           </section>
 
           <nav id="build-menu" aria-label="Build menu">
-            <button type="button">Build Farm</button>
-            <button type="button">Build Barracks</button>
-            <button type="button">Upgrade Farm</button>
-            <button type="button">Eco Policy</button>
+            <button type="button" class="tile-highlight">Build Farm</button>
+            <button type="button" class="tile-highlight">Build Barracks</button>
+            <button type="button" class="tile-highlight">Upgrade Farm</button>
+            <button type="button" class="tile-highlight">Eco Policy</button>
           </nav>
 
           <div class="loading-message" role="status">Preparing arena</div>

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,7 +1,3 @@
-import plains from '../assets/sprites/plains.svg';
-import forest from '../assets/sprites/forest.svg';
-import hills from '../assets/sprites/hills.svg';
-import lake from '../assets/sprites/lake.svg';
 import farm from '../assets/sprites/farm.svg';
 import barracks from '../assets/sprites/barracks.svg';
 import city from '../assets/sprites/city.svg';
@@ -31,13 +27,6 @@ import { draw as render } from './render/renderer.ts';
 import { HexMapRenderer } from './render/HexMapRenderer.ts';
 
 const PUBLIC_ASSET_BASE = import.meta.env.BASE_URL;
-const tileAssets = {
-  forest: `${PUBLIC_ASSET_BASE}assets/tiles/forest.svg`,
-  water: `${PUBLIC_ASSET_BASE}assets/tiles/water.svg`,
-  mountain: `${PUBLIC_ASSET_BASE}assets/tiles/mountain.svg`,
-  plains: `${PUBLIC_ASSET_BASE}assets/tiles/plains.svg`
-};
-
 const uiIcons = {
   gold: `${PUBLIC_ASSET_BASE}assets/ui/gold.svg`,
   resource: `${PUBLIC_ASSET_BASE}assets/ui/resource.svg`,
@@ -83,10 +72,6 @@ const assetPaths: AssetPaths = {
   images: {
     placeholder:
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=',
-    'terrain-plains': plains,
-    'terrain-forest': forest,
-    'terrain-hills': hills,
-    'terrain-lake': lake,
     'building-farm': farm,
     'building-barracks': barracks,
     'building-city': city,
@@ -94,10 +79,6 @@ const assetPaths: AssetPaths = {
     'unit-soldier': soldier,
     'unit-archer': archer,
     'unit-raider': raider,
-    'tile-forest': tileAssets.forest,
-    'tile-water': tileAssets.water,
-    'tile-mountain': tileAssets.mountain,
-    'tile-plains': tileAssets.plains,
     'icon-gold': uiIcons.gold,
     'icon-resource': uiIcons.resource,
     'icon-sound': uiIcons.sound

--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -32,6 +32,7 @@ describe('HexMap', () => {
     const tile = map.getTile(0, 0)!;
     tile.placeBuilding('barracks');
     // stub canvas context
+    const gradient = { addColorStop: vi.fn() };
     const ctx = {
       drawImage: vi.fn(),
       beginPath: vi.fn(),
@@ -44,13 +45,22 @@ describe('HexMap', () => {
       save: vi.fn(),
       restore: vi.fn(),
       arc: vi.fn(),
+      fillRect: vi.fn(),
+      createRadialGradient: vi.fn(() => gradient),
       globalAlpha: 1,
       fillStyle: '',
       strokeStyle: '',
+      lineWidth: 1,
+      lineJoin: 'round' as CanvasLineJoin,
+      lineCap: 'round' as CanvasLineCap,
+      shadowColor: '',
+      shadowBlur: 0,
+      shadowOffsetX: 0,
+      shadowOffsetY: 0,
+      globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
     } as unknown as CanvasRenderingContext2D;
     const createImg = () => document.createElement('img') as HTMLImageElement;
     const images = {
-      'terrain-plains': createImg(),
       'building-barracks': createImg(),
       placeholder: createImg(),
     };

--- a/src/render/HexMapRenderer.ts
+++ b/src/render/HexMapRenderer.ts
@@ -3,6 +3,56 @@ import { axialToPixel } from '../hex/HexUtils.ts';
 import { getHexDimensions } from '../hex/HexDimensions.ts';
 import type { HexMap } from '../hexmap.ts';
 import { TerrainId } from '../map/terrain.ts';
+import { TERRAIN } from './TerrainPalette.ts';
+import { loadIcon } from './loadIcon.ts';
+
+const DEFAULT_HIGHLIGHT = 'rgba(56, 189, 248, 0.85)';
+const DEFAULT_HIGHLIGHT_GLOW = 'rgba(56, 189, 248, 0.45)';
+
+let highlightStroke: string | null = null;
+let highlightGlow: string | null = null;
+
+function getHighlightTokens(): { stroke: string; glow: string } {
+  if (highlightStroke && highlightGlow) {
+    return { stroke: highlightStroke, glow: highlightGlow };
+  }
+
+  if (typeof window !== 'undefined') {
+    const styles = getComputedStyle(document.documentElement);
+    const stroke = styles.getPropertyValue('--tile-highlight-ring').trim();
+    const glow = styles.getPropertyValue('--tile-highlight-glow').trim();
+    highlightStroke = stroke || DEFAULT_HIGHLIGHT;
+    highlightGlow = glow || DEFAULT_HIGHLIGHT_GLOW;
+  } else {
+    highlightStroke = DEFAULT_HIGHLIGHT;
+    highlightGlow = DEFAULT_HIGHLIGHT_GLOW;
+  }
+
+  return { stroke: highlightStroke, glow: highlightGlow };
+}
+
+function toRgb(color: string): [number, number, number] {
+  const hex = color.replace('#', '');
+  const value = Number.parseInt(hex, 16);
+  const r = (value >> 16) & 0xff;
+  const g = (value >> 8) & 0xff;
+  const b = value & 0xff;
+  return [r, g, b];
+}
+
+function mixColor(
+  [r, g, b]: [number, number, number],
+  [tr, tg, tb]: [number, number, number],
+  amount: number
+): string {
+  const clamped = Math.min(1, Math.max(0, amount));
+  const mix = (channel: number, target: number) => Math.round(channel + (target - channel) * clamped);
+  return `rgb(${mix(r, tr)}, ${mix(g, tg)}, ${mix(b, tb)})`;
+}
+
+function withAlpha([r, g, b]: [number, number, number], alpha: number): string {
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
 
 export class HexMapRenderer {
   constructor(private readonly mapRef: HexMap) {}
@@ -30,7 +80,7 @@ export class HexMapRenderer {
       ctx.save();
       if (tile.isFogged) ctx.globalAlpha *= 0.4;
 
-      this.drawTerrain(ctx, images, tile.terrain, drawX, drawY, hexWidth, hexHeight);
+      this.drawTerrain(ctx, tile.terrain, drawX, drawY, hexWidth, hexHeight);
 
       if (tile.building) {
         const building = images[`building-${tile.building}`] ?? images['placeholder'];
@@ -63,16 +113,53 @@ export class HexMapRenderer {
 
   private drawTerrain(
     ctx: CanvasRenderingContext2D,
-    images: Record<string, HTMLImageElement>,
     terrain: TerrainId,
     x: number,
     y: number,
     width: number,
     height: number
   ): void {
-    const key = `terrain-${TerrainId[terrain].toLowerCase()}`;
-    const img = images[key] ?? images['placeholder'];
-    ctx.drawImage(img, x, y, width, height);
+    const palette = TERRAIN[terrain] ?? TERRAIN[TerrainId.Plains];
+    const rgb = toRgb(palette.baseColor);
+    const radius = this.hexSize;
+    const centerX = x + radius;
+    const centerY = y + radius;
+
+    ctx.save();
+    this.hexPath(ctx, x + this.hexSize, y + this.hexSize, radius);
+    ctx.clip();
+
+    const gradient = ctx.createRadialGradient(centerX, centerY, radius * 0.2, centerX, centerY, radius * 1.05);
+    gradient.addColorStop(0, mixColor(rgb, [255, 255, 255], 0.3));
+    gradient.addColorStop(0.7, palette.baseColor);
+    gradient.addColorStop(1, mixColor(rgb, [12, 18, 28], 0.4));
+
+    ctx.fillStyle = gradient;
+    ctx.shadowColor = withAlpha(rgb, 0.35);
+    ctx.shadowBlur = radius * 0.9;
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
+    ctx.fillRect(x - radius * 0.1, y - radius * 0.1, width + radius * 0.2, height + radius * 0.2);
+
+    ctx.globalCompositeOperation = 'lighter';
+    const rim = ctx.createRadialGradient(centerX, centerY, radius * 0.85, centerX, centerY, radius * 1.18);
+    rim.addColorStop(0, 'rgba(255, 255, 255, 0)');
+    rim.addColorStop(1, withAlpha(rgb, 0.18));
+    ctx.fillStyle = rim;
+    ctx.fillRect(x - radius * 0.1, y - radius * 0.1, width + radius * 0.2, height + radius * 0.2);
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.restore();
+
+    const icon = loadIcon(palette.icon);
+    if (icon) {
+      const iconSize = Math.min(width, height) * 0.62;
+      const iconX = centerX - iconSize / 2;
+      const iconY = centerY - iconSize / 2;
+      ctx.save();
+      ctx.globalAlpha *= 0.92;
+      ctx.drawImage(icon, iconX, iconY, iconSize, iconSize);
+      ctx.restore();
+    }
   }
 
   private strokeHex(
@@ -82,9 +169,23 @@ export class HexMapRenderer {
     size: number,
     selected = false
   ): void {
+    const { stroke, glow } = getHighlightTokens();
     this.hexPath(ctx, x, y, size);
-    ctx.strokeStyle = selected ? '#ff0000' : '#000000';
-    ctx.stroke();
+    ctx.save();
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+    if (selected) {
+      ctx.shadowColor = glow;
+      ctx.shadowBlur = size * 0.65;
+      ctx.lineWidth = Math.max(2, size * 0.08);
+      ctx.strokeStyle = stroke;
+      ctx.stroke();
+    } else {
+      ctx.lineWidth = Math.max(1, size * 0.05);
+      ctx.strokeStyle = 'rgba(12, 18, 28, 0.55)';
+      ctx.stroke();
+    }
+    ctx.restore();
   }
 
   private hexPath(

--- a/src/render/TerrainPalette.ts
+++ b/src/render/TerrainPalette.ts
@@ -1,0 +1,31 @@
+import { TerrainId } from '../map/terrain.ts';
+import plainsIcon from '../../assets/tiles/plains.svg';
+import forestIcon from '../../assets/tiles/forest.svg';
+import hillsIcon from '../../assets/tiles/mountain.svg';
+import lakeIcon from '../../assets/tiles/water.svg';
+
+export type TerrainVisual = {
+  /** Base color used to paint the underlying hex. */
+  baseColor: string;
+  /** Path to the vector icon that represents the terrain. */
+  icon: string;
+};
+
+export const TERRAIN: Record<TerrainId, TerrainVisual> = {
+  [TerrainId.Plains]: {
+    baseColor: '#d8b869',
+    icon: plainsIcon,
+  },
+  [TerrainId.Forest]: {
+    baseColor: '#237a55',
+    icon: forestIcon,
+  },
+  [TerrainId.Hills]: {
+    baseColor: '#b57c57',
+    icon: hillsIcon,
+  },
+  [TerrainId.Lake]: {
+    baseColor: '#3185d5',
+    icon: lakeIcon,
+  },
+};

--- a/src/render/loadIcon.ts
+++ b/src/render/loadIcon.ts
@@ -1,0 +1,21 @@
+const iconCache = new Map<string, HTMLImageElement>();
+
+export function loadIcon(path: string): HTMLImageElement | undefined {
+  let icon = iconCache.get(path);
+  if (!icon) {
+    icon = new Image();
+    icon.decoding = 'async';
+    icon.src = path;
+    iconCache.set(path, icon);
+  }
+
+  if (icon.complete && icon.naturalWidth > 0 && icon.naturalHeight > 0) {
+    return icon;
+  }
+
+  return undefined;
+}
+
+export function clearIconCache(): void {
+  iconCache.clear();
+}

--- a/src/style.css
+++ b/src/style.css
@@ -17,6 +17,8 @@
   --shadow-strong: 0 32px 64px rgba(8, 25, 53, 0.6);
   --shadow-soft: 0 24px 48px rgba(8, 25, 53, 0.45);
   --shadow-glow: 0 0 36px rgba(56, 189, 248, 0.5);
+  --tile-highlight-ring: rgba(56, 189, 248, 0.85);
+  --tile-highlight-glow: rgba(56, 189, 248, 0.45);
   --radius-panel: 24px;
   --radius-pill: 999px;
   --transition-snappy: 180ms ease;
@@ -408,6 +410,61 @@ button {
 [data-tooltip]:focus-visible::after {
   opacity: 1;
   transform: translate(-50%, 0);
+}
+
+.tile-highlight {
+  position: relative;
+  isolation: isolate;
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy),
+    filter var(--transition-snappy);
+}
+
+.tile-highlight::before,
+.tile-highlight::after {
+  content: '';
+  position: absolute;
+  inset: -12px;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--transition-snappy), filter var(--transition-snappy),
+    transform var(--transition-snappy);
+  z-index: -1;
+}
+
+.tile-highlight::before {
+  inset: -6px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(148, 163, 184, 0.08));
+  border: 1px solid color-mix(in srgb, var(--tile-highlight-ring) 45%, transparent);
+  filter: blur(0);
+}
+
+.tile-highlight::after {
+  background: radial-gradient(circle, var(--tile-highlight-glow), rgba(56, 189, 248, 0));
+  filter: blur(18px);
+}
+
+.tile-highlight:hover,
+.tile-highlight:focus-visible,
+.tile-highlight.is-selected {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 18px 36px rgba(56, 189, 248, 0.35);
+  filter: saturate(1.12);
+}
+
+.tile-highlight:hover::before,
+.tile-highlight:focus-visible::before,
+.tile-highlight.is-selected::before,
+.tile-highlight:hover::after,
+.tile-highlight:focus-visible::after,
+.tile-highlight.is-selected::after {
+  opacity: 1;
+}
+
+.tile-highlight:hover::before,
+.tile-highlight:focus-visible::before,
+.tile-highlight.is-selected::before {
+  filter: blur(6px);
 }
 
 .tile--highlighted {


### PR DESCRIPTION
## Summary
- add a terrain palette that pairs each biome with a base color and SVG icon plus an icon cache helper
- redraw map tiles with gradient fills, cached icons, and highlight-aware strokes while trimming unused terrain asset registrations
- style the shared `.tile-highlight` hover/selection treatment in CSS, apply it to the build menu, update tests, and document the renderer upgrade in the changelog

## Testing
- npm run build
- npm run test *(fails: scripts/check-demo-link.js cannot fetch the live demo in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8513324a48330bb4c65cacdf92630