### PR TITLE
Auto initialize game on module load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Invoke `init()` automatically on module load (except during Vitest) so the map and
+  resource HUD initialize as soon as the bundle runs
 - Render hex tiles using a palette-driven gradient fill, cached SVG terrain icons,
   and highlight styling shared with the `.tile-highlight` class
 - Introduce a glassmorphism-inspired HUD styling system with shared color tokens,

--- a/src/main.ts
+++ b/src/main.ts
@@ -401,3 +401,7 @@ export function init(): void {
   }
 }
 
+if (!import.meta.vitest) {
+  init();
+}
+


### PR DESCRIPTION
## Summary
- call `init()` when `main.ts` is loaded outside Vitest so the map and HUD boot immediately
- document the automatic initialization in the changelog

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c857e09e8c833085b95d1ec1aaa997