### PR TITLE
Add Saunoja helpers and visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Introduce Saunoja data helpers, sauna combat damage utilities, and polished
+  canvas rendering helpers for HP, selection, and steam effects
 - Add a polished monochrome Saunoja unit icon to `public/assets/units`
 - Export shared hex rendering helpers (radius constant, `axialToPixel`, and
   a flat-topped `pathHex` canvas utility) via `src/hex/index.ts`

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -3,3 +3,6 @@ export * from './units/Soldier.ts';
 export * from './units/Archer.ts';
 export * from './units/Raider.ts';
 export * from './units/UnitFactory.ts';
+export * from './units/saunoja.ts';
+export * from './units/combat.ts';
+export * from './units/visualHelpers.ts';

--- a/src/units/combat.ts
+++ b/src/units/combat.ts
@@ -1,0 +1,17 @@
+import type { Saunoja } from './saunoja.ts';
+
+/**
+ * Apply incoming damage to a Saunoja, mutating its hit points in-place.
+ *
+ * @param target The sauna enjoyer receiving damage.
+ * @param amount The raw damage amount. Non-positive values are ignored.
+ * @returns `true` when the Saunoja has zero hit points after the attack.
+ */
+export function applyDamage(target: Saunoja, amount: number): boolean {
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return target.hp <= 0;
+  }
+
+  target.hp = Math.max(0, target.hp - amount);
+  return target.hp === 0;
+}

--- a/src/units/saunoja.test.ts
+++ b/src/units/saunoja.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { makeSaunoja } from './saunoja.ts';
+import { applyDamage } from './combat.ts';
+
+describe('makeSaunoja', () => {
+  it('applies defaults and clamps mutable values', () => {
+    const coord = { q: 2, r: -1 };
+    const saunoja = makeSaunoja({
+      id: 's1',
+      name: 'Custom',
+      coord,
+      maxHp: 20,
+      hp: 28,
+      steam: 1.7,
+      selected: true
+    });
+    coord.q = 9;
+    expect(saunoja.name).toBe('Custom');
+    expect(saunoja.maxHp).toBe(20);
+    expect(saunoja.hp).toBe(20);
+    expect(saunoja.steam).toBe(1);
+    expect(saunoja.coord).toEqual({ q: 2, r: -1 });
+    expect(saunoja.selected).toBe(true);
+  });
+
+  it('falls back to safe defaults for invalid data', () => {
+    const saunoja = makeSaunoja({
+      id: 's2',
+      maxHp: 0,
+      hp: -5,
+      steam: -1
+    });
+    expect(saunoja.maxHp).toBe(1);
+    expect(saunoja.hp).toBe(0);
+    expect(saunoja.steam).toBe(0);
+    expect(saunoja.name).toBe('Saunoja');
+  });
+});
+
+describe('applyDamage', () => {
+  it('reduces hit points and returns true when depleted', () => {
+    const saunoja = makeSaunoja({ id: 's3', maxHp: 10 });
+    expect(applyDamage(saunoja, 4)).toBe(false);
+    expect(saunoja.hp).toBe(6);
+    expect(applyDamage(saunoja, 10)).toBe(true);
+    expect(saunoja.hp).toBe(0);
+  });
+
+  it('ignores non-positive or invalid damage values', () => {
+    const saunoja = makeSaunoja({ id: 's4', maxHp: 5, hp: 3 });
+    expect(applyDamage(saunoja, 0)).toBe(false);
+    expect(saunoja.hp).toBe(3);
+    expect(applyDamage(saunoja, Number.NaN)).toBe(false);
+    expect(saunoja.hp).toBe(3);
+  });
+});

--- a/src/units/saunoja.ts
+++ b/src/units/saunoja.ts
@@ -1,0 +1,68 @@
+import type { AxialCoord } from '../hex/HexUtils.ts';
+
+export interface Saunoja {
+  /** Unique identifier used to reference the unit. */
+  id: string;
+  /** Display name shown in UI panels and tooltips. */
+  name: string;
+  /** Axial hex coordinate locating the unit on the map. */
+  coord: AxialCoord;
+  /** Maximum hit points the unit can have. */
+  maxHp: number;
+  /** Current hit points remaining. */
+  hp: number;
+  /** Steam intensity from 0 (idle) to 1 (billowing). */
+  steam: number;
+  /** Whether the unit is currently selected in the UI. */
+  selected: boolean;
+}
+
+export interface SaunojaInit {
+  id: string;
+  name?: string;
+  coord?: AxialCoord;
+  maxHp?: number;
+  hp?: number;
+  steam?: number;
+  selected?: boolean;
+}
+
+const DEFAULT_COORD: AxialCoord = { q: 0, r: 0 };
+const DEFAULT_NAME = 'Saunoja';
+const DEFAULT_MAX_HP = 18;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Construct a Saunoja with defensive defaults while sanitising the provided
+ * configuration so downstream combat helpers can rely on consistent data.
+ */
+export function makeSaunoja(init: SaunojaInit): Saunoja {
+  const {
+    id,
+    name = DEFAULT_NAME,
+    coord = DEFAULT_COORD,
+    maxHp = DEFAULT_MAX_HP,
+    hp = maxHp,
+    steam = 0,
+    selected = false
+  } = init;
+
+  const normalizedMaxHp = Number.isFinite(maxHp) ? Math.max(1, maxHp) : DEFAULT_MAX_HP;
+  const normalizedHpSource = Number.isFinite(hp) ? hp : normalizedMaxHp;
+  const clampedHp = clamp(normalizedHpSource, 0, normalizedMaxHp);
+  const normalizedSteamSource = Number.isFinite(steam) ? steam : 0;
+  const clampedSteam = clamp(normalizedSteamSource, 0, 1);
+
+  return {
+    id,
+    name,
+    coord: { q: coord.q, r: coord.r },
+    maxHp: normalizedMaxHp,
+    hp: clampedHp,
+    steam: clampedSteam,
+    selected
+  };
+}

--- a/src/units/visualHelpers.test.ts
+++ b/src/units/visualHelpers.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { drawHP, drawSelectionRing, drawSteam } from './visualHelpers.ts';
+import * as hex from '../hex/index.ts';
+
+function createMockContext() {
+  const gradient = { addColorStop: vi.fn() } as unknown as CanvasGradient;
+  const ctx = {
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    clip: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    fillRect: vi.fn(),
+    createLinearGradient: vi.fn(() => gradient),
+    bezierCurveTo: vi.fn(),
+    setLineDash: vi.fn(),
+    lineWidth: 0,
+    strokeStyle: '',
+    fillStyle: '',
+    shadowColor: '',
+    shadowBlur: 0,
+    globalCompositeOperation: 'source-over',
+    lineCap: 'butt'
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, gradient };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('drawHP', () => {
+  it('fills remaining health proportionally to the ratio', () => {
+    const { ctx } = createMockContext();
+    const pathSpy = vi.spyOn(hex, 'pathHex');
+    drawHP(ctx, { centerX: 10, centerY: 20, hp: 5, maxHp: 10, radius: 10 });
+    expect(pathSpy).toHaveBeenCalledTimes(3);
+    const fillRectMock = ctx.fillRect as unknown as Mock;
+    expect(fillRectMock.mock.calls).toHaveLength(1);
+    const [x, y, width, height] = fillRectMock.mock.calls[0];
+    expect(x).toBeCloseTo(0);
+    expect(y).toBeCloseTo(20);
+    expect(width).toBeCloseTo(20);
+    expect(height).toBeCloseTo(10);
+  });
+
+  it('skips the fill when no health remains', () => {
+    const { ctx } = createMockContext();
+    const pathSpy = vi.spyOn(hex, 'pathHex');
+    drawHP(ctx, { centerX: 0, centerY: 0, hp: -2, maxHp: 10, radius: 8 });
+    const fillRectMock = ctx.fillRect as unknown as Mock;
+    expect(fillRectMock.mock.calls).toHaveLength(0);
+    expect(pathSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('drawSelectionRing', () => {
+  it('draws an outer glow and inner dashed ring using hex paths', () => {
+    const { ctx } = createMockContext();
+    const pathSpy = vi.spyOn(hex, 'pathHex');
+    drawSelectionRing(ctx, { centerX: 4, centerY: -6 });
+    expect(pathSpy).toHaveBeenCalledTimes(2);
+    const firstCall = pathSpy.mock.calls[0];
+    const secondCall = pathSpy.mock.calls[1];
+    expect(firstCall[1]).toBe(4);
+    expect(firstCall[2]).toBe(-6);
+    expect(firstCall[3]).toBeCloseTo(hex.HEX_R);
+    expect(secondCall[3]).toBeCloseTo(hex.HEX_R * 0.74);
+    const strokeMock = ctx.stroke as unknown as Mock;
+    expect(strokeMock.mock.calls.length).toBe(2);
+    const dashMock = ctx.setLineDash as unknown as Mock;
+    expect(dashMock.mock.calls.length).toBeGreaterThan(0);
+    expect(dashMock.mock.calls[0][0][0]).toBeGreaterThan(0);
+  });
+});
+
+describe('drawSteam', () => {
+  it('respects zero intensity by avoiding any drawing work', () => {
+    const { ctx } = createMockContext();
+    const pathSpy = vi.spyOn(hex, 'pathHex');
+    drawSteam(ctx, { centerX: 0, centerY: 0, intensity: 0 });
+    expect(pathSpy).not.toHaveBeenCalled();
+    const fillRectMock = ctx.fillRect as unknown as Mock;
+    expect(fillRectMock.mock.calls).toHaveLength(0);
+    const bezierMock = ctx.bezierCurveTo as unknown as Mock;
+    expect(bezierMock.mock.calls).toHaveLength(0);
+  });
+
+  it('clips to a hex silhouette and adds swirling strokes', () => {
+    const { ctx } = createMockContext();
+    const pathSpy = vi.spyOn(hex, 'pathHex');
+    drawSteam(ctx, { centerX: 2, centerY: 3, intensity: 0.6, radius: 9 });
+    expect(pathSpy).toHaveBeenCalledTimes(1);
+    const clipMock = ctx.clip as unknown as Mock;
+    expect(clipMock.mock.calls.length).toBeGreaterThan(0);
+    const fillRectMock = ctx.fillRect as unknown as Mock;
+    expect(fillRectMock.mock.calls).toHaveLength(1);
+    const bezierMock = ctx.bezierCurveTo as unknown as Mock;
+    expect(bezierMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/units/visualHelpers.ts
+++ b/src/units/visualHelpers.ts
@@ -1,0 +1,135 @@
+import { HEX_R, pathHex } from '../hex/index.ts';
+
+export interface HPDrawOptions {
+  centerX: number;
+  centerY: number;
+  hp: number;
+  maxHp: number;
+  radius?: number;
+}
+
+export interface SelectionRingOptions {
+  centerX: number;
+  centerY: number;
+  radius?: number;
+}
+
+export interface SteamOptions {
+  centerX: number;
+  centerY: number;
+  radius?: number;
+  intensity?: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function drawHP(
+  ctx: CanvasRenderingContext2D,
+  { centerX, centerY, hp, maxHp, radius = HEX_R * 0.55 }: HPDrawOptions
+): void {
+  const safeMax = Number.isFinite(maxHp) ? Math.max(1, maxHp) : 1;
+  const safeHp = Number.isFinite(hp) ? hp : safeMax;
+  const ratio = clamp(safeHp / safeMax, 0, 1);
+
+  ctx.save();
+  pathHex(ctx, centerX, centerY, radius);
+  ctx.fillStyle = 'rgba(7, 11, 18, 0.72)';
+  ctx.fill();
+  ctx.restore();
+
+  if (ratio > 0) {
+    ctx.save();
+    pathHex(ctx, centerX, centerY, radius);
+    ctx.clip();
+    const gradient = ctx.createLinearGradient(centerX, centerY + radius, centerX, centerY - radius);
+    gradient.addColorStop(0, 'rgba(46, 160, 98, 0.35)');
+    gradient.addColorStop(1, 'rgba(218, 255, 239, 0.95)');
+    ctx.fillStyle = gradient;
+    const height = radius * 2 * ratio;
+    const top = centerY + radius - height;
+    ctx.fillRect(centerX - radius, top, radius * 2, height);
+    ctx.restore();
+  }
+
+  ctx.save();
+  pathHex(ctx, centerX, centerY, radius);
+  ctx.lineWidth = Math.max(1, radius * 0.12);
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.28)';
+  ctx.stroke();
+  ctx.restore();
+}
+
+export function drawSelectionRing(
+  ctx: CanvasRenderingContext2D,
+  { centerX, centerY, radius = HEX_R }: SelectionRingOptions
+): void {
+  ctx.save();
+  const outerRadius = radius;
+  pathHex(ctx, centerX, centerY, outerRadius);
+  const gradient = ctx.createLinearGradient(centerX, centerY - outerRadius, centerX, centerY + outerRadius);
+  gradient.addColorStop(0, 'rgba(127, 220, 255, 0.95)');
+  gradient.addColorStop(1, 'rgba(42, 122, 255, 0.65)');
+  ctx.strokeStyle = gradient;
+  ctx.lineWidth = Math.max(2, outerRadius * 0.12);
+  ctx.shadowColor = 'rgba(80, 200, 255, 0.65)';
+  ctx.shadowBlur = outerRadius * 0.75;
+  ctx.lineJoin = 'round';
+  ctx.stroke();
+  ctx.restore();
+
+  ctx.save();
+  const innerRadius = outerRadius * 0.74;
+  pathHex(ctx, centerX, centerY, innerRadius);
+  ctx.setLineDash([innerRadius * 0.8, innerRadius * 0.4]);
+  ctx.lineWidth = Math.max(1, outerRadius * 0.05);
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.45)';
+  ctx.stroke();
+  ctx.restore();
+}
+
+export function drawSteam(
+  ctx: CanvasRenderingContext2D,
+  { centerX, centerY, radius = HEX_R * 0.85, intensity = 1 }: SteamOptions
+): void {
+  const clampedIntensity = clamp(intensity, 0, 1);
+  if (clampedIntensity <= 0) {
+    return;
+  }
+
+  ctx.save();
+  pathHex(ctx, centerX, centerY, radius);
+  ctx.clip();
+  const gradient = ctx.createLinearGradient(centerX, centerY + radius, centerX, centerY - radius);
+  gradient.addColorStop(0, 'rgba(255, 255, 255, 0)');
+  gradient.addColorStop(0.55, `rgba(255, 255, 255, ${0.12 * clampedIntensity})`);
+  gradient.addColorStop(1, `rgba(255, 255, 255, ${0.35 * clampedIntensity})`);
+  ctx.globalCompositeOperation = 'lighter';
+  ctx.fillStyle = gradient;
+  ctx.fillRect(centerX - radius, centerY - radius, radius * 2, radius * 2);
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+  ctx.lineCap = 'round';
+  ctx.strokeStyle = `rgba(255, 255, 255, ${0.25 * clampedIntensity})`;
+  ctx.lineWidth = Math.max(1, radius * 0.08);
+  const swirlRadius = radius * 0.75;
+  const swirlSpacing = radius * 0.35;
+  for (let i = 0; i < 3; i++) {
+    const offsetY = centerY - radius * 0.5 + i * swirlSpacing;
+    ctx.beginPath();
+    ctx.moveTo(centerX - swirlRadius, offsetY);
+    ctx.bezierCurveTo(
+      centerX - swirlRadius * 0.4,
+      offsetY - radius * 0.4,
+      centerX + swirlRadius * 0.4,
+      offsetY + radius * 0.2,
+      centerX + swirlRadius,
+      offsetY - radius * 0.45
+    );
+    ctx.stroke();
+  }
+  ctx.restore();
+}


### PR DESCRIPTION
## Summary
- add a dedicated `Saunoja` data model factory and combat helper for safely mutating hit points
- implement reusable canvas helpers for HP rings, selection highlights, and steam effects and export them via the unit barrel
- cover the new helpers with focused unit tests and note the additions in the changelog

## Testing
- `npm test` *(fails during the demo link fetch in this environment after unit tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e834b4c4833083f4e192a9c072df