### PR TITLE
Add Saunoja renderer with warm tint overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Render Saunoja units with a dedicated canvas helper that preloads the SVG
+  icon, applies warm tint and highlight overlays, and layers steam and HP bars
+  within clipped hex silhouettes
 - Introduce Saunoja data helpers, sauna combat damage utilities, and polished
   canvas rendering helpers for HP, selection, and steam effects
 - Add a polished monochrome Saunoja unit icon to `public/assets/units`

--- a/src/units/renderSaunoja.test.ts
+++ b/src/units/renderSaunoja.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+const OriginalImage = globalThis.Image;
+
+class MockImage {
+  static lastInstance: MockImage | null = null;
+  static created: MockImage[] = [];
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  decoding = '';
+  complete = false;
+  naturalWidth = 0;
+  naturalHeight = 0;
+  private _src = '';
+
+  constructor() {
+    MockImage.lastInstance = this;
+    MockImage.created.push(this);
+  }
+
+  get src(): string {
+    return this._src;
+  }
+
+  set src(value: string) {
+    this._src = value;
+  }
+
+  triggerLoad(width = 128, height = 128) {
+    this.naturalWidth = width;
+    this.naturalHeight = height;
+    this.complete = true;
+    this.onload?.();
+  }
+
+  static reset(): void {
+    MockImage.lastInstance = null;
+    MockImage.created = [];
+  }
+}
+
+function createMockContext() {
+  const gradient = { addColorStop: vi.fn() } as unknown as CanvasGradient;
+  const ctx = {
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    clip: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    drawImage: vi.fn(),
+    stroke: vi.fn(),
+    bezierCurveTo: vi.fn(),
+    createLinearGradient: vi.fn(() => gradient),
+    createRadialGradient: vi.fn(() => gradient),
+    filter: 'none',
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    lineCap: 'butt',
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over'
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, gradient };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  MockImage.reset();
+  // @ts-ignore - override Image constructor for tests
+  globalThis.Image = MockImage as any;
+});
+
+afterEach(() => {
+  if (OriginalImage) {
+    // @ts-ignore - restore original constructor
+    globalThis.Image = OriginalImage;
+  } else {
+    // @ts-ignore - remove shim when no original existed
+    delete globalThis.Image;
+  }
+});
+
+describe('preloadSaunojaIcon', () => {
+  it('creates the image once and resolves after load', async () => {
+    const { preloadSaunojaIcon } = await import('./renderSaunoja.ts');
+    const promise1 = preloadSaunojaIcon();
+    const promise2 = preloadSaunojaIcon();
+    expect(promise2).toBe(promise1);
+
+    const instance = MockImage.lastInstance;
+    expect(instance).toBeTruthy();
+    instance?.triggerLoad(200, 200);
+
+    const icon = await promise1;
+    expect(icon).toBe(instance);
+    expect(icon.src).toBe('/assets/units/saunoja.svg');
+    expect(icon.decoding).toBe('async');
+
+    const promise3 = preloadSaunojaIcon();
+    expect(await promise3).toBe(icon);
+  });
+});
+
+describe('drawSaunojas', () => {
+  it('skips drawing when the icon is not ready', async () => {
+    const { drawSaunojas } = await import('./renderSaunoja.ts');
+    const { ctx } = createMockContext();
+    const units = [
+      {
+        id: 'unit-1',
+        name: 'Uno',
+        coord: { q: 0, r: 0 },
+        maxHp: 10,
+        hp: 6,
+        steam: 0.3,
+        selected: false
+      }
+    ];
+
+    drawSaunojas(ctx, units, { hexRadius: 32 });
+    expect((ctx.drawImage as unknown as Mock).mock.calls).toHaveLength(0);
+  });
+
+  it('sorts units by axial row and applies overlays', async () => {
+    const { preloadSaunojaIcon, drawSaunojas } = await import('./renderSaunoja.ts');
+    const helpers = await import('./visualHelpers.ts');
+    const hex = await import('../hex/index.ts');
+
+    const drawHPSpy = vi.spyOn(helpers, 'drawHP');
+    const drawSteamSpy = vi.spyOn(helpers, 'drawSteam');
+    const pathSpy = vi.spyOn(hex, 'pathHex');
+
+    const promise = preloadSaunojaIcon();
+    MockImage.lastInstance?.triggerLoad(256, 256);
+    await promise;
+
+    const { ctx } = createMockContext();
+    const units = [
+      {
+        id: 'south',
+        name: 'South',
+        coord: { q: -1, r: 2 },
+        maxHp: 18,
+        hp: 12,
+        steam: 0.8,
+        selected: false
+      },
+      {
+        id: 'north',
+        name: 'North',
+        coord: { q: 0, r: -1 },
+        maxHp: 14,
+        hp: 8,
+        steam: 0.1,
+        selected: false
+      },
+      {
+        id: 'center',
+        name: 'Center',
+        coord: { q: 1, r: 0 },
+        maxHp: 16,
+        hp: 5,
+        steam: 0.4,
+        selected: true
+      }
+    ];
+
+    drawSaunojas(ctx, units, { hexRadius: 30 });
+
+    expect((ctx.drawImage as unknown as Mock).mock.calls).toHaveLength(3);
+
+    const clipRadius = 30 * 0.98;
+    const clipCalls = pathSpy.mock.calls.filter(([, , , radius]) => Math.abs(radius - clipRadius) < 0.001);
+    expect(clipCalls).toHaveLength(3);
+
+    const hpOrder = drawHPSpy.mock.calls.map(([, options]) => options.hp);
+    expect(hpOrder).toEqual([8, 5, 12]);
+
+    const steamOrder = drawSteamSpy.mock.calls.map(([, options]) => options.intensity);
+    expect(steamOrder).toEqual([0.1, 0.4, 0.8]);
+  });
+});

--- a/src/units/renderSaunoja.ts
+++ b/src/units/renderSaunoja.ts
@@ -1,0 +1,177 @@
+import { axialToPixel, HEX_R, pathHex } from '../hex/index.ts';
+import type { Saunoja } from './saunoja.ts';
+import { drawHP, drawSteam } from './visualHelpers.ts';
+
+const SAUNOJA_ICON_PATH = '/assets/units/saunoja.svg';
+
+let saunojaIcon: HTMLImageElement | null = null;
+let saunojaIconPromise: Promise<HTMLImageElement> | null = null;
+
+function isImageReady(image: HTMLImageElement | null): image is HTMLImageElement {
+  return Boolean(image && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0);
+}
+
+export function preloadSaunojaIcon(): Promise<HTMLImageElement> {
+  if (isImageReady(saunojaIcon)) {
+    return Promise.resolve(saunojaIcon);
+  }
+
+  if (saunojaIconPromise) {
+    return saunojaIconPromise;
+  }
+
+  if (typeof Image === 'undefined') {
+    return Promise.reject(new Error('Image constructor is not available in this environment.'));
+  }
+
+  const img = new Image();
+  img.decoding = 'async';
+  saunojaIcon = img;
+
+  saunojaIconPromise = new Promise((resolve, reject) => {
+    const cleanup = () => {
+      img.onload = null;
+      img.onerror = null;
+    };
+
+    const finalize = () => {
+      cleanup();
+      resolve(img);
+    };
+
+    img.onload = finalize;
+    img.onerror = () => {
+      cleanup();
+      saunojaIcon = null;
+      saunojaIconPromise = null;
+      reject(new Error(`Failed to load saunoja icon from ${SAUNOJA_ICON_PATH}`));
+    };
+
+    img.src = SAUNOJA_ICON_PATH;
+
+    if (isImageReady(img)) {
+      finalize();
+    }
+  });
+
+  return saunojaIconPromise;
+}
+
+export interface DrawSaunojasOptions {
+  originX?: number;
+  originY?: number;
+  hexRadius?: number;
+}
+
+export function drawSaunojas(
+  ctx: CanvasRenderingContext2D,
+  saunojas: Saunoja[],
+  { originX = 0, originY = 0, hexRadius = HEX_R }: DrawSaunojasOptions = {}
+): void {
+  if (!ctx || !Array.isArray(saunojas) || saunojas.length === 0) {
+    return;
+  }
+
+  const icon = isImageReady(saunojaIcon) ? saunojaIcon : null;
+  if (!icon) {
+    return;
+  }
+
+  const radius = Number.isFinite(hexRadius) && hexRadius > 0 ? hexRadius : HEX_R;
+  const clipRadius = radius * 0.98;
+  const renderable = [...saunojas].sort((a, b) => {
+    if (a.coord.r !== b.coord.r) {
+      return a.coord.r - b.coord.r;
+    }
+    if (a.coord.q !== b.coord.q) {
+      return a.coord.q - b.coord.q;
+    }
+    return a.id.localeCompare(b.id);
+  });
+
+  for (const unit of renderable) {
+    const { x, y } = axialToPixel(unit.coord, radius);
+    const drawX = x - originX;
+    const drawY = y - originY;
+    const centerX = drawX + radius;
+    const centerY = drawY + radius;
+
+    ctx.save();
+    pathHex(ctx, centerX, centerY, clipRadius);
+    ctx.clip();
+
+    const baseScale = (radius * 2.15) / Math.max(icon.naturalWidth, icon.naturalHeight || 1);
+    const drawWidth = icon.naturalWidth * baseScale;
+    const drawHeight = icon.naturalHeight * baseScale;
+    const imageX = centerX - drawWidth / 2;
+    const imageY = centerY - drawHeight * 0.72;
+
+    ctx.save();
+    ctx.filter = 'grayscale(100%) contrast(112%)';
+    ctx.globalAlpha *= 0.96;
+    ctx.drawImage(icon, imageX, imageY, drawWidth, drawHeight);
+    ctx.restore();
+
+    ctx.save();
+    ctx.globalCompositeOperation = 'multiply';
+    const shadow = ctx.createRadialGradient(
+      centerX,
+      centerY + clipRadius * 0.38,
+      clipRadius * 0.2,
+      centerX,
+      centerY + clipRadius * 0.38,
+      clipRadius * 1.05
+    );
+    shadow.addColorStop(0, 'rgba(15, 23, 42, 0.55)');
+    shadow.addColorStop(1, 'rgba(15, 23, 42, 0)');
+    ctx.fillStyle = shadow;
+    ctx.fillRect(centerX - clipRadius, centerY - clipRadius, clipRadius * 2, clipRadius * 2);
+    ctx.restore();
+
+    ctx.save();
+    ctx.globalCompositeOperation = 'soft-light';
+    const tint = ctx.createLinearGradient(centerX, centerY - clipRadius, centerX, centerY + clipRadius);
+    tint.addColorStop(0, 'rgba(255, 232, 210, 0.18)');
+    tint.addColorStop(0.52, 'rgba(255, 183, 124, 0.32)');
+    tint.addColorStop(1, 'rgba(212, 97, 54, 0.5)');
+    ctx.fillStyle = tint;
+    ctx.fillRect(centerX - clipRadius, centerY - clipRadius, clipRadius * 2, clipRadius * 2);
+    ctx.restore();
+
+    ctx.save();
+    ctx.globalCompositeOperation = 'screen';
+    ctx.globalAlpha = 0.75;
+    const highlight = ctx.createRadialGradient(
+      centerX,
+      centerY - clipRadius * 0.68,
+      clipRadius * 0.1,
+      centerX,
+      centerY,
+      clipRadius * 1.12
+    );
+    highlight.addColorStop(0, 'rgba(255, 255, 255, 0.85)');
+    highlight.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    ctx.fillStyle = highlight;
+    ctx.fillRect(centerX - clipRadius, centerY - clipRadius, clipRadius * 2, clipRadius * 2);
+    ctx.restore();
+
+    ctx.restore();
+
+    drawSteam(ctx, {
+      centerX,
+      centerY: centerY - radius * 0.18,
+      radius: radius * 0.94,
+      intensity: unit.steam
+    });
+
+    const hpRadius = radius * 0.42;
+    const hpCenterY = centerY + radius * 0.34;
+    drawHP(ctx, {
+      centerX,
+      centerY: hpCenterY,
+      hp: unit.hp,
+      maxHp: unit.maxHp,
+      radius: hpRadius
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Saunoja renderer that preloads the SVG icon, clips to the hex silhouette, and layers warm tint, highlight, steam, and HP treatments
- cover the renderer with Vitest coverage to confirm icon preloading, sorting, and helper invocations
- note the new rendering helper in the changelog

## Testing
- `npx vitest run`
- `npm test` *(fails: live demo fetch is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eac1ec28833085cce236d8c1e3b4