### PR TITLE
Persist Saunoja units and render through main loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Persist Saunoja attendants across sessions via localStorage, spawn an initial
+  guide when none exist, and pipe their selection-aware rendering through the
+  main canvas renderer
 - Render Saunoja units with a dedicated canvas helper that preloads the SVG
   icon, applies warm tint and highlight overlays, and layers steam and HP bars
   within clipped hex silhouettes

--- a/src/game.ts
+++ b/src/game.ts
@@ -25,6 +25,9 @@ import { setupRightPanel } from './ui/rightPanel.tsx';
 import { showError } from './ui/overlay.ts';
 import { draw as render } from './render/renderer.ts';
 import { HexMapRenderer } from './render/HexMapRenderer.ts';
+import type { Saunoja } from './units/saunoja.ts';
+import { makeSaunoja } from './units/saunoja.ts';
+import { preloadSaunojaIcon, drawSaunojas } from './units/renderSaunoja.ts';
 
 const PUBLIC_ASSET_BASE = import.meta.env.BASE_URL;
 const uiIcons = {
@@ -36,6 +39,95 @@ const uiIcons = {
 let canvas: HTMLCanvasElement;
 let resourceBar: HTMLElement;
 let resourceValue: HTMLSpanElement | null = null;
+let saunojas: Saunoja[] = [];
+
+const SAUNOJA_STORAGE_KEY = 'autobattles:saunojas';
+
+function getSaunojaStorage(): Storage | null {
+  try {
+    const globalWithStorage = globalThis as typeof globalThis & { localStorage?: Storage };
+    return globalWithStorage.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function loadUnits(): Saunoja[] {
+  const storage = getSaunojaStorage();
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    const raw = storage.getItem(SAUNOJA_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    const restored: Saunoja[] = [];
+    for (const entry of parsed) {
+      if (!entry || typeof entry !== 'object') continue;
+      const data = entry as Record<string, unknown>;
+      const idValue = data.id;
+      if (typeof idValue !== 'string' || idValue.length === 0) continue;
+
+      const coordSource = data.coord as { q?: unknown; r?: unknown } | undefined;
+      const coord =
+        coordSource &&
+        typeof coordSource === 'object' &&
+        typeof coordSource.q === 'number' &&
+        Number.isFinite(coordSource.q) &&
+        typeof coordSource.r === 'number' &&
+        Number.isFinite(coordSource.r)
+          ? { q: coordSource.q, r: coordSource.r }
+          : undefined;
+
+      restored.push(
+        makeSaunoja({
+          id: idValue,
+          name: typeof data.name === 'string' ? data.name : undefined,
+          coord,
+          maxHp: typeof data.maxHp === 'number' ? data.maxHp : undefined,
+          hp: typeof data.hp === 'number' ? data.hp : undefined,
+          steam: typeof data.steam === 'number' ? data.steam : undefined,
+          selected: Boolean(data.selected)
+        })
+      );
+    }
+
+    return restored;
+  } catch (error) {
+    console.warn('Failed to load Saunoja units from storage', error);
+    return [];
+  }
+}
+
+export function saveUnits(): void {
+  const storage = getSaunojaStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    const payload = saunojas.map((unit) => ({
+      id: unit.id,
+      name: unit.name,
+      coord: { q: unit.coord.q, r: unit.coord.r },
+      maxHp: unit.maxHp,
+      hp: unit.hp,
+      steam: unit.steam,
+      selected: unit.selected
+    }));
+    storage.setItem(SAUNOJA_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Failed to persist Saunoja units', error);
+  }
+}
 
 export function setupGame(canvasEl: HTMLCanvasElement, resourceBarEl: HTMLElement): void {
   canvas = canvasEl;
@@ -64,7 +156,22 @@ export function setupGame(canvasEl: HTMLCanvasElement, resourceBarEl: HTMLElemen
 }
 
 export function handleCanvasClick(x: number, y: number): void {
-  selected = pixelToAxial(x - map.hexSize, y - map.hexSize, map.hexSize);
+  const clicked = pixelToAxial(x - map.hexSize, y - map.hexSize, map.hexSize);
+  selected = clicked;
+
+  let selectionChanged = false;
+  for (const unit of saunojas) {
+    const isSelected = unit.coord.q === clicked.q && unit.coord.r === clicked.r;
+    if (unit.selected !== isSelected) {
+      unit.selected = isSelected;
+      selectionChanged = true;
+    }
+  }
+
+  if (selectionChanged) {
+    saveUnits();
+  }
+
   draw();
 }
 
@@ -114,6 +221,32 @@ const sauna = createSauna({
   r: Math.floor(map.height / 2)
 });
 map.revealAround(sauna.pos, 3);
+saunojas = loadUnits();
+if (saunojas.length === 0) {
+  saunojas.push(
+    makeSaunoja({
+      id: 'saunoja-1',
+      coord: sauna.pos,
+      selected: true
+    })
+  );
+  saveUnits();
+} else {
+  let foundSelected = false;
+  let selectionDirty = false;
+  for (const unit of saunojas) {
+    if (!unit.selected) continue;
+    if (!foundSelected) {
+      foundSelected = true;
+    } else {
+      unit.selected = false;
+      selectionDirty = true;
+    }
+  }
+  if (selectionDirty) {
+    saveUnits();
+  }
+}
 const updateSaunaUI = setupSaunaUI(sauna);
 const updateTopbar = setupTopbar(state, {
   saunakunnia: uiIcons.resource,
@@ -136,11 +269,20 @@ function spawn(type: UnitType, coord: AxialCoord): void {
 state.addResource(Resource.GOLD, 200);
 
 let selected: AxialCoord | null = null;
+const storedSelection = saunojas.find((unit) => unit.selected);
+if (storedSelection) {
+  selected = { q: storedSelection.coord.q, r: storedSelection.coord.r };
+}
 
 export function draw(): void {
   const ctx = canvas.getContext('2d');
   if (!ctx || !assets) return;
-  render(ctx, mapRenderer, assets.images, units, selected);
+  render(ctx, mapRenderer, assets.images, units, selected, {
+    saunojas: {
+      units: saunojas,
+      draw: drawSaunojas
+    }
+  });
 }
 
 const onResourceChanged = ({ resource, total, amount }) => {
@@ -171,6 +313,9 @@ export function cleanup(): void {
 }
 
 export async function start(): Promise<void> {
+  preloadSaunojaIcon().catch((error) => {
+    console.warn('Unable to preload Saunoja icon', error);
+  });
   const { assets: loaded, failures } = await loadAssets(assetPaths);
   assets = loaded;
   if (failures.length) {

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -6,13 +6,29 @@ import type { Unit } from '../unit.ts';
 import { isSisuActive } from '../sim/sisu.ts';
 import { HexMapRenderer } from './HexMapRenderer.ts';
 import { camera } from '../camera/autoFrame.ts';
+import type { Saunoja } from '../units/saunoja.ts';
+import type { DrawSaunojasOptions } from '../units/renderSaunoja.ts';
+
+type DrawSaunojaFn = (
+  ctx: CanvasRenderingContext2D,
+  units: Saunoja[],
+  options?: DrawSaunojasOptions
+) => void;
+
+export interface DrawOptions {
+  saunojas?: {
+    units: Saunoja[];
+    draw: DrawSaunojaFn;
+  };
+}
 
 export function draw(
   ctx: CanvasRenderingContext2D,
   mapRenderer: HexMapRenderer,
   assets: LoadedAssets['images'],
   units: Unit[],
-  selected: AxialCoord | null
+  selected: AxialCoord | null,
+  options?: DrawOptions
 ): void {
   const dpr = window.devicePixelRatio || 1;
   const canvasWidth = ctx.canvas.width;
@@ -33,6 +49,14 @@ export function draw(
   ctx.translate(-(camera.x - origin.x), -(camera.y - origin.y));
 
   mapRenderer.draw(ctx, assets, selected ?? undefined);
+  const saunojaLayer = options?.saunojas;
+  if (saunojaLayer && Array.isArray(saunojaLayer.units) && saunojaLayer.units.length > 0) {
+    saunojaLayer.draw(ctx, saunojaLayer.units, {
+      originX: origin.x,
+      originY: origin.y,
+      hexRadius: mapRenderer.hexSize
+    });
+  }
   drawUnits(ctx, mapRenderer, assets, units, origin);
   ctx.restore();
 }


### PR DESCRIPTION
## Summary
- persist Saunoja attendants in localStorage, spawn a default unit when storage is empty, and update selection state while preloading the icon
- pass Saunoja data into the renderer via a dedicated hook so the helper can draw after tiles
- document the Saunoja persistence and rendering pipeline in the changelog

## Testing
- npm run build
- npm run test *(fails to fetch live demo in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8eee49458833089aa64aea64ef0d1