### PR TITLE
Handle Saunoja selection in world coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Convert canvas clicks to world-space selection toggles that persist Saunoja
+  highlights, clear selection on empty hexes, and redraw the scene only when the
+  active Saunoja set changes
 - Persist Saunoja attendants across sessions via localStorage, spawn an initial
   guide when none exist, and pipe their selection-aware rendering through the
   main canvas renderer

--- a/src/main.ts
+++ b/src/main.ts
@@ -172,10 +172,8 @@ function isTapGesture(state: TouchGestureState): boolean {
 
 function fireTap(state: TouchGestureState): void {
   if (!canvasRef || state.startX == null || state.startY == null) return;
-  const rect = canvasRef.getBoundingClientRect();
-  const canvasX = state.startX - rect.left;
-  const canvasY = state.startY - rect.top;
-  handleCanvasClick(canvasX, canvasY);
+  const world = screenToWorld(canvasRef, state.startX, state.startY);
+  handleCanvasClick(world);
 }
 
 function handlePanTouch(touch: Touch): void {
@@ -310,8 +308,8 @@ function onTouchEnd(event: TouchEvent): void {
 
 function onCanvasClick(event: MouseEvent): void {
   if (!canvasRef) return;
-  const rect = canvasRef.getBoundingClientRect();
-  handleCanvasClick(event.clientX - rect.left, event.clientY - rect.top);
+  const world = screenToWorld(canvasRef, event.clientX, event.clientY);
+  handleCanvasClick(world);
 }
 
 function attachCanvasListeners(canvas: HTMLCanvasElement): void {


### PR DESCRIPTION
## Summary
- convert canvas click and tap events to world coordinates before delegating to the game logic
- toggle Saunoja selection state with new helpers that clear empty clicks, persist changes, and redraw only when necessary
- record the interaction update in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8f795a770833087748bced0df3bc3