### PR TITLE
Fix Saunoja icon path for nested deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Resolve Saunoja icon path against the configured Vite base URL so attendants
+  render correctly when the game is served from a subdirectory
 - Convert canvas clicks to world-space selection toggles that persist Saunoja
   highlights, clear selection on empty hexes, and redraw the scene only when the
   active Saunoja set changes

--- a/src/units/renderSaunoja.test.ts
+++ b/src/units/renderSaunoja.test.ts
@@ -71,12 +71,15 @@ function createMockContext() {
 beforeEach(() => {
   vi.resetModules();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.stubEnv('BASE_URL', '/test-base/');
   MockImage.reset();
   // @ts-ignore - override Image constructor for tests
   globalThis.Image = MockImage as any;
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   if (OriginalImage) {
     // @ts-ignore - restore original constructor
     globalThis.Image = OriginalImage;
@@ -99,7 +102,7 @@ describe('preloadSaunojaIcon', () => {
 
     const icon = await promise1;
     expect(icon).toBe(instance);
-    expect(icon.src).toBe('/assets/units/saunoja.svg');
+    expect(icon.src).toBe('/test-base/assets/units/saunoja.svg');
     expect(icon.decoding).toBe('async');
 
     const promise3 = preloadSaunojaIcon();

--- a/src/units/renderSaunoja.ts
+++ b/src/units/renderSaunoja.ts
@@ -2,7 +2,14 @@ import { axialToPixel, HEX_R, pathHex } from '../hex/index.ts';
 import type { Saunoja } from './saunoja.ts';
 import { drawHP, drawSteam } from './visualHelpers.ts';
 
-const SAUNOJA_ICON_PATH = '/assets/units/saunoja.svg';
+function resolveSaunojaIconPath(): string {
+  const baseUrl = import.meta.env.BASE_URL ?? '/';
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const assetPath = 'assets/units/saunoja.svg';
+  return `${normalizedBase}${assetPath.replace(/^\/+/, '')}`;
+}
+
+const SAUNOJA_ICON_PATH = resolveSaunojaIconPath();
 
 let saunojaIcon: HTMLImageElement | null = null;
 let saunojaIconPromise: Promise<HTMLImageElement> | null = null;


### PR DESCRIPTION
## Summary
- resolve the Saunoja icon URL with the configured Vite base so attendants render when hosted under a subpath
- stub the Vite base environment in the Saunoja renderer tests to assert the dynamic asset path
- document the fix in the changelog

## Testing
- `npm test` *(fails when fetching the live demo URL in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fc9a7e808330b896f21ad1c514ac