### PR TITLE
Add event-driven damage flash overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Highlight recently damaged units with a screen-blended hex flash driven by
+  the draw loop and event-bus tracking
 - Convert canvas clicks to world-space selection toggles that persist Saunoja
   highlights, clear selection on empty hexes, and redraw the scene only when the
   active Saunoja set changes

--- a/src/game.ts
+++ b/src/game.ts
@@ -25,6 +25,7 @@ import { setupRightPanel } from './ui/rightPanel.tsx';
 import { showError } from './ui/overlay.ts';
 import { draw as render } from './render/renderer.ts';
 import { HexMapRenderer } from './render/HexMapRenderer.ts';
+import { activateUnitDamageFlashTracking, deactivateUnitDamageFlashTracking } from './render/unitDamageFlash.ts';
 import type { Saunoja } from './units/saunoja.ts';
 import { makeSaunoja } from './units/saunoja.ts';
 import { preloadSaunojaIcon, drawSaunojas } from './units/renderSaunoja.ts';
@@ -153,6 +154,7 @@ export function setupGame(canvasEl: HTMLCanvasElement, resourceBarEl: HTMLElemen
 
   resourceBar.append(icon, labelSpan, resourceValue);
   updateResourceDisplay(state.getResource(Resource.GOLD));
+  activateUnitDamageFlashTracking();
 }
 
 const assetPaths: AssetPaths = {
@@ -366,6 +368,7 @@ export function cleanup(): void {
   eventBus.off('resourceChanged', onResourceChanged);
   eventBus.off('policyApplied', onPolicyApplied);
   eventBus.off('unitDied', onUnitDied);
+  deactivateUnitDamageFlashTracking();
 }
 
 export async function start(): Promise<void> {

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -8,6 +8,7 @@ import { HexMapRenderer } from './HexMapRenderer.ts';
 import { camera } from '../camera/autoFrame.ts';
 import type { Saunoja } from '../units/saunoja.ts';
 import type { DrawSaunojasOptions } from '../units/renderSaunoja.ts';
+import { drawUnitDamageFlash } from './unitDamageFlash.ts';
 
 type DrawSaunojaFn = (
   ctx: CanvasRenderingContext2D,
@@ -69,6 +70,10 @@ export function drawUnits(
   origin: PixelCoord
 ): void {
   const { width: hexWidth, height: hexHeight } = getHexDimensions(mapRenderer.hexSize);
+  const now =
+    typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
   for (const unit of units) {
     const { x, y } = axialToPixel(unit.coord, mapRenderer.hexSize);
     const drawX = x - origin.x;
@@ -86,5 +91,14 @@ export function drawUnits(
       ctx.strokeRect(drawX, drawY, hexWidth, hexHeight);
     }
     ctx.restore();
+
+    drawUnitDamageFlash(
+      ctx,
+      unit.id,
+      drawX + mapRenderer.hexSize,
+      drawY + mapRenderer.hexSize,
+      mapRenderer.hexSize,
+      now
+    );
   }
 }

--- a/src/render/unitDamageFlash.ts
+++ b/src/render/unitDamageFlash.ts
@@ -1,0 +1,102 @@
+import { eventBus } from '../events/index.ts';
+import { pathHex } from '../hex/index.ts';
+
+interface UnitDamagedPayload {
+  targetId?: string;
+}
+
+const FLASH_DURATION_MS = 220;
+
+const flashStartByUnit = new Map<string, number>();
+
+let teardown: (() => void) | null = null;
+
+function getTimestamp(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function onUnitDamaged(payload: UnitDamagedPayload): void {
+  if (!payload || typeof payload.targetId !== 'string' || payload.targetId.length === 0) {
+    return;
+  }
+  flashStartByUnit.set(payload.targetId, getTimestamp());
+}
+
+export function activateUnitDamageFlashTracking(): void {
+  if (teardown) {
+    return;
+  }
+  const listener = (payload: UnitDamagedPayload): void => {
+    onUnitDamaged(payload);
+  };
+  eventBus.on('unitDamaged', listener);
+  teardown = () => {
+    eventBus.off('unitDamaged', listener);
+    flashStartByUnit.clear();
+  };
+}
+
+export function deactivateUnitDamageFlashTracking(): void {
+  if (!teardown) {
+    return;
+  }
+  teardown();
+  teardown = null;
+}
+
+function getFlashStrength(unitId: string, now = getTimestamp()): number {
+  const start = flashStartByUnit.get(unitId);
+  if (start == null) {
+    return 0;
+  }
+  const elapsed = now - start;
+  if (elapsed >= FLASH_DURATION_MS) {
+    flashStartByUnit.delete(unitId);
+    return 0;
+  }
+  const t = 1 - elapsed / FLASH_DURATION_MS;
+  // Ease-out cubic curve for a sharp pop that fades smoothly.
+  const eased = 1 - Math.pow(1 - t, 3);
+  return Math.max(0, Math.min(1, eased));
+}
+
+export function drawUnitDamageFlash(
+  ctx: CanvasRenderingContext2D,
+  unitId: string,
+  centerX: number,
+  centerY: number,
+  radius: number,
+  now = getTimestamp()
+): void {
+  const intensity = getFlashStrength(unitId, now);
+  if (intensity <= 0) {
+    return;
+  }
+
+  const outerRadius = radius * 0.98;
+  const innerRadius = outerRadius * 0.35;
+  ctx.save();
+  ctx.globalCompositeOperation = 'screen';
+  ctx.globalAlpha = intensity;
+  pathHex(ctx, centerX, centerY, outerRadius);
+  const gradient = ctx.createRadialGradient(centerX, centerY, innerRadius, centerX, centerY, outerRadius);
+  gradient.addColorStop(0, 'rgba(255, 255, 255, 0.9)');
+  gradient.addColorStop(0.45, 'rgba(255, 255, 255, 0.55)');
+  gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+  ctx.fillStyle = gradient;
+  ctx.fill();
+
+  ctx.lineWidth = Math.max(1, radius * 0.1);
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.45)';
+  ctx.shadowColor = 'rgba(255, 255, 255, 0.4)';
+  ctx.shadowBlur = radius * 0.6;
+  ctx.stroke();
+  ctx.restore();
+}
+
+export function resetUnitDamageFlashTracking(): void {
+  flashStartByUnit.clear();
+}


### PR DESCRIPTION
## Summary
- add an event-driven damage flash tracker that listens for `unitDamaged` events and renders a polished screen-blend hex pulse
- hook the tracker into the game lifecycle and unit draw loop so recently hit units briefly glow without leaking listeners
- document the new combat feedback in the changelog

## Testing
- `npm run build`
- `npm test` *(fails: fetch for live demo is blocked in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fab7038883308f1373449ffcf858