### PR TITLE
Add Saunoja hit flash and tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Track Saunoja damage timestamps and render a clipped radial hit flash when a
+  unit is struck for more immediate feedback
 - Resolve Saunoja icon path against the configured Vite base URL so attendants
   render correctly when the game is served from a subdirectory
 - Convert canvas clicks to world-space selection toggles that persist Saunoja

--- a/src/units/combat.ts
+++ b/src/units/combat.ts
@@ -13,5 +13,9 @@ export function applyDamage(target: Saunoja, amount: number): boolean {
   }
 
   target.hp = Math.max(0, target.hp - amount);
+  const now = typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+  target.lastHitAt = now;
   return target.hp === 0;
 }

--- a/src/units/renderSaunoja.ts
+++ b/src/units/renderSaunoja.ts
@@ -1,6 +1,6 @@
 import { axialToPixel, HEX_R, pathHex } from '../hex/index.ts';
 import type { Saunoja } from './saunoja.ts';
-import { drawHP, drawSteam } from './visualHelpers.ts';
+import { drawHP, drawHitFlash, drawSteam } from './visualHelpers.ts';
 
 function resolveSaunojaIconPath(): string {
   const baseUrl = import.meta.env.BASE_URL ?? '/';
@@ -161,6 +161,14 @@ export function drawSaunojas(
     ctx.fillStyle = highlight;
     ctx.fillRect(centerX - clipRadius, centerY - clipRadius, clipRadius * 2, clipRadius * 2);
     ctx.restore();
+
+    const now = performance.now();
+    const elapsed = now - unit.lastHitAt;
+    const FLASH_MS = 120;
+    if (elapsed < FLASH_MS) {
+      const progress = 1 - elapsed / FLASH_MS;
+      drawHitFlash(ctx, { centerX, centerY, radius: clipRadius, progress });
+    }
 
     ctx.restore();
 

--- a/src/units/saunoja.test.ts
+++ b/src/units/saunoja.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { makeSaunoja } from './saunoja.ts';
 import { applyDamage } from './combat.ts';
 
@@ -12,6 +12,7 @@ describe('makeSaunoja', () => {
       maxHp: 20,
       hp: 28,
       steam: 1.7,
+      lastHitAt: 1234,
       selected: true
     });
     coord.q = 9;
@@ -20,6 +21,7 @@ describe('makeSaunoja', () => {
     expect(saunoja.hp).toBe(20);
     expect(saunoja.steam).toBe(1);
     expect(saunoja.coord).toEqual({ q: 2, r: -1 });
+    expect(saunoja.lastHitAt).toBe(1234);
     expect(saunoja.selected).toBe(true);
   });
 
@@ -28,29 +30,47 @@ describe('makeSaunoja', () => {
       id: 's2',
       maxHp: 0,
       hp: -5,
-      steam: -1
+      steam: -1,
+      lastHitAt: Number.NaN
     });
     expect(saunoja.maxHp).toBe(1);
     expect(saunoja.hp).toBe(0);
     expect(saunoja.steam).toBe(0);
     expect(saunoja.name).toBe('Saunoja');
+    expect(saunoja.lastHitAt).toBe(0);
   });
 });
 
 describe('applyDamage', () => {
   it('reduces hit points and returns true when depleted', () => {
     const saunoja = makeSaunoja({ id: 's3', maxHp: 10 });
+    const nowSpy = vi.spyOn(performance, 'now');
+    nowSpy.mockReturnValueOnce(100).mockReturnValueOnce(200);
+
     expect(applyDamage(saunoja, 4)).toBe(false);
     expect(saunoja.hp).toBe(6);
+    expect(saunoja.lastHitAt).toBe(100);
+
     expect(applyDamage(saunoja, 10)).toBe(true);
     expect(saunoja.hp).toBe(0);
+    expect(saunoja.lastHitAt).toBe(200);
+
+    nowSpy.mockRestore();
   });
 
   it('ignores non-positive or invalid damage values', () => {
     const saunoja = makeSaunoja({ id: 's4', maxHp: 5, hp: 3 });
+    saunoja.lastHitAt = 250;
+    const nowSpy = vi.spyOn(performance, 'now');
+    nowSpy.mockReturnValue(999);
+
     expect(applyDamage(saunoja, 0)).toBe(false);
     expect(saunoja.hp).toBe(3);
     expect(applyDamage(saunoja, Number.NaN)).toBe(false);
     expect(saunoja.hp).toBe(3);
+    expect(saunoja.lastHitAt).toBe(250);
+    expect(nowSpy).not.toHaveBeenCalled();
+
+    nowSpy.mockRestore();
   });
 });

--- a/src/units/saunoja.ts
+++ b/src/units/saunoja.ts
@@ -13,6 +13,8 @@ export interface Saunoja {
   hp: number;
   /** Steam intensity from 0 (idle) to 1 (billowing). */
   steam: number;
+  /** Timestamp in milliseconds of the most recent damage event. */
+  lastHitAt: number;
   /** Whether the unit is currently selected in the UI. */
   selected: boolean;
 }
@@ -24,12 +26,14 @@ export interface SaunojaInit {
   maxHp?: number;
   hp?: number;
   steam?: number;
+  lastHitAt?: number;
   selected?: boolean;
 }
 
 const DEFAULT_COORD: AxialCoord = { q: 0, r: 0 };
 const DEFAULT_NAME = 'Saunoja';
 const DEFAULT_MAX_HP = 18;
+const DEFAULT_LAST_HIT_AT = 0;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
@@ -47,6 +51,7 @@ export function makeSaunoja(init: SaunojaInit): Saunoja {
     maxHp = DEFAULT_MAX_HP,
     hp = maxHp,
     steam = 0,
+    lastHitAt = DEFAULT_LAST_HIT_AT,
     selected = false
   } = init;
 
@@ -55,6 +60,8 @@ export function makeSaunoja(init: SaunojaInit): Saunoja {
   const clampedHp = clamp(normalizedHpSource, 0, normalizedMaxHp);
   const normalizedSteamSource = Number.isFinite(steam) ? steam : 0;
   const clampedSteam = clamp(normalizedSteamSource, 0, 1);
+  const normalizedLastHitSource = Number.isFinite(lastHitAt) ? lastHitAt : DEFAULT_LAST_HIT_AT;
+  const clampedLastHitAt = Math.max(0, normalizedLastHitSource);
 
   return {
     id,
@@ -63,6 +70,7 @@ export function makeSaunoja(init: SaunojaInit): Saunoja {
     maxHp: normalizedMaxHp,
     hp: clampedHp,
     steam: clampedSteam,
+    lastHitAt: clampedLastHitAt,
     selected
   };
 }

--- a/src/units/visualHelpers.ts
+++ b/src/units/visualHelpers.ts
@@ -21,6 +21,13 @@ export interface SteamOptions {
   intensity?: number;
 }
 
+export interface HitFlashOptions {
+  centerX: number;
+  centerY: number;
+  radius?: number;
+  progress?: number;
+}
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
@@ -58,6 +65,37 @@ export function drawHP(
   ctx.lineWidth = Math.max(1, radius * 0.12);
   ctx.strokeStyle = 'rgba(255, 255, 255, 0.28)';
   ctx.stroke();
+  ctx.restore();
+}
+
+export function drawHitFlash(
+  ctx: CanvasRenderingContext2D,
+  { centerX, centerY, radius = HEX_R, progress = 0 }: HitFlashOptions
+): void {
+  const clampedProgress = clamp(progress, 0, 1);
+  if (clampedProgress <= 0) {
+    return;
+  }
+
+  const safeRadius = Number.isFinite(radius) && radius > 0 ? radius : HEX_R;
+  ctx.save();
+  ctx.globalCompositeOperation = 'lighter';
+  ctx.globalAlpha = clampedProgress;
+  const gradient = ctx.createRadialGradient(
+    centerX,
+    centerY,
+    Math.max(1, safeRadius * 0.1),
+    centerX,
+    centerY,
+    safeRadius
+  );
+  gradient.addColorStop(0, 'rgba(255, 255, 255, 0.92)');
+  gradient.addColorStop(0.45, 'rgba(255, 255, 255, 0.68)');
+  gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.arc(centerX, centerY, safeRadius, 0, Math.PI * 2);
+  ctx.fill();
   ctx.restore();
 }
 


### PR DESCRIPTION
## Summary
- extend Saunoja data with a sanitised `lastHitAt` timestamp and stamp it when damage is applied
- add a polished radial hit flash overlay helper and render it for recently struck attendants
- update unit tests and changelog entries to cover the new timestamp behaviour

## Testing
- npm run build
- npm run test *(fails: scripts/check-demo-link.js cannot reach live demo in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9009afcbc833095e93295911133ae