### PR TITLE
Handle offline demo link check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Treat the live demo availability check as a warning when outbound network
+  access is blocked so offline CI runs can succeed
 - Track Saunoja damage timestamps and render a clipped radial hit flash when a
   unit is struck for more immediate feedback
 - Resolve Saunoja icon path against the configured Vite base URL so attendants


### PR DESCRIPTION
## Summary
- relax the live demo verification script so CI without outbound access treats fetch failures as warnings
- surface the underlying network codes for easier debugging and document the behavior in the changelog

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c906dd211c8330b70e9901ac276bd3