### PR TITLE
build: refresh docs fallback handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Copy `docs/index.html` to `docs/404.html` during the build step and remove the
+  legacy root-level `404.html`
 - Sync GitHub Pages output directly from `dist/`, generating a SPA-friendly
   `404.html` and removing legacy root-level bundles
 - Treat the live demo availability check as a warning when outbound network


### PR DESCRIPTION
## Summary
- validate the built docs index before copying it to `docs/404.html` as the SPA fallback
- remove any legacy root-level `404.html` while syncing GitHub Pages assets
- record the fallback handling change in the changelog

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c912654538833084646163b9e669a5