### PR TITLE
Surface build metadata in HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Extend the viewport meta tag for full-bleed mobile layouts and surface the
+  short git commit hash in a polished HUD footer
 - Copy `docs/index.html` to `docs/404.html` during the build step and remove the
   legacy root-level `404.html`
 - Sync GitHub Pages output directly from `dist/`, generating a SPA-friendly

--- a/build-info.ts
+++ b/build-info.ts
@@ -1,0 +1,10 @@
+import { execSync } from 'node:child_process';
+
+export function getShortCommitHash(): string {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch (error) {
+    console.warn('Unable to resolve git commit hash:', error);
+    return 'unknown';
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <title>Autobattles4xFinsauna</title>
   </head>
   <body>
@@ -11,6 +14,10 @@
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">
         <div id="resource-bar">Resources: 0</div>
+        <footer id="build-id" aria-live="polite">
+          <span class="build-id__label">Build</span>
+          <span class="build-id__value" data-build-commit>—</span>
+        </footer>
       </div>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,41 @@ interface TouchGestureState {
   moved: boolean;
 }
 
+function applyBuildMetadata(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const buildValueElement = document.querySelector<HTMLElement>('[data-build-commit]');
+  if (!buildValueElement) {
+    return;
+  }
+
+  const normalizedCommit =
+    typeof __BUILD_COMMIT__ === 'string' ? __BUILD_COMMIT__.trim() : '';
+  const displayValue =
+    normalizedCommit && normalizedCommit !== 'unknown'
+      ? normalizedCommit
+      : 'development';
+
+  buildValueElement.textContent = displayValue;
+
+  const container = buildValueElement.closest<HTMLElement>('#build-id');
+  if (container) {
+    const accessibleLabel =
+      normalizedCommit && normalizedCommit !== 'unknown'
+        ? `Build commit ${normalizedCommit}`
+        : 'Development build';
+    container.setAttribute('aria-label', accessibleLabel);
+    container.title =
+      normalizedCommit && normalizedCommit !== 'unknown'
+        ? `Commit ${normalizedCommit}`
+        : 'Unversioned development build';
+  }
+}
+
+applyBuildMetadata();
+
 const cleanupHandlers: Array<() => void> = [];
 
 let canvasRef: HTMLCanvasElement | null = null;

--- a/src/style.css
+++ b/src/style.css
@@ -348,6 +348,52 @@ button {
   letter-spacing: 0.24em;
 }
 
+#build-id {
+  pointer-events: auto;
+  position: relative;
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 22px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--hud-border);
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
+  backdrop-filter: blur(18px) saturate(140%);
+  box-shadow: var(--shadow-soft);
+  color: var(--color-muted);
+  font-size: clamp(10px, 0.9vw, 12px);
+  user-select: text;
+}
+
+#build-id::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+}
+
+#build-id .build-id__label {
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+#build-id .build-id__value {
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--color-surface) 72%, transparent);
+  color: var(--color-foreground);
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Consolas,
+    monospace;
+  font-size: clamp(12px, 1vw, 13px);
+  letter-spacing: 0.18em;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __BUILD_COMMIT__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'vite';
+import { getShortCommitHash } from './build-info';
+
+const buildCommit = getShortCommitHash();
 
 // Vite configuration
 export default defineConfig({
@@ -9,5 +12,8 @@ export default defineConfig({
   build: {
     outDir: '../dist',
     emptyOutDir: true,
+  },
+  define: {
+    __BUILD_COMMIT__: JSON.stringify(buildCommit),
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { getShortCommitHash } from './build-info';
+
+const buildCommit = getShortCommitHash();
 
 export default defineConfig({
+  define: {
+    __BUILD_COMMIT__: JSON.stringify(buildCommit),
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- update the viewport meta tag and add a HUD footer for surfacing the build identifier
- inject the short git commit hash through shared build metadata helpers used by Vite and Vitest
- document the viewport and build footer refinements in the changelog

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c915ea65e0833095f78331173ad1cb