### PR TITLE
Add unified resource loader with HUD feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Introduce a unified resource bootstrapper that surfaces a polished HUD loader,
+  aggregates asset warnings, and presents graceful recovery banners when
+  initialization fails
 - Copy production build output to `docs/` via an `npm postbuild` script that
   mirrors GitHub Pages fallbacks using standard shell utilities
 - Stretch the canvas container to the full viewport, adopt dynamic viewport

--- a/src/lib/loadResources.ts
+++ b/src/lib/loadResources.ts
@@ -1,0 +1,87 @@
+export type ResourceLoaderResult<T> = {
+  value: T;
+  warnings?: string[];
+  errors?: string[];
+};
+
+export type ResourceLoaderDescriptor<T> = {
+  label?: string;
+  load: () => Promise<ResourceLoaderResult<T>>;
+};
+
+type LoaderValue<T> = T extends ResourceLoaderDescriptor<infer Value> ? Value : never;
+
+type LoaderMap = Record<string, ResourceLoaderDescriptor<unknown>>;
+
+export type LoadResourcesResult<TLoaders extends LoaderMap> = {
+  resources: Partial<{ [K in keyof TLoaders]: LoaderValue<TLoaders[K]> }>;
+  warnings: string[];
+  errors: string[];
+};
+
+export async function loadResources<TLoaders extends LoaderMap>(
+  loaders: TLoaders
+): Promise<LoadResourcesResult<TLoaders>> {
+  const entries = Object.entries(loaders) as Array<[
+    keyof TLoaders,
+    ResourceLoaderDescriptor<unknown>
+  ]>;
+
+  const settled = await Promise.allSettled(
+    entries.map(([key, descriptor]) =>
+      descriptor
+        .load()
+        .then((value) => ({ key, descriptor, value }))
+    )
+  );
+
+  const resources: Partial<Record<keyof TLoaders, unknown>> = {};
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  settled.forEach((outcome, index) => {
+    const [key, descriptor] = entries[index];
+    const label = descriptor.label ?? String(key);
+
+    if (outcome.status === 'fulfilled') {
+      const { value } = outcome.value;
+      resources[key] = value.value;
+
+      if (value.warnings?.length) {
+        for (const message of value.warnings) {
+          warnings.push(label ? `${label}: ${message}` : message);
+        }
+      }
+
+      if (value.errors?.length) {
+        for (const message of value.errors) {
+          errors.push(label ? `${label}: ${message}` : message);
+        }
+      }
+      return;
+    }
+
+    const message = formatReason(outcome.reason);
+    errors.push(label ? `${label}: ${message}` : message);
+  });
+
+  return {
+    resources: resources as Partial<{ [K in keyof TLoaders]: LoaderValue<TLoaders[K]> }>,
+    warnings,
+    errors,
+  };
+}
+
+function formatReason(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.message;
+  }
+  if (typeof reason === 'string') {
+    return reason;
+  }
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,18 @@
 import './style.css';
-import { setupGame, start, handleCanvasClick, draw, cleanup } from './game.ts';
+import {
+  setupGame,
+  start,
+  handleCanvasClick,
+  draw,
+  cleanup,
+  assetPaths,
+  setAssets,
+} from './game.ts';
 import { camera } from './camera/autoFrame.ts';
 import type { PixelCoord } from './hex/HexUtils.ts';
+import { loadResources } from './lib/loadResources.ts';
+import { loadAssets } from './loader.ts';
+import { preloadSaunojaIcon } from './units/renderSaunoja.ts';
 
 const MIN_CAMERA_ZOOM = 0.5;
 const MAX_CAMERA_ZOOM = 3.5;
@@ -57,6 +68,8 @@ function applyBuildMetadata(): void {
 applyBuildMetadata();
 
 const cleanupHandlers: Array<() => void> = [];
+
+let initToken = 0;
 
 let canvasRef: HTMLCanvasElement | null = null;
 let isInitialized = false;
@@ -391,6 +404,7 @@ function clearCleanupHandlers(): void {
 }
 
 export function destroy(): void {
+  initToken += 1;
   clearCleanupHandlers();
   pointerPanState.active = false;
   pointerPanState.pointerId = null;
@@ -400,7 +414,360 @@ export function destroy(): void {
   touchState = null;
   canvasRef = null;
   isInitialized = false;
+  removeTransientUI();
   cleanup();
+}
+
+function removeTransientUI(): void {
+  document.querySelectorAll('.hud-loader').forEach((element) => {
+    element.remove();
+  });
+  document.querySelectorAll('.hud-banner-stack').forEach((element) => {
+    element.remove();
+  });
+}
+
+interface LoadingHandle {
+  update(message: string): void;
+  clear(): void;
+  dispose(): void;
+}
+
+function showLoadingUI(message = 'Heating the sauna stones…'): LoadingHandle {
+  const overlay = document.getElementById('ui-overlay');
+  if (!overlay) {
+    return {
+      update: () => undefined,
+      clear: () => undefined,
+      dispose: () => undefined,
+    };
+  }
+
+  const loader = document.createElement('div');
+  loader.className = 'hud-loader';
+  loader.setAttribute('role', 'status');
+  loader.setAttribute('aria-live', 'polite');
+
+  const card = document.createElement('div');
+  card.className = 'hud-loader__card';
+
+  const spinner = document.createElement('div');
+  spinner.className = 'hud-loader__spinner';
+  spinner.setAttribute('aria-hidden', 'true');
+
+  const messageElement = document.createElement('p');
+  messageElement.className = 'hud-loader__message';
+  messageElement.textContent = message;
+
+  card.append(spinner, messageElement);
+  loader.append(card);
+  overlay.append(loader);
+
+  let dismissed = false;
+
+  return {
+    update(text: string) {
+      messageElement.textContent = text;
+    },
+    clear() {
+      if (dismissed) {
+        return;
+      }
+      animateRemoval(loader, 'hud-loader--hidden', () => {
+        dismissed = true;
+        loader.remove();
+      });
+    },
+    dispose() {
+      if (dismissed) {
+        return;
+      }
+      dismissed = true;
+      loader.remove();
+    },
+  };
+}
+
+type BannerType = 'info' | 'warning' | 'error';
+
+interface BannerAction {
+  label: string;
+  onClick: () => void;
+  variant?: 'primary' | 'secondary';
+}
+
+interface BannerOptions {
+  title?: string;
+  messages: string[];
+  actions?: BannerAction[];
+  dismissible?: boolean;
+  autoCloseMs?: number;
+}
+
+interface BannerHandle {
+  element: HTMLElement;
+  dismiss: () => void;
+}
+
+function showBanner(type: BannerType, options: BannerOptions): BannerHandle | null {
+  const stack = ensureBannerStack();
+  if (!stack) {
+    return null;
+  }
+
+  const banner = document.createElement('section');
+  banner.className = `hud-banner hud-banner--${type}`;
+  banner.setAttribute('role', type === 'error' ? 'alert' : 'status');
+  banner.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
+
+  const header = document.createElement('header');
+  header.className = 'hud-banner__header';
+
+  const title = document.createElement('p');
+  title.className = 'hud-banner__title';
+  title.textContent =
+    options.title ??
+    (type === 'error' ? 'Attention required' : type === 'warning' ? 'Heads up' : 'Status update');
+  header.append(title);
+
+  const list = document.createElement('ul');
+  list.className = 'hud-banner__list';
+  for (const message of options.messages) {
+    const item = document.createElement('li');
+    item.textContent = message;
+    list.append(item);
+  }
+
+  banner.append(header);
+  if (options.messages.length) {
+    banner.append(list);
+  }
+
+  if (options.actions?.length) {
+    const actions = document.createElement('div');
+    actions.className = 'hud-banner__actions';
+    for (const action of options.actions) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className =
+        action.variant === 'secondary'
+          ? 'hud-banner__button hud-banner__button--secondary'
+          : 'hud-banner__button';
+      button.textContent = action.label;
+      button.addEventListener('click', () => {
+        action.onClick();
+      });
+      actions.append(button);
+    }
+    banner.append(actions);
+  }
+
+  let autoDismissId: number | undefined;
+  let dismissed = false;
+
+  const dismiss = () => {
+    if (dismissed) {
+      return;
+    }
+    dismissed = true;
+    if (autoDismissId) {
+      window.clearTimeout(autoDismissId);
+    }
+    animateRemoval(banner, 'hud-banner--hide', () => {
+      banner.remove();
+      if (!stack.hasChildNodes()) {
+        stack.remove();
+      }
+    });
+  };
+
+  if (options.dismissible !== false) {
+    const closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'hud-banner__close';
+    closeButton.setAttribute('aria-label', 'Dismiss notification');
+    closeButton.textContent = '×';
+    closeButton.addEventListener('click', () => {
+      dismiss();
+    });
+    header.append(closeButton);
+  }
+
+  stack.append(banner);
+
+  if (options.autoCloseMs && options.autoCloseMs > 0) {
+    autoDismissId = window.setTimeout(() => dismiss(), options.autoCloseMs);
+  }
+
+  return {
+    element: banner,
+    dismiss,
+  };
+}
+
+function ensureBannerStack(): HTMLElement | null {
+  const overlay = document.getElementById('ui-overlay');
+  if (!overlay) {
+    return null;
+  }
+
+  let stack = overlay.querySelector<HTMLElement>('.hud-banner-stack');
+  if (!stack) {
+    stack = document.createElement('div');
+    stack.className = 'hud-banner-stack';
+    overlay.append(stack);
+  }
+  return stack;
+}
+
+function animateRemoval(element: HTMLElement, hiddenClass: string, onComplete: () => void): void {
+  let finished = false;
+  const finalize = () => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    element.removeEventListener('transitionend', finalize);
+    onComplete();
+  };
+
+  element.addEventListener('transitionend', finalize);
+  requestAnimationFrame(() => {
+    element.classList.add(hiddenClass);
+  });
+  window.setTimeout(finalize, 400);
+}
+
+function formatError(reason: unknown): string {
+  if (reason instanceof Error && reason.message) {
+    return reason.message;
+  }
+  if (typeof reason === 'string' && reason.trim().length > 0) {
+    return reason;
+  }
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
+}
+
+async function prepareAndStart(runToken: number): Promise<void> {
+  const loader = showLoadingUI('Heating the sauna stones…');
+  addCleanup(() => loader.dispose());
+
+  try {
+    const { resources, warnings, errors } = await loadResources({
+      assets: {
+        label: 'Core assets',
+        load: async () => {
+          const result = await loadAssets(assetPaths);
+          return { value: result.assets, errors: result.failures };
+        },
+      },
+      saunojaIcon: {
+        label: 'Saunoja icon',
+        load: async () => {
+          try {
+            const icon = await preloadSaunojaIcon();
+            return { value: icon };
+          } catch (error) {
+            return {
+              value: null,
+              warnings: [`Unable to preload Saunoja icon (${formatError(error)})`],
+            };
+          }
+        },
+      },
+    });
+
+    if (runToken !== initToken) {
+      loader.dispose();
+      return;
+    }
+
+    loader.update('Polishing sauna ambience…');
+    loader.clear();
+
+    const loadedAssets = resources.assets;
+
+    if (!loadedAssets) {
+      const fatalMessages = errors.length
+        ? [...errors]
+        : ['Critical assets were unavailable. Please refresh to try again.'];
+      console.error('Critical assets failed to load', fatalMessages);
+      const fatalBanner = showBanner('error', {
+        title: 'Unable to start the sauna battle',
+        messages: fatalMessages,
+        actions: [
+          {
+            label: 'Reload',
+            onClick: () => window.location.reload(),
+            variant: 'primary',
+          },
+        ],
+        dismissible: false,
+      });
+      if (fatalBanner) {
+        addCleanup(() => fatalBanner.dismiss());
+      }
+      return;
+    }
+
+    if (errors.length) {
+      console.error('Resource loader errors', errors);
+      const errorBanner = showBanner('error', {
+        title: 'Some resources failed to load',
+        messages: errors,
+        actions: [
+          {
+            label: 'Reload',
+            onClick: () => window.location.reload(),
+            variant: 'primary',
+          },
+        ],
+      });
+      if (errorBanner) {
+        addCleanup(() => errorBanner.dismiss());
+      }
+    }
+
+    if (warnings.length) {
+      console.warn('Resource loader warnings', warnings);
+      const warningBanner = showBanner('warning', {
+        title: 'Heads up',
+        messages: warnings,
+        autoCloseMs: 12000,
+      });
+      if (warningBanner) {
+        addCleanup(() => warningBanner.dismiss());
+      }
+    }
+
+    setAssets(loadedAssets);
+    start();
+  } catch (error) {
+    if (runToken !== initToken) {
+      loader.dispose();
+      return;
+    }
+    console.error('Failed to initialize resources', error);
+    loader.clear();
+    const banner = showBanner('error', {
+      title: 'Failed to initialize',
+      messages: [formatError(error)],
+      actions: [
+        {
+          label: 'Reload',
+          onClick: () => window.location.reload(),
+          variant: 'primary',
+        },
+      ],
+    });
+    if (banner) {
+      addCleanup(() => banner.dismiss());
+    }
+  }
 }
 
 export function init(): void {
@@ -413,6 +780,8 @@ export function init(): void {
   if (isInitialized) {
     destroy();
   }
+
+  const runToken = ++initToken;
 
   canvasRef = canvas;
   isInitialized = true;
@@ -430,7 +799,7 @@ export function init(): void {
   resize();
 
   if (!import.meta.vitest) {
-    start();
+    void prepareAndStart(runToken);
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -12,6 +12,7 @@
   --color-accent: #38bdf8;
   --color-accent-soft: rgba(56, 189, 248, 0.18);
   --color-warning: #fbbf24;
+  --color-danger: #f87171;
   --hud-border: rgba(148, 163, 184, 0.24);
   --hud-border-strong: rgba(148, 163, 184, 0.34);
   --shadow-strong: 0 32px 64px rgba(8, 25, 53, 0.6);
@@ -378,6 +379,283 @@ body > #game-container {
   color: var(--color-muted);
   text-transform: uppercase;
   letter-spacing: 0.24em;
+}
+
+.hud-loader {
+  pointer-events: auto;
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(24px, 6vw, 48px);
+  background:
+    linear-gradient(160deg, rgba(2, 6, 23, 0.82), rgba(2, 6, 23, 0.68));
+  backdrop-filter: blur(22px) saturate(120%);
+  transition: opacity 240ms ease, visibility 240ms ease;
+  z-index: 220;
+}
+
+.hud-loader--hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.hud-loader__card {
+  pointer-events: auto;
+  display: grid;
+  gap: clamp(16px, 3vw, 22px);
+  align-items: center;
+  justify-items: center;
+  padding: clamp(24px, 5vw, 32px) clamp(28px, 6vw, 42px);
+  border-radius: var(--radius-panel);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
+  background:
+    linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.72));
+  box-shadow: 0 32px 60px rgba(8, 25, 53, 0.55);
+  color: var(--color-foreground);
+  text-align: center;
+}
+
+.hud-loader__spinner {
+  width: clamp(48px, 12vw, 64px);
+  height: clamp(48px, 12vw, 64px);
+  border-radius: 50%;
+  border: 4px solid rgba(56, 189, 248, 0.25);
+  border-top-color: var(--color-accent);
+  animation: hud-loader-spin 1.1s linear infinite;
+  filter: drop-shadow(0 0 16px rgba(56, 189, 248, 0.4));
+}
+
+@keyframes hud-loader-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hud-loader__spinner {
+    animation-duration: 1.8s;
+  }
+}
+
+.hud-loader__message {
+  margin: 0;
+  font-size: clamp(16px, 2.5vw, 20px);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 75%, var(--color-foreground) 25%);
+}
+
+.hud-banner-stack {
+  pointer-events: none;
+  position: absolute;
+  left: 50%;
+  bottom: clamp(28px, 10vh, 88px);
+  display: grid;
+  gap: clamp(12px, 2.6vw, 18px);
+  width: min(560px, calc(100% - clamp(40px, 10vw, 120px)));
+  transform: translateX(-50%);
+  z-index: 210;
+}
+
+.hud-banner {
+  position: relative;
+  pointer-events: auto;
+  display: grid;
+  gap: clamp(12px, 2vw, 18px);
+  padding: clamp(20px, 3.6vw, 28px);
+  border-radius: var(--radius-panel);
+  border: 1px solid var(--hud-border-strong);
+  background:
+    linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.74));
+  box-shadow: 0 32px 72px rgba(8, 25, 53, 0.55);
+  color: var(--color-foreground);
+  transition: opacity 220ms ease, transform 220ms ease;
+  overflow: hidden;
+  --banner-accent: var(--color-accent);
+}
+
+.hud-banner::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 18% 22%, color-mix(in srgb, var(--banner-accent) 36%, transparent) 0%, transparent 62%),
+    radial-gradient(circle at 82% 12%, color-mix(in srgb, var(--banner-accent) 24%, transparent) 0%, transparent 60%);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.hud-banner--hide {
+  opacity: 0;
+  transform: translateY(12px) scale(0.98);
+  pointer-events: none;
+}
+
+.hud-banner--warning {
+  --banner-accent: color-mix(in srgb, var(--color-warning) 80%, white 15%);
+  border-color: color-mix(in srgb, var(--color-warning) 48%, transparent);
+  box-shadow: 0 26px 64px rgba(251, 191, 36, 0.3);
+}
+
+.hud-banner--error {
+  --banner-accent: color-mix(in srgb, var(--color-danger) 82%, white 12%);
+  border-color: color-mix(in srgb, var(--color-danger) 52%, transparent);
+  box-shadow: 0 28px 68px rgba(248, 113, 113, 0.38);
+}
+
+.hud-banner__header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  z-index: 1;
+}
+
+.hud-banner__title {
+  margin: 0;
+  font-size: clamp(14px, 2vw, 16px);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--banner-accent);
+}
+
+.hud-banner__list {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.hud-banner__list li {
+  position: relative;
+  padding-left: 18px;
+  font-size: clamp(13px, 1.8vw, 15px);
+  color: color-mix(in srgb, var(--color-muted) 70%, var(--color-foreground) 40%);
+}
+
+.hud-banner__list li::before {
+  content: '';
+  position: absolute;
+  top: 8px;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--banner-accent);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--banner-accent) 70%, transparent);
+  opacity: 0.85;
+}
+
+.hud-banner__actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.hud-banner__button {
+  pointer-events: auto;
+  padding: 10px 20px;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--banner-accent) 45%, transparent);
+  background: color-mix(in srgb, var(--banner-accent) 18%, transparent);
+  color: var(--color-foreground);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy),
+    background var(--transition-snappy), border-color var(--transition-snappy);
+}
+
+.hud-banner__button:hover,
+.hud-banner__button:focus-visible {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--banner-accent) 65%, transparent);
+  background: color-mix(in srgb, var(--banner-accent) 30%, transparent);
+  box-shadow: 0 18px 36px color-mix(in srgb, var(--banner-accent) 45%, transparent);
+  outline: none;
+}
+
+.hud-banner__button:active {
+  transform: translateY(0);
+}
+
+.hud-banner__button--secondary {
+  border-color: color-mix(in srgb, var(--banner-accent) 22%, transparent);
+  background: color-mix(in srgb, var(--banner-accent) 12%, transparent);
+  color: color-mix(in srgb, var(--color-muted) 80%, var(--color-foreground) 20%);
+}
+
+.hud-banner__close {
+  pointer-events: auto;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid color-mix(in srgb, var(--banner-accent) 40%, transparent);
+  background: color-mix(in srgb, var(--banner-accent) 18%, transparent);
+  color: var(--color-foreground);
+  font-size: 18px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy),
+    background var(--transition-snappy), border-color var(--transition-snappy);
+}
+
+.hud-banner__close:hover,
+.hud-banner__close:focus-visible {
+  transform: translateY(-1px) scale(1.05);
+  border-color: color-mix(in srgb, var(--banner-accent) 68%, transparent);
+  background: color-mix(in srgb, var(--banner-accent) 32%, transparent);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--banner-accent) 38%, transparent);
+  outline: none;
+}
+
+.hud-banner__close:active {
+  transform: translateY(0) scale(0.98);
+}
+
+@media (max-width: 640px) {
+  .hud-loader {
+    padding: clamp(18px, 8vw, 32px);
+  }
+
+  .hud-loader__card {
+    padding: clamp(20px, 8vw, 28px) clamp(22px, 10vw, 34px);
+  }
+
+  .hud-banner-stack {
+    bottom: clamp(20px, 12vh, 60px);
+    width: calc(100% - clamp(24px, 10vw, 48px));
+  }
+
+  .hud-banner {
+    padding: clamp(18px, 7vw, 24px);
+  }
+
+  .hud-banner__title {
+    letter-spacing: 0.16em;
+  }
+
+  .hud-banner__actions {
+    justify-content: stretch;
+  }
+
+  .hud-banner__button {
+    flex: 1 1 auto;
+    width: 100%;
+  }
 }
 
 #build-id {


### PR DESCRIPTION
## Summary
- add a reusable `loadResources` helper that aggregates loader outcomes with `Promise.allSettled`
- update the main entry point to preload assets through the helper, drive a polished loading overlay, and surface warning/error banners
- adjust the game bootstrap to accept injected assets and extend the HUD styling tokens for the new UI treatments

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c928d575d8833080d8d27a6f734b86