### PR TITLE
Expose git commit metadata in HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Surface the short git commit hash at build time, expose it via Vite/Vitest globals, and render a refined HUD badge for quick build identification
 - Introduce a unified resource bootstrapper that surfaces a polished HUD loader,
   aggregates asset warnings, and presents graceful recovery banners when
   initialization fails

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,25 +43,29 @@ function applyBuildMetadata(): void {
   }
 
   const normalizedCommit =
-    typeof __BUILD_COMMIT__ === 'string' ? __BUILD_COMMIT__.trim() : '';
-  const displayValue =
-    normalizedCommit && normalizedCommit !== 'unknown'
-      ? normalizedCommit
-      : 'development';
+    typeof __COMMIT__ === 'string' ? __COMMIT__.trim() : '';
+  const isCommitKnown =
+    normalizedCommit.length > 0 && normalizedCommit !== 'unknown';
+  const displayValue = isCommitKnown ? `#${normalizedCommit}` : 'development';
 
   buildValueElement.textContent = displayValue;
+  buildValueElement.dataset.buildState = isCommitKnown ? 'commit' : 'development';
+
+  if (isCommitKnown) {
+    buildValueElement.dataset.commitHash = normalizedCommit;
+  } else {
+    delete buildValueElement.dataset.commitHash;
+  }
 
   const container = buildValueElement.closest<HTMLElement>('#build-id');
   if (container) {
-    const accessibleLabel =
-      normalizedCommit && normalizedCommit !== 'unknown'
-        ? `Build commit ${normalizedCommit}`
-        : 'Development build';
+    const accessibleLabel = isCommitKnown
+      ? `Build commit ${normalizedCommit}`
+      : 'Development build';
     container.setAttribute('aria-label', accessibleLabel);
-    container.title =
-      normalizedCommit && normalizedCommit !== 'unknown'
-        ? `Commit ${normalizedCommit}`
-        : 'Unversioned development build';
+    container.title = isCommitKnown
+      ? `Commit ${normalizedCommit}`
+      : 'Unversioned development build';
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -702,6 +702,22 @@ body > #game-container {
   font-size: clamp(12px, 1vw, 13px);
   letter-spacing: 0.18em;
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+  transition: background var(--transition-snappy), box-shadow var(--transition-snappy),
+    color var(--transition-snappy);
+}
+
+#build-id .build-id__value[data-build-state='commit'] {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), rgba(37, 99, 235, 0.12));
+  box-shadow:
+    0 18px 28px rgba(15, 23, 42, 0.55),
+    0 0 12px rgba(56, 189, 248, 0.35);
+  color: color-mix(in srgb, var(--color-foreground) 90%, white 10%);
+}
+
+#build-id .build-id__value[data-build-state='development'] {
+  background: color-mix(in srgb, var(--color-surface) 68%, transparent);
+  color: color-mix(in srgb, var(--color-muted) 85%, white 15%);
+  letter-spacing: 0.12em;
 }
 
 .sr-only {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="vite/client" />
 
-declare const __BUILD_COMMIT__: string;
+declare const __COMMIT__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import { getShortCommitHash } from './build-info';
 
-const buildCommit = getShortCommitHash();
+const GIT_COMMIT = JSON.stringify(getShortCommitHash());
 
 // Vite configuration
 export default defineConfig({
@@ -14,6 +14,6 @@ export default defineConfig({
     emptyOutDir: true,
   },
   define: {
-    __BUILD_COMMIT__: JSON.stringify(buildCommit),
+    __COMMIT__: GIT_COMMIT,
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vitest/config';
 import { getShortCommitHash } from './build-info';
 
-const buildCommit = getShortCommitHash();
+const GIT_COMMIT = JSON.stringify(getShortCommitHash());
 
 export default defineConfig({
   define: {
-    __BUILD_COMMIT__: JSON.stringify(buildCommit),
+    __COMMIT__: GIT_COMMIT,
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- compute the short git commit hash at build time and expose it as `__COMMIT__` for both Vite and Vitest builds
- surface the commit identifier in the HUD footer with accessible fallbacks and data attributes for stateful styling
- refine the build badge styling so production commits receive a luminous gradient treatment while development builds stay muted

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c932f5f8fc83308571ae264fd9451f