### PR TITLE
Expose build commit metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Resolve the current git commit via `git rev-parse --short HEAD`, expose it as
+  a shared `__COMMIT__` define, and use it for build-aware tooling and tests
+- Refresh the HUD build badge with a glowing commit chip that surfaces the
+  resolved hash (or a dev indicator) alongside improved accessibility metadata
 - Regenerate GitHub Pages artifacts by running the latest production build,
   syncing hashed bundles into `docs/`, duplicating the SPA fallback, and
   reaffirming the `.nojekyll` guard file

--- a/src/index.html
+++ b/src/index.html
@@ -14,9 +14,15 @@
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">
         <div id="resource-bar">Resources: 0</div>
-        <footer id="build-id" aria-live="polite">
+        <footer
+          id="build-id"
+          aria-live="polite"
+          aria-label="Development build"
+          data-build-state="development"
+          title="Unversioned development build"
+        >
           <span class="build-id__label">Build</span>
-          <span class="build-id__value" data-build-commit>—</span>
+          <span class="build-id__value" data-build-commit data-state="dev">—</span>
         </footer>
       </div>
     </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ interface TouchGestureState {
   moved: boolean;
 }
 
-function applyBuildMetadata(): void {
+function applyBuildIdentity(): void {
   if (typeof document === 'undefined') {
     return;
   }
@@ -42,30 +42,27 @@ function applyBuildMetadata(): void {
     return;
   }
 
-  const normalizedCommit =
-    typeof __BUILD_COMMIT__ === 'string' ? __BUILD_COMMIT__.trim() : '';
-  const displayValue =
-    normalizedCommit && normalizedCommit !== 'unknown'
-      ? normalizedCommit
-      : 'development';
+  const rawCommit = typeof __COMMIT__ === 'string' ? __COMMIT__.trim() : '';
+  const isCommitAvailable = rawCommit.length > 0 && rawCommit !== 'unknown';
 
+  const displayValue = isCommitAvailable ? `#${rawCommit}` : 'DEV BUILD';
   buildValueElement.textContent = displayValue;
+  buildValueElement.dataset.state = isCommitAvailable ? 'commit' : 'dev';
 
   const container = buildValueElement.closest<HTMLElement>('#build-id');
   if (container) {
-    const accessibleLabel =
-      normalizedCommit && normalizedCommit !== 'unknown'
-        ? `Build commit ${normalizedCommit}`
-        : 'Development build';
+    const accessibleLabel = isCommitAvailable
+      ? `Build commit ${rawCommit}`
+      : 'Development build';
     container.setAttribute('aria-label', accessibleLabel);
-    container.title =
-      normalizedCommit && normalizedCommit !== 'unknown'
-        ? `Commit ${normalizedCommit}`
-        : 'Unversioned development build';
+    container.title = isCommitAvailable
+      ? `Autobattles build ${rawCommit}`
+      : 'Unversioned development build';
+    container.dataset.buildState = isCommitAvailable ? 'release' : 'development';
   }
 }
 
-applyBuildMetadata();
+applyBuildIdentity();
 
 const cleanupHandlers: Array<() => void> = [];
 

--- a/src/style.css
+++ b/src/style.css
@@ -664,16 +664,42 @@ body > #game-container {
   align-self: flex-end;
   display: inline-flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 22px;
+  gap: clamp(12px, 1.8vw, 16px);
+  padding: 14px clamp(22px, 3vw, 28px);
   border-radius: var(--radius-pill);
-  border: 1px solid var(--hud-border);
-  background: linear-gradient(140deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
-  backdrop-filter: blur(18px) saturate(140%);
+  border: 1px solid transparent;
+  background:
+    linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.68));
+  backdrop-filter: blur(20px) saturate(160%);
   box-shadow: var(--shadow-soft);
   color: var(--color-muted);
   font-size: clamp(10px, 0.9vw, 12px);
   user-select: text;
+  overflow: hidden;
+  isolation: isolate;
+  transition:
+    border-color var(--transition-snappy),
+    box-shadow var(--transition-snappy),
+    transform var(--transition-snappy);
+}
+
+#build-id:hover,
+#build-id:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(8, 25, 53, 0.55);
+}
+
+#build-id::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  pointer-events: none;
+  background:
+    linear-gradient(120deg, rgba(56, 189, 248, 0.4), rgba(14, 116, 144, 0.12), rgba(14, 116, 144, 0));
+  opacity: 0.45;
+  z-index: 0;
+  transition: opacity var(--transition-snappy);
 }
 
 #build-id::after {
@@ -683,25 +709,95 @@ body > #game-container {
   border-radius: inherit;
   pointer-events: none;
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  z-index: 1;
+}
+
+#build-id [class^='build-id__'] {
+  position: relative;
+  z-index: 2;
+}
+
+#build-id[data-build-state='release'] {
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow:
+    0 18px 36px rgba(8, 25, 53, 0.6),
+    0 0 28px rgba(56, 189, 248, 0.28);
+}
+
+#build-id[data-build-state='release']::before {
+  opacity: 0.85;
+}
+
+#build-id[data-build-state='development']::before {
+  opacity: 0.35;
 }
 
 #build-id .build-id__label {
   font-weight: 600;
-  letter-spacing: 0.32em;
+  letter-spacing: 0.38em;
   text-transform: uppercase;
-  color: var(--color-muted);
+  color: color-mix(in srgb, var(--color-muted) 80%, white 20%);
+}
+
+#build-id[data-build-state='release'] .build-id__label {
+  color: color-mix(in srgb, var(--color-muted) 65%, white 35%);
 }
 
 #build-id .build-id__value {
-  padding: 4px 12px;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 16px;
   border-radius: var(--radius-pill);
   background: color-mix(in srgb, var(--color-surface) 72%, transparent);
   color: var(--color-foreground);
   font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Consolas,
     monospace;
   font-size: clamp(12px, 1vw, 13px);
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+  min-width: clamp(110px, 16vw, 148px);
+  transition:
+    background var(--transition-snappy),
+    color var(--transition-snappy),
+    box-shadow var(--transition-snappy),
+    opacity var(--transition-snappy);
+}
+
+#build-id .build-id__value::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0));
+  opacity: 0.35;
+  pointer-events: none;
+  transition: opacity var(--transition-snappy);
+  z-index: 1;
+}
+
+#build-id .build-id__value[data-state='dev'] {
+  color: color-mix(in srgb, var(--color-foreground) 75%, white 25%);
+  opacity: 0.85;
+}
+
+#build-id .build-id__value[data-state='dev']::before {
+  opacity: 0.22;
+}
+
+#build-id[data-build-state='release'] .build-id__value {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), rgba(56, 189, 248, 0.45));
+  box-shadow:
+    0 18px 32px rgba(56, 189, 248, 0.35),
+    0 4px 18px rgba(8, 25, 53, 0.55);
+  color: color-mix(in srgb, var(--color-foreground) 95%, white 5%);
+}
+
+#build-id[data-build-state='release'] .build-id__value::before {
+  opacity: 0.5;
 }
 
 .sr-only {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="vite/client" />
 
-declare const __BUILD_COMMIT__: string;
+declare const __COMMIT__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,21 @@
+import { execSync } from 'node:child_process';
 import { defineConfig } from 'vite';
-import { getShortCommitHash } from './build-info';
 
-const buildCommit = getShortCommitHash();
+let GIT_COMMIT = JSON.stringify('unknown');
+
+try {
+  const commit = execSync('git rev-parse --short HEAD', {
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+    .toString()
+    .trim();
+
+  if (commit) {
+    GIT_COMMIT = JSON.stringify(commit);
+  }
+} catch (error) {
+  console.warn('Unable to resolve git commit hash:', error);
+}
 
 // Vite configuration
 export default defineConfig({
@@ -14,6 +28,6 @@ export default defineConfig({
     emptyOutDir: true,
   },
   define: {
-    __BUILD_COMMIT__: JSON.stringify(buildCommit),
+    __COMMIT__: GIT_COMMIT,
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vitest/config';
 import { getShortCommitHash } from './build-info';
 
-const buildCommit = getShortCommitHash();
+const gitCommit = getShortCommitHash();
 
 export default defineConfig({
   define: {
-    __BUILD_COMMIT__: JSON.stringify(buildCommit),
+    __COMMIT__: JSON.stringify(gitCommit),
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- resolve the git short hash in the Vite config and expose it via a shared `__COMMIT__` define
- update the entrypoint, markup, and type declarations to render the commit badge or a dev fallback in the HUD
- refresh the HUD badge styling to deliver a polished, commit-aware presentation and document the change in the changelog

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68c935eaeec88330b478016f2c477426