### PR TITLE
Replace deploy workflow with GitHub Pages pipeline

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Pages
 
 on:
   push:
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 jobs:
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,11 +16,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
-      - run: npm ci
-      - run: npm run build
-      - run: rm -rf docs && cp -r dist docs
+      - name: Install dependencies
+        run: npm ci
+      - name: Build project
+        run: npm run build
+      - name: Prepare docs artifacts
+        run: |
+          rm -rf docs
+          mkdir -p docs
+          cp -R dist/* docs/
+          cp docs/index.html docs/404.html
+          touch docs/.nojekyll
+      - name: Smoke checks
+        run: npm run test
       - name: Commit docs
         run: |
           git config user.name "${{ github.actor }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Replace the legacy deploy workflow with a Node.js 20 GitHub Pages pipeline
+  that rebuilds docs, reruns smoke checks, and commits refreshed artifacts
 - Resolve the current git commit via `git rev-parse --short HEAD`, expose it as
   a shared `__COMMIT__` define, and use it for build-aware tooling and tests
 - Refresh the HUD build badge with a glowing commit chip that surfaces the


### PR DESCRIPTION
## Summary
- replace the legacy deploy workflow with a Node.js 20 GitHub Pages pipeline that builds the site, prepares docs artifacts, runs smoke checks, and commits the output
- document the workflow change in the changelog

## Testing
- npm run build
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68c93a2466788330ade86ef21bc5c6bd