### PR TITLE
Add dev diagnostics for Saunoja storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Add development-only Saunoja diagnostics that confirm storage seeding and log
+  restored attendant coordinates after loading
 - Simplify GitHub Pages deployment by publishing the raw `dist/` output with the
   official Pages actions, removing the repository-managed `docs/` mirror, and
   introducing a polished SPA-friendly 404 fallback in `public/404.html`

--- a/src/game.ts
+++ b/src/game.ts
@@ -213,6 +213,14 @@ if (saunojas.length === 0) {
     })
   );
   saveUnits();
+  if (import.meta.env.DEV) {
+    const storage = getSaunojaStorage();
+    const storedValue = storage?.getItem(SAUNOJA_STORAGE_KEY);
+    console.debug('Seeded Saunoja storage with default attendant', {
+      storageAvailable: Boolean(storage),
+      storageKeyPresent: typeof storedValue === 'string'
+    });
+  }
 } else {
   let foundSelected = false;
   let selectionDirty = false;
@@ -228,6 +236,12 @@ if (saunojas.length === 0) {
   if (selectionDirty) {
     saveUnits();
   }
+}
+if (import.meta.env.DEV) {
+  console.debug('Saunoja roster restored', {
+    count: saunojas.length,
+    coordinates: saunojas.map((unit) => ({ q: unit.coord.q, r: unit.coord.r }))
+  });
 }
 const updateSaunaUI = setupSaunaUI(sauna);
 const updateTopbar = setupTopbar(state, {


### PR DESCRIPTION
## Summary
- add development-only debug output confirming Saunoja storage seeding and logging restored coordinates
- document the new diagnostics in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c941e75d1c8330b242b6981e34ed17