### PR TITLE
Align sauna controls with top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Anchor the sauna controls within the polished HUD top bar, style the sauna
+  toggle with premium gradients, and ensure the overlay keeps pointer
+  interactions enabled for those controls
 - Simplify GitHub Pages deployment by publishing the raw `dist/` output with the
   official Pages actions, removing the repository-managed `docs/` mirror, and
   introducing a polished SPA-friendly 404 fallback in `public/404.html`

--- a/src/style.css
+++ b/src/style.css
@@ -148,6 +148,10 @@ body > #game-container {
 
 #topbar {
   pointer-events: auto;
+  position: absolute;
+  top: clamp(18px, 3vw, 32px);
+  left: 50%;
+  transform: translateX(-50%);
   display: inline-flex;
   align-items: center;
   gap: clamp(14px, 2vw, 22px);
@@ -160,6 +164,8 @@ body > #game-container {
   box-shadow: var(--shadow-soft);
   color: var(--color-foreground);
   white-space: nowrap;
+  z-index: 4;
+  max-width: min(92%, 960px);
 }
 
 .topbar-badge {
@@ -251,6 +257,22 @@ body > #game-container {
 .topbar-button[aria-pressed="true"] {
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(30, 64, 175, 0.4));
   box-shadow: var(--shadow-glow);
+}
+
+.sauna-button {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.28), rgba(251, 191, 36, 0.2));
+  border-color: color-mix(in srgb, var(--color-warning) 50%, transparent);
+  box-shadow: 0 18px 34px rgba(248, 113, 113, 0.26);
+}
+
+.sauna-button:hover,
+.sauna-button:focus-visible {
+  box-shadow: 0 22px 44px rgba(248, 113, 113, 0.35);
+  border-color: color-mix(in srgb, var(--color-warning) 65%, transparent);
+}
+
+.sauna-button:active {
+  box-shadow: 0 12px 22px rgba(248, 113, 113, 0.3);
 }
 
 #resource-bar {
@@ -964,6 +986,13 @@ body > #game-container {
   .hud-row {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  #topbar {
+    position: static;
+    transform: none;
+    margin: 0 auto;
+    max-width: 100%;
   }
 
   #topbar,

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -5,10 +5,30 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   if (!overlay) return () => {};
 
   const btn = document.createElement('button');
+  btn.type = 'button';
   btn.textContent = 'Sauna \u2668\ufe0f';
-  overlay.appendChild(btn);
+  btn.classList.add('topbar-button', 'sauna-button');
+  btn.setAttribute('aria-expanded', 'false');
+
+  const attachToTopbar = (): boolean => {
+    const topbar = document.getElementById('topbar');
+    if (!topbar) return false;
+    topbar.appendChild(btn);
+    return true;
+  };
+
+  if (!attachToTopbar()) {
+    const observer = new MutationObserver(() => {
+      if (attachToTopbar()) {
+        observer.disconnect();
+      }
+    });
+    observer.observe(overlay, { childList: true });
+  }
 
   const card = document.createElement('div');
+  const cardId = 'sauna-control-card';
+  card.id = cardId;
   card.style.position = 'absolute';
   card.style.left = '0';
   card.style.top = '0';
@@ -17,6 +37,8 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   card.style.padding = '8px';
   card.style.display = 'none';
   card.style.minWidth = '120px';
+  card.style.pointerEvents = 'auto';
+  card.style.zIndex = '5';
 
   const barContainer = document.createElement('div');
   barContainer.style.height = '8px';
@@ -42,8 +64,12 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   overlay.appendChild(card);
 
   btn.addEventListener('click', () => {
-    card.style.display = card.style.display === 'none' ? 'block' : 'none';
+    const isHidden = card.style.display === 'none';
+    card.style.display = isHidden ? 'block' : 'none';
+    btn.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
   });
+
+  btn.setAttribute('aria-controls', cardId);
 
   return () => {
     const progress = 1 - sauna.timer / sauna.spawnCooldown;


### PR DESCRIPTION
## Summary
- mount the sauna toggle into the shared top bar and expose accessibility metadata for the control panel
- reposition and restyle the HUD bar so it stays pinned to the top while keeping interactive elements responsive
- document the HUD adjustment in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9433cf3a08330a6b49ab29ad97239