### PR TITLE
Refine HUD layout and sauna controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Recompose the HUD layout so the build menu and sauna controls live beside a
+  fixed-width right panel, eliminating overlap and polishing the top-row
+  alignment
 - Add development-only Saunoja diagnostics that confirm storage seeding and log
   restored attendant coordinates after loading
 - Simplify GitHub Pages deployment by publishing the raw `dist/` output with the

--- a/src/style.css
+++ b/src/style.css
@@ -23,6 +23,7 @@
   --radius-panel: 24px;
   --radius-pill: 999px;
   --transition-snappy: 180ms ease;
+  --hud-padding: clamp(16px, 2.5vw, 32px);
   color: var(--color-foreground);
   background-color: var(--color-background);
   font-synthesis: none;
@@ -133,10 +134,11 @@ body > #game-container {
   pointer-events: none;
   position: absolute;
   inset: 0;
-  padding: clamp(16px, 2.5vw, 32px);
+  padding: var(--hud-padding);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: clamp(20px, 3vw, 32px);
 }
 
 .hud-row {
@@ -144,6 +146,39 @@ body > #game-container {
   align-items: flex-start;
   justify-content: space-between;
   gap: clamp(16px, 2vw, 28px);
+}
+
+.hud-top-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(20px, 3vw, 36px);
+  width: 100%;
+}
+
+.hud-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: clamp(16px, 2.4vw, 24px);
+  max-width: min(620px, 58vw);
+}
+
+.hud-actions > * {
+  pointer-events: auto;
+}
+
+.hud-right-column {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: clamp(18px, 2vw, 24px);
+  width: fit-content;
+  max-width: min(360px, 32vw);
+}
+
+.hud-right-column > * {
+  pointer-events: auto;
 }
 
 #topbar {
@@ -255,9 +290,7 @@ body > #game-container {
 
 #resource-bar {
   pointer-events: auto;
-  position: absolute;
-  top: clamp(18px, 3vw, 32px);
-  right: clamp(20px, 3vw, 40px);
+  align-self: flex-end;
   display: inline-flex;
   align-items: center;
   gap: 16px;
@@ -295,49 +328,22 @@ body > #game-container {
   text-shadow: 0 0 20px rgba(56, 189, 248, 0.4);
 }
 
-#event-log {
-  pointer-events: auto;
-  max-width: min(320px, 28vw);
-  padding: clamp(16px, 2vw, 20px);
-  border-radius: var(--radius-panel);
-  border: 1px solid var(--hud-border);
-  background: linear-gradient(160deg, rgba(15, 23, 42, 0.84), rgba(15, 23, 42, 0.68));
-  backdrop-filter: blur(16px);
-  box-shadow: var(--shadow-soft);
-  color: var(--color-muted);
-}
-
-#event-log h2 {
-  margin: 0 0 12px;
-  font-size: 14px;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--color-foreground);
-}
-
-#event-log ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 8px;
-  font-size: 13px;
-  line-height: 1.4;
-}
-
 #build-menu {
   pointer-events: auto;
-  display: inline-flex;
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 12px;
-  padding: 16px;
-  border-radius: var(--radius-pill);
+  padding: 18px clamp(20px, 3vw, 28px);
+  border-radius: var(--radius-panel);
   border: 1px solid var(--hud-border);
   background:
-    linear-gradient(140deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.6));
+    linear-gradient(145deg, rgba(15, 23, 42, 0.84), rgba(15, 23, 42, 0.6));
   backdrop-filter: blur(18px);
   box-shadow: var(--shadow-soft);
+  align-self: stretch;
+  width: min(100%, 580px);
 }
 
 #build-menu button {
@@ -366,6 +372,227 @@ body > #game-container {
 
 #build-menu button:active {
   transform: translateY(0);
+}
+
+.hud-card {
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 1.8vw, 18px);
+  padding: clamp(18px, 2.4vw, 24px);
+  border-radius: var(--radius-panel);
+  border: 1px solid var(--hud-border);
+  background:
+    linear-gradient(150deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.66));
+  backdrop-filter: blur(18px) saturate(120%);
+  box-shadow: var(--shadow-soft);
+}
+
+#right-panel {
+  flex: 0 0 clamp(240px, 26vw, 300px);
+  max-height: calc(100vh - (var(--hud-padding) * 2));
+  color: var(--color-foreground);
+  overflow: hidden;
+  z-index: 140;
+  align-self: flex-start;
+}
+
+.panel-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--color-surface) 65%, transparent);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.panel-tabs button {
+  pointer-events: auto;
+  padding: 8px 18px;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--color-surface) 55%, transparent);
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  transition: transform var(--transition-snappy), background var(--transition-snappy),
+    border-color var(--transition-snappy), box-shadow var(--transition-snappy), color var(--transition-snappy);
+}
+
+.panel-tabs button:not(:disabled):hover,
+.panel-tabs button:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  box-shadow: 0 18px 36px rgba(56, 189, 248, 0.32);
+  color: var(--color-foreground);
+  outline: none;
+}
+
+.panel-tabs button:disabled {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.28), rgba(37, 99, 235, 0.42));
+  color: var(--color-foreground);
+  box-shadow: 0 18px 36px rgba(56, 189, 248, 0.25);
+  cursor: default;
+}
+
+.panel-content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 2vw, 18px);
+  min-height: 0;
+}
+
+.panel-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.panel-section--scroll {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 6px;
+  scrollbar-gutter: stable both-edges;
+}
+
+.panel-section--log {
+  gap: 10px;
+}
+
+.panel-event {
+  display: grid;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--color-surface) 65%, transparent);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+}
+
+.panel-event h4 {
+  margin: 0;
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-foreground);
+}
+
+.panel-event p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-muted);
+}
+
+.panel-action {
+  pointer-events: auto;
+  align-self: flex-start;
+  padding: 12px 20px;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 22%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 16%, transparent);
+  color: var(--color-foreground);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy),
+    background var(--transition-snappy), border-color var(--transition-snappy), color var(--transition-snappy);
+}
+
+.panel-action:not(:disabled):hover,
+.panel-action:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 28%, transparent);
+  box-shadow: 0 16px 32px rgba(56, 189, 248, 0.3);
+  outline: none;
+}
+
+.panel-action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.panel-log-entry {
+  padding: 10px 14px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--color-surface) 58%, transparent);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  color: var(--color-muted);
+  font-size: 13px;
+}
+
+.sauna-control {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  pointer-events: auto;
+  align-self: flex-start;
+}
+
+.sauna-toggle {
+  pointer-events: auto;
+}
+
+.sauna-card {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  display: grid;
+  gap: 12px;
+  min-width: clamp(220px, 26vw, 260px);
+  padding: clamp(16px, 2vw, 20px);
+  z-index: 160;
+  box-shadow: 0 24px 48px rgba(8, 25, 53, 0.45);
+}
+
+.sauna-card[hidden] {
+  display: none;
+}
+
+.sauna-progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-surface) 60%, transparent);
+  overflow: hidden;
+}
+
+.sauna-progress__fill {
+  width: 0%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--color-accent), color-mix(in srgb, var(--color-accent) 40%, var(--color-warning) 60%));
+  transition: width 240ms ease;
+}
+
+.sauna-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-foreground);
+}
+
+.sauna-option__input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-accent);
+}
+
+.sauna-option__label {
+  color: var(--color-muted);
 }
 
 .loading-message {
@@ -961,24 +1188,50 @@ body > #game-container {
     gap: 16px;
   }
 
-  .hud-row {
+  .hud-top-row {
     flex-direction: column;
     align-items: stretch;
+    gap: 16px;
+  }
+
+  .hud-actions {
+    max-width: 100%;
+  }
+
+  .hud-right-column {
+    align-items: stretch;
+    width: 100%;
+    max-width: 100%;
+    gap: 16px;
   }
 
   #topbar,
   #build-menu,
   #resource-bar {
     align-self: stretch;
+  }
+
+  #build-menu {
     justify-content: center;
   }
 
   #resource-bar {
-    position: static;
+    justify-content: center;
   }
 
-  #event-log {
-    max-width: 100%;
+  #right-panel {
+    flex: 1 1 auto;
+    width: 100%;
+    max-height: none;
+  }
+
+  .sauna-card {
+    position: relative;
+    top: 0;
+    left: 0;
+    width: 100%;
+    min-width: 0;
+    margin-top: 8px;
   }
 }
 

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,0 +1,40 @@
+export type HudLayout = {
+  container: HTMLDivElement;
+  actions: HTMLDivElement;
+  side: HTMLDivElement;
+};
+
+export function ensureHudLayout(overlay: HTMLElement): HudLayout {
+  let container = overlay.querySelector<HTMLDivElement>('.hud-top-row');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'hud-top-row';
+    overlay.prepend(container);
+  }
+
+  let actions = container.querySelector<HTMLDivElement>('.hud-actions');
+  if (!actions) {
+    actions = document.createElement('div');
+    actions.className = 'hud-actions';
+    container.appendChild(actions);
+  }
+
+  let side = container.querySelector<HTMLDivElement>('.hud-right-column');
+  if (!side) {
+    side = document.createElement('div');
+    side.className = 'hud-right-column';
+    container.appendChild(side);
+
+    const resourceBar = overlay.querySelector<HTMLElement>('#resource-bar');
+    if (resourceBar) {
+      side.prepend(resourceBar);
+    }
+  }
+
+  const buildMenu = overlay.querySelector<HTMLElement>('#build-menu');
+  if (buildMenu && buildMenu.parentElement !== actions) {
+    actions.appendChild(buildMenu);
+  }
+
+  return { container, actions, side };
+}

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -1,48 +1,56 @@
 import type { Sauna } from '../sim/sauna.ts';
+import { ensureHudLayout } from './layout.ts';
 
 export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   const overlay = document.getElementById('ui-overlay');
   if (!overlay) return () => {};
 
+  const { actions } = ensureHudLayout(overlay);
+
+  const container = document.createElement('div');
+  container.classList.add('sauna-control');
+
   const btn = document.createElement('button');
+  btn.type = 'button';
   btn.textContent = 'Sauna \u2668\ufe0f';
-  overlay.appendChild(btn);
+  btn.classList.add('topbar-button', 'sauna-toggle');
+  btn.setAttribute('aria-expanded', 'false');
+  container.appendChild(btn);
 
   const card = document.createElement('div');
-  card.style.position = 'absolute';
-  card.style.left = '0';
-  card.style.top = '0';
-  card.style.background = 'rgba(0,0,0,0.7)';
-  card.style.color = '#fff';
-  card.style.padding = '8px';
-  card.style.display = 'none';
-  card.style.minWidth = '120px';
+  card.classList.add('sauna-card', 'hud-card');
+  card.hidden = true;
 
   const barContainer = document.createElement('div');
-  barContainer.style.height = '8px';
-  barContainer.style.background = '#555';
+  barContainer.classList.add('sauna-progress');
   const barFill = document.createElement('div');
-  barFill.style.height = '100%';
-  barFill.style.background = '#0f0';
-  barFill.style.width = '0%';
+  barFill.classList.add('sauna-progress__fill');
   barContainer.appendChild(barFill);
   card.appendChild(barContainer);
 
   const label = document.createElement('label');
+  label.classList.add('sauna-option');
   const checkbox = document.createElement('input');
   checkbox.type = 'checkbox';
+  checkbox.classList.add('sauna-option__input');
   checkbox.checked = sauna.rallyToFront;
   checkbox.addEventListener('change', () => {
     sauna.rallyToFront = checkbox.checked;
   });
   label.appendChild(checkbox);
-  label.appendChild(document.createTextNode(' Rally to Front'));
+  const labelText = document.createElement('span');
+  labelText.textContent = 'Rally to Front';
+  labelText.classList.add('sauna-option__label');
+  label.appendChild(labelText);
   card.appendChild(label);
 
-  overlay.appendChild(card);
+  container.appendChild(card);
+  actions.appendChild(container);
 
   btn.addEventListener('click', () => {
-    card.style.display = card.style.display === 'none' ? 'block' : 'none';
+    const nextHidden = !card.hidden;
+    card.hidden = nextHidden;
+    btn.setAttribute('aria-expanded', String(!nextHidden));
   });
 
   return () => {

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -1,6 +1,7 @@
 import { eventBus } from '../events';
 import { setMuted, isMuted } from '../sfx.ts';
 import { GameState, Resource } from '../core/GameState.ts';
+import { ensureHudLayout } from './layout.ts';
 
 type Badge = {
   container: HTMLDivElement;
@@ -56,9 +57,11 @@ export function setupTopbar(state: GameState, icons: TopbarIcons = {}): (deltaMs
   const overlay = document.getElementById('ui-overlay');
   if (!overlay) return () => {};
 
+  const { actions } = ensureHudLayout(overlay);
+
   const bar = document.createElement('div');
   bar.id = 'topbar';
-  overlay.appendChild(bar);
+  actions.prepend(bar);
 
   const saunakunnia = createBadge('Saunakunnia', icons.saunakunnia);
   saunakunnia.container.classList.add('badge-sauna');


### PR DESCRIPTION
## Summary
- introduce a shared HUD layout helper so the top-bar actions and right-column HUD elements share a consistent structure
- reposition the right panel and sauna controls into the action column, restyling their tabs/cards to eliminate overlap with the build menu
- refresh HUD styling (including build menu and responsive rules) and document the layout adjustments in the changelog

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c94371e3a08330b9608e83eab54faf