### PR TITLE
Route sauna controls through the HUD top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Anchor the sauna HUD toggle within the shared top bar and refresh styling so
+  interactive controls remain pointer-enabled at the top of the overlay
 - Add development-only Saunoja diagnostics that confirm storage seeding and log
   restored attendant coordinates after loading
 - Simplify GitHub Pages deployment by publishing the raw `dist/` output with the

--- a/src/style.css
+++ b/src/style.css
@@ -148,6 +148,10 @@ body > #game-container {
 
 #topbar {
   pointer-events: auto;
+  position: absolute;
+  top: clamp(18px, 3vw, 32px);
+  left: 50%;
+  transform: translateX(-50%);
   display: inline-flex;
   align-items: center;
   gap: clamp(14px, 2vw, 22px);
@@ -160,6 +164,7 @@ body > #game-container {
   box-shadow: var(--shadow-soft);
   color: var(--color-foreground);
   white-space: nowrap;
+  z-index: 210;
 }
 
 .topbar-badge {
@@ -251,6 +256,21 @@ body > #game-container {
 .topbar-button[aria-pressed="true"] {
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(30, 64, 175, 0.4));
   box-shadow: var(--shadow-glow);
+}
+
+.sauna-button {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.26), rgba(249, 115, 22, 0.22));
+  border-color: color-mix(in srgb, var(--color-warning) 35%, transparent);
+  box-shadow: 0 14px 28px rgba(249, 115, 22, 0.32);
+}
+
+.sauna-button:hover,
+.sauna-button:focus-visible {
+  box-shadow: 0 20px 40px rgba(249, 115, 22, 0.44);
+}
+
+.sauna-button:active {
+  transform: translateY(0);
 }
 
 #resource-bar {
@@ -959,6 +979,15 @@ body > #game-container {
   #ui-overlay {
     padding: 16px;
     gap: 16px;
+  }
+
+  #topbar {
+    position: static;
+    transform: none;
+    left: auto;
+    right: auto;
+    margin: 0 auto;
+    width: 100%;
   }
 
   .hud-row {

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -4,9 +4,22 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   const overlay = document.getElementById('ui-overlay');
   if (!overlay) return () => {};
 
+  let topbar = document.getElementById('topbar') as HTMLDivElement | null;
+  if (!topbar) {
+    topbar = document.createElement('div');
+    topbar.id = 'topbar';
+    overlay.appendChild(topbar);
+  } else if (topbar.parentElement !== overlay) {
+    overlay.appendChild(topbar);
+  }
+
   const btn = document.createElement('button');
+  btn.type = 'button';
   btn.textContent = 'Sauna \u2668\ufe0f';
-  overlay.appendChild(btn);
+  btn.classList.add('topbar-button', 'sauna-button');
+  btn.setAttribute('aria-expanded', 'false');
+  btn.setAttribute('aria-haspopup', 'true');
+  topbar.appendChild(btn);
 
   const card = document.createElement('div');
   card.style.position = 'absolute';
@@ -17,6 +30,7 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   card.style.padding = '8px';
   card.style.display = 'none';
   card.style.minWidth = '120px';
+  card.style.pointerEvents = 'auto';
 
   const barContainer = document.createElement('div');
   barContainer.style.height = '8px';
@@ -42,7 +56,9 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   overlay.appendChild(card);
 
   btn.addEventListener('click', () => {
-    card.style.display = card.style.display === 'none' ? 'block' : 'none';
+    const isHidden = card.style.display === 'none';
+    card.style.display = isHidden ? 'block' : 'none';
+    btn.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
   });
 
   return () => {

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -56,9 +56,19 @@ export function setupTopbar(state: GameState, icons: TopbarIcons = {}): (deltaMs
   const overlay = document.getElementById('ui-overlay');
   if (!overlay) return () => {};
 
-  const bar = document.createElement('div');
-  bar.id = 'topbar';
-  overlay.appendChild(bar);
+  let bar = document.getElementById('topbar') as HTMLDivElement | null;
+  if (!bar) {
+    bar = document.createElement('div');
+    bar.id = 'topbar';
+    overlay.appendChild(bar);
+  } else if (bar.parentElement !== overlay) {
+    overlay.appendChild(bar);
+  }
+
+  const preservedActions = Array.from(bar.querySelectorAll<HTMLElement>('.topbar-button'));
+  for (const action of preservedActions) {
+    bar.removeChild(action);
+  }
 
   const saunakunnia = createBadge('Saunakunnia', icons.saunakunnia);
   saunakunnia.container.classList.add('badge-sauna');
@@ -115,6 +125,10 @@ export function setupTopbar(state: GameState, icons: TopbarIcons = {}): (deltaMs
   });
   renderMute();
   bar.appendChild(muteBtn);
+
+  for (const action of preservedActions) {
+    bar.appendChild(action);
+  }
 
   eventBus.on('sisuPulseStart', ({ remaining }) => {
     sisuBtn.disabled = true;


### PR DESCRIPTION
## Summary
- route the sauna toggle through the shared HUD top bar and expose aria state for the menu
- reuse any pre-existing top bar container when initializing the HUD and style the sauna button with a polished accent
- anchor the bar at the top of the overlay and log the refinement in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c945f29d9c833085d16af1043848de