### PR TITLE
Set Vite base to root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Set Vite `base` to `/` so production builds resolve polished assets from the
+  site root without relying on a subdirectory deployment
 - Recompose the HUD layout so the build menu and sauna controls live beside a
   fixed-width right panel, eliminating overlap and polishing the top-row
   alignment

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ try {
 export default defineConfig({
   root: 'src',
   // Ensure assets resolve correctly when hosted on GitHub Pages.
-  base: '/autobattles4xfinsauna/',
+  base: '/',
   publicDir: '../public',
   build: {
     outDir: '../dist',


### PR DESCRIPTION
## Summary
- point Vite's base configuration at the site root so bundles resolve without a subdirectory
- document the base-path adjustment in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c94fee9d9c83309a851dedaf4932b2