### PR TITLE
Relocate CNAME into public assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Relocate `CNAME` from `docs/` to `public/` so production builds retain the
+  custom domain via Vite's static asset pipeline
 - Set Vite `base` to `/` so production builds resolve polished assets from the
   site root without relying on a subdirectory deployment
 - Recompose the HUD layout so the build menu and sauna controls live beside a

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-www.artobest.com

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+www.artobest.com


### PR DESCRIPTION
## Summary
- move the GitHub Pages CNAME record from docs/ into public/ so builds publish it
- document the relocation in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c950e0a198833097a630de8b1ecebd