### PR TITLE
Update live site metadata to artobest.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Point the documented live demo links and npm `homepage` metadata to
+  https://www.artobest.com/ so references match the production site
 - Relocate `CNAME` from `docs/` to `public/` so production builds retain the
   custom domain via Vite's static asset pipeline
 - Set Vite `base` to `/` so production builds resolve polished assets from the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for considering a contribution!
 
 - Ensure the README's "Live Demo" link points to:
-  https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com
+  https://www.artobest.com/?utm_source=chatgpt.com
 - Run the full CI workflow locally before pushing:
   - `npm test`
   - `npm run build`

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ npm install
 - `npm run build` – compile TypeScript and bundle the production build.
 - `npm run preview` – preview the built app locally.
 - `npm test` – run the test suite with Vitest.
-- `npm run check:demo` – verify the README demo link and ensure the GitHub Pages
-  deployment responds with a 200 status and contains the game's
+- `npm run check:demo` – verify the README demo link and ensure the live site
+  responds with a 200 status and contains the game's
   `<title>Autobattles4xFinsauna</title>` tag.
 
 ## Gameplay
@@ -48,7 +48,7 @@ npm run build
 The production files are written to `dist/`.
 
 ## Live Demo
-Deployed on GitHub Pages: https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com
+Experience the latest build at https://www.artobest.com/?utm_source=chatgpt.com
 
 ## Running Tests
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "autobattles4xfinsauna",
   "private": true,
   "version": "0.0.0",
-  "homepage": "https://wasab1kastike.github.io/autobattles4xfinsauna/",
+  "homepage": "https://www.artobest.com/",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/check-demo-link.js
+++ b/scripts/check-demo-link.js
@@ -5,8 +5,7 @@ import { dirname, join } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const readmePath = join(__dirname, '..', 'README.md');
 const readme = readFileSync(readmePath, 'utf8');
-const demoUrl =
-  'https://wasab1kastike.github.io/autobattles4xfinsauna/?utm_source=chatgpt.com';
+const demoUrl = 'https://www.artobest.com/?utm_source=chatgpt.com';
 const expectedTitle = '<title>Autobattles4xFinsauna</title>';
 
 if (!readme.includes(demoUrl)) {


### PR DESCRIPTION
## Summary
- point the package homepage and live demo documentation to https://www.artobest.com/
- update the demo link check script so automated verification targets the new domain
- record the domain migration in the changelog for future releases

## Testing
- npm run build
- npm run check:demo

------
https://chatgpt.com/codex/tasks/task_e_68c9548569d48330a2bcf848f2115ef1