### PR TITLE
Document root-based Vite build verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Confirm Vite's root-level base path configuration and regenerate the
+  production build to deliver `/assets/`-prefixed bundles for the GitHub Pages
+  workflow
 - Point the documented live demo links and npm `homepage` metadata to
   https://www.artobest.com/ so references match the production site
 - Relocate `CNAME` from `docs/` to `public/` so production builds retain the


### PR DESCRIPTION
## Summary
- document the root-level Vite base configuration remains in place
- note that a fresh production build emits /assets/ hashed bundles for Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9592c42c88330aa7bdb243d189edf