### PR TITLE
Attach sauna controls to top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Mount the sauna toggle and dropdown directly to the polished top bar so the
+  controls align with other HUD actions
 - Update the custom domain configuration and documentation to serve the live
   build from https://artobest.com/ after the DNS cutover
 - Confirm Vite's root-level base path configuration and regenerate the

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -1,11 +1,8 @@
 import type { Sauna } from '../sim/sauna.ts';
-import { ensureHudLayout } from './layout.ts';
 
 export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   const overlay = document.getElementById('ui-overlay');
   if (!overlay) return () => {};
-
-  const { actions } = ensureHudLayout(overlay);
 
   const container = document.createElement('div');
   container.classList.add('sauna-control');
@@ -45,7 +42,24 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   card.appendChild(label);
 
   container.appendChild(card);
-  actions.appendChild(container);
+
+  const attachToTopbar = (): HTMLDivElement | null => {
+    const topbar = overlay.querySelector<HTMLDivElement>('#topbar');
+    if (!topbar) return null;
+    if (container.parentElement !== topbar) {
+      topbar.appendChild(container);
+    }
+    return topbar;
+  };
+
+  if (!attachToTopbar()) {
+    const observer = new MutationObserver(() => {
+      if (attachToTopbar()) {
+        observer.disconnect();
+      }
+    });
+    observer.observe(overlay, { childList: true, subtree: true });
+  }
 
   btn.addEventListener('click', () => {
     const nextHidden = !card.hidden;


### PR DESCRIPTION
## Summary
- mount the sauna HUD container onto the `#topbar` element once it appears so the dropdown remains positioned beneath the bar
- record the control relocation in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9602ea5548330903a69bb0eecd93d