### PR TITLE
Ensure game boots after DOM is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Wait for the DOM to finish parsing before bootstrapping the canvas so the
+  artobest.com deployment reliably mounts the game shell on every visit
 - Mount the sauna toggle and dropdown directly to the polished top bar so the
   controls align with other HUD actions
 - Update the custom domain configuration and documentation to serve the live

--- a/src/main.ts
+++ b/src/main.ts
@@ -771,6 +771,13 @@ export function init(): void {
   const canvas = document.getElementById('game-canvas') as HTMLCanvasElement | null;
   const resourceBar = document.getElementById('resource-bar');
   if (!canvas || !resourceBar) {
+    console.error(
+      'Autobattles4xFinsauna shell is missing the required canvas or resource bar elements.',
+      {
+        hasCanvas: Boolean(canvas),
+        hasResourceBar: Boolean(resourceBar),
+      }
+    );
     return;
   }
 
@@ -800,7 +807,25 @@ export function init(): void {
   }
 }
 
+function initWhenDomReady(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const start = () => {
+    document.removeEventListener('DOMContentLoaded', start);
+    init();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+    return;
+  }
+
+  start();
+}
+
 if (!import.meta.vitest) {
-  init();
+  initWhenDomReady();
 }
 


### PR DESCRIPTION
## Summary
- defer game initialization until the DOM has finished parsing so the artobest.com deployment consistently mounts the canvas
- log a diagnostic error when the canvas or resource bar shell elements are missing
- document the bootstrap fix in the changelog

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c96583a0ac8330936a95f78bd67c27