### PR TITLE
Ensure game boots after DOM is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Wait for the DOM to finish parsing before bootstrapping the canvas so the
+  artobest.com deployment reliably mounts the game shell on every visit
+- Document the DOM-ready requirement and troubleshooting steps for external
+  hosts so blank-screen issues can be resolved quickly
 - Mount the sauna toggle and dropdown directly to the polished top bar so the
   controls align with other HUD actions
 - Update the custom domain configuration and documentation to serve the live

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ The production files are written to `dist/`.
 ## Live Demo
 Experience the latest build at https://artobest.com/?utm_source=chatgpt.com
 
+## Troubleshooting
+
+### Canvas fails to render on artobest.com or other hosts
+
+If the live site loads without showing the canvas or HUD, confirm the hosting
+shell matches the expected structure:
+
+1. Ensure the HTML includes both `<canvas id="game-canvas"></canvas>` and a
+   `<div id="resource-bar"></div>` element before loading the entry module.
+2. Load `src/main.ts` after the DOM has been parsed (for example, place the
+   `<script type="module" src="./main.ts"></script>` tag at the end of the
+   `<body>` or invoke `init()` after the `DOMContentLoaded` event).
+3. Open the browser console to review diagnostics—the bootstrapper now logs a
+   descriptive error when either required element is missing.
+
 ## Running Tests
 
 ```bash

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,8 +62,6 @@ function applyBuildIdentity(): void {
   }
 }
 
-applyBuildIdentity();
-
 const cleanupHandlers: Array<() => void> = [];
 
 let initToken = 0;
@@ -768,9 +766,18 @@ async function prepareAndStart(runToken: number): Promise<void> {
 }
 
 export function init(): void {
+  applyBuildIdentity();
+
   const canvas = document.getElementById('game-canvas') as HTMLCanvasElement | null;
   const resourceBar = document.getElementById('resource-bar');
   if (!canvas || !resourceBar) {
+    console.error(
+      'Autobattles4xFinsauna shell is missing the required canvas or resource bar elements.',
+      {
+        hasCanvas: Boolean(canvas),
+        hasResourceBar: Boolean(resourceBar),
+      }
+    );
     return;
   }
 
@@ -800,7 +807,25 @@ export function init(): void {
   }
 }
 
+function initWhenDomReady(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const start = () => {
+    document.removeEventListener('DOMContentLoaded', start);
+    init();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+    return;
+  }
+
+  start();
+}
+
 if (!import.meta.vitest) {
-  init();
+  initWhenDomReady();
 }
 


### PR DESCRIPTION
## Summary
- defer game initialization until the DOM has finished parsing so the artobest.com deployment consistently mounts the canvas
- log a diagnostic error when the canvas or resource bar shell elements are missing
- hydrate the build identity during init and document the DOM-ready troubleshooting guidance in the changelog and README

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c96583a0ac8330936a95f78bd67c27