### PR TITLE
Normalize icon loader for nested deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Normalize icon loader paths against `import.meta.env.BASE_URL` so nested
+  deployments fetch HUD imagery without 404s
 - Layer polished stroke patterns onto every terrain hex and dim fog-of-war tiles
   to 40% opacity for clearer, more atmospheric map readability
 - Wait for the DOM to finish parsing before bootstrapping the canvas so the

--- a/src/render/loadIcon.ts
+++ b/src/render/loadIcon.ts
@@ -5,7 +5,8 @@ export function loadIcon(path: string): HTMLImageElement | undefined {
   if (!icon) {
     icon = new Image();
     icon.decoding = 'async';
-    icon.src = path;
+    const normalized = new URL(path, import.meta.env.BASE_URL).href;
+    icon.src = normalized;
     iconCache.set(path, icon);
   }
 


### PR DESCRIPTION
## Summary
- resolve loaded icon URLs against `import.meta.env.BASE_URL` so nested builds load HUD assets
- document the update in the changelog

## Testing
- npm run build
- npm run build -- --base=/nested/
- npm run preview -- --base=/nested/ --port=4173 --strictPort --host=0.0.0.0 (manual verification of asset requests)
- curl -I http://127.0.0.1:4173/nested/
- curl -I http://127.0.0.1:4173/nested/assets/index-rbrf5UD3.css
- curl -I http://127.0.0.1:4173/nested/assets/index-CDWwR4CZ.js
- curl -I http://127.0.0.1:4173/nested/assets/ui/resource.svg
- curl -I http://127.0.0.1:4173/nested/assets/ui/gold.svg
- curl -I http://127.0.0.1:4173/nested/assets/ui/sound.svg
- curl -I http://127.0.0.1:4173/nested/assets/units/saunoja.svg

------
https://chatgpt.com/codex/tasks/task_e_68c97d97aac8833081986cf638102788