### PR TITLE
Update CI asset verification for root-relative bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,29 +22,67 @@ jobs:
           test -f dist/index.html
           test -f dist/404.html
 
-      # Verify that asset URLs include the Vite base (/autobattles4xfinsauna/)
-      - name: Verify Vite base in index.html
+      # Verify that asset URLs use root-relative /assets/ prefixes
+      - name: Verify root-relative asset URLs in index.html
         run: |
-          grep -q "/autobattles4xfinsauna/" dist/index.html || (echo "❌ Missing correct base path in index.html" && exit 1)
+          if ! grep -qE "=(\"|')/assets/" dist/index.html; then
+            echo "❌ Missing root-relative /assets/ references in index.html"
+            exit 1
+          fi
 
       # Guard against bare asset paths without the base prefix
       - name: Check for bare asset paths
         run: |
-          grep -q 'href="assets/' dist/index.html && (echo "❌ Found href=\"assets/\" in index.html" && exit 1)
-          grep -q 'src="assets/' dist/index.html && (echo "❌ Found src=\"assets/\" in index.html" && exit 1)
+          node <<'NODE'
+          const fs = require('fs');
+          const html = fs.readFileSync('dist/index.html', 'utf8');
+          const attrRe = /(href|src)=["']([^"'#?]+)["']/g;
+          const offenders = [];
+          let match;
+          while ((match = attrRe.exec(html))) {
+            const value = match[2];
+            if (!value.startsWith('/') && /^(\.{0,2}\/)?assets\//.test(value)) {
+              offenders.push(value);
+            }
+          }
+          if (offenders.length) {
+            console.error('❌ Found relative asset references without leading slash:', offenders);
+            process.exit(1);
+          }
+          NODE
 
       # Verify that all referenced JS/CSS files actually exist
       - name: Verify asset files exist
         run: |
-          node -e "
-          const fs=require('fs');const path=require('path');
-          const html=fs.readFileSync('dist/index.html','utf8');
-          const re=/(href|src)=\"(\\/autobattles4xfinsauna\\/[^\"?#]+)\"/g;
-          const misses=[];
-          let m; while((m=re.exec(html))){const p=m[2].replace('/autobattles4xfinsauna/','');
-            const fp=path.join('dist',p); if(!fs.existsSync(fp)) misses.push(fp); }
-          if(misses.length){ console.error('Missing assets:',misses); process.exit(1) }
-          "
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const html = fs.readFileSync('dist/index.html', 'utf8');
+          const attrRe = /(href|src)=["']([^"'#?]+)["']/g;
+          const misses = [];
+          let match;
+
+          while ((match = attrRe.exec(html))) {
+            const value = match[2];
+            if (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('//')) {
+              continue;
+            }
+            if (!value.startsWith('/')) {
+              continue;
+            }
+            const relativePath = value.replace(/^\/+/, '');
+            const filePath = path.join('dist', relativePath);
+            if (!fs.existsSync(filePath)) {
+              misses.push(`${value} -> ${filePath}`);
+            }
+          }
+
+          if (misses.length) {
+            console.error('Missing assets:', misses);
+            process.exit(1);
+          }
+          NODE
 
       # Optional: quick local link check for 404.html presence
       - name: Ensure 404.html exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Update CI asset verification to expect root-relative `/assets/` URLs and confirm hashed bundles exist before publishing
 - Paint a pulsing sauna aura overlay with a countdown badge and seat the sauna
   controls beneath the left HUD actions for aligned interaction
 - Normalize icon loader paths against `import.meta.env.BASE_URL` so nested


### PR DESCRIPTION
## Summary
- update the CI workflow to assert that Vite emits root-relative /assets/ URLs
- harden the bare asset guard to reject only truly relative asset references
- resolve asset existence checks against dist/ after trimming the leading slash

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9a45a57048330903e6219ddb83cf8