### PR TITLE
Add Saunakunnia prestige resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Introduce the Saunakunnia prestige track with dedicated HUD formatting, sauna aura
+  and victory generation hooks, policy costs, and refreshed log copy
 - Regenerate the GitHub Pages `docs/` mirror from the current production build
   so the custom domain serves the polished SPA entry point and fallback
 - Update CI asset verification to expect root-relative `/assets/` URLs and confirm hashed bundles exist before publishing

--- a/src/battle/BattleManager.test.ts
+++ b/src/battle/BattleManager.test.ts
@@ -54,7 +54,12 @@ describe('BattleManager', () => {
       amount: 5,
       remainingHealth: 0
     });
-    expect(deathEvents[0]).toMatchObject({ unitId: 'b', attackerId: 'a' });
+    expect(deathEvents[0]).toMatchObject({
+      unitId: 'b',
+      attackerId: 'a',
+      unitFaction: 'B',
+      attackerFaction: 'A'
+    });
   });
 
   it('prioritizes targets based on faction when multiple enemies are in range', () => {

--- a/src/core/GameState.test.ts
+++ b/src/core/GameState.test.ts
@@ -29,6 +29,21 @@ describe('GameState', () => {
     expect(loaded.getResource(Resource.GOLD)).toBe(6); // 1 saved + 5 offline ticks
   });
 
+  it('persists Saunakunnia alongside other resources', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.SAUNAKUNNIA, 5);
+    state.save();
+
+    const serialized = localStorage.getItem('gameState');
+    expect(serialized).not.toBeNull();
+    const parsed = JSON.parse(serialized ?? '{}');
+    expect(parsed.resources[Resource.SAUNAKUNNIA]).toBe(5);
+
+    const loaded = new GameState(1000);
+    loaded.load();
+    expect(loaded.getResource(Resource.SAUNAKUNNIA)).toBe(5);
+  });
+
   it('applies policy modifiers via listeners', () => {
     const state = new GameState(1000);
     state.applyPolicy('eco', 0); // free for testing

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -24,12 +24,14 @@ function createBuilding(type: string): Building | undefined {
 
 /** Available resource types. */
 export enum Resource {
-  GOLD = 'gold'
+  GOLD = 'gold',
+  SAUNAKUNNIA = 'saunakunnia'
 }
 
 /** Default passive generation per tick for each resource. */
 export const PASSIVE_GENERATION: Record<Resource, number> = {
-  [Resource.GOLD]: 1
+  [Resource.GOLD]: 1,
+  [Resource.SAUNAKUNNIA]: 0
 };
 
 // Shape of the serialized game state stored in localStorage.
@@ -43,7 +45,8 @@ type SerializedState = {
 export class GameState {
   /** Current amounts of each resource. */
   resources: Record<Resource, number> = {
-    [Resource.GOLD]: 0
+    [Resource.GOLD]: 0,
+    [Resource.SAUNAKUNNIA]: 0
   };
 
   /** Passive generation applied each tick. */
@@ -99,6 +102,11 @@ export class GameState {
       return;
     }
     this.resources = { ...this.resources, ...data.resources };
+    (Object.keys(this.resources) as Resource[]).forEach((res) => {
+      if (!Number.isFinite(this.resources[res])) {
+        this.resources[res] = 0;
+      }
+    });
     const validBuildings: Record<string, number> = {};
     Object.entries(data.buildings ?? {}).forEach(([type, count]) => {
       if (BUILDING_FACTORIES[type]) {

--- a/src/events/policies.ts
+++ b/src/events/policies.ts
@@ -17,5 +17,12 @@ const applyTemperance = ({ policy, state }: PolicyPayload): void => {
   eventBus.off('policyApplied', applyTemperance);
 };
 
+const applySteamDiplomats = ({ policy, state }: PolicyPayload): void => {
+  if (policy !== 'steam-diplomats') return;
+  state.modifyPassiveGeneration(Resource.SAUNAKUNNIA, 1);
+  eventBus.off('policyApplied', applySteamDiplomats);
+};
+
 eventBus.on<PolicyPayload>('policyApplied', applyEco);
 eventBus.on<PolicyPayload>('policyApplied', applyTemperance);
+eventBus.on<PolicyPayload>('policyApplied', applySteamDiplomats);

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -132,7 +132,9 @@ export class Unit {
       this.alive = false;
       eventBus.emit('unitDied', {
         unitId: this.id,
-        attackerId: attacker?.id
+        attackerId: attacker?.id,
+        unitFaction: this.faction,
+        attackerFaction: attacker?.faction
       });
       this.emitDeath();
     }


### PR DESCRIPTION
## Summary
- add the Saunakunnia resource to the core game state, persistence, and unit death payloads
- route sauna aura pulses, victory bonuses, and a new policy through the prestige currency while polishing HUD badges
- refresh right-panel policy copy, accessibility text, and changelog entries for the new prestige track

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca2cb1d1308330a9af1dbb674efa8d