### PR TITLE
Refine event logging and coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Focus the event log on sauna-flavored narratives by muting resource gain spam,
+  echoing right-panel events, and celebrating unit arrivals and farewells
 - Replace every terrain, building, and unit sprite with high-fidelity SVG art
   tailored to the Autobattles4xFinsauna palette and HUD glow treatments
 - Drive the BattleManager each fixed tick, funnel spawned player/enemy units

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -1,23 +1,90 @@
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('log function', () => {
+const flushLogs = () =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+async function initGame() {
+  const { eventBus } = await import('./events');
+  const game = await import('./game.ts');
+  const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
+  const resourceBar = document.getElementById('resource-bar') as HTMLElement;
+  game.setupGame(canvas, resourceBar);
+  return { eventBus, ...game };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: vi.fn(() => null)
+  });
+  document.body.innerHTML = `
+    <canvas id="game-canvas"></canvas>
+    <div id="resource-bar"></div>
+    <div id="ui-overlay"></div>
+  `;
+});
+
+describe('game logging', () => {
   it('caps event log at 100 messages', async () => {
-    document.body.innerHTML = `
-      <canvas id="game-canvas"></canvas>
-      <div id="resource-bar"></div>
-      <div id="ui-overlay"></div>
-    `;
-
-    const { log } = await import('./game.ts');
+    const { log } = await initGame();
 
     for (let i = 1; i <= 150; i++) {
       log(`msg ${i}`);
     }
 
-    await new Promise((r) => requestAnimationFrame(r));
+    await flushLogs();
 
     const eventLog = document.getElementById('event-log')!;
     expect(eventLog.childElementCount).toBe(100);
     expect(eventLog.firstChild?.textContent).toBe('msg 51');
+  });
+
+  it('updates gold HUD without logging resource changes', async () => {
+    const { eventBus } = await initGame();
+
+    eventBus.emit('resourceChanged', { resource: 'gold', total: 42, amount: 5 });
+    await flushLogs();
+
+    const resourceValue = document.querySelector<HTMLSpanElement>('.resource-value');
+    expect(resourceValue?.textContent).toBe('42');
+
+    const eventLog = document.getElementById('event-log')!;
+    expect(eventLog.childElementCount).toBe(0);
+  });
+
+  it('records spawn and casualty events with sauna flavor', async () => {
+    const { eventBus } = await initGame();
+    const { Unit } = await import('./units/Unit.ts');
+    const baseStats = { health: 10, attackDamage: 1, attackRange: 1, movementRange: 1 };
+
+    const ally = new Unit('steam-ally', { q: 0, r: 0 }, 'player', { ...baseStats });
+    eventBus.emit('unitSpawned', { unit: ally });
+    await flushLogs();
+
+    const eventLog = document.getElementById('event-log')!;
+    const allySpawn = eventLog.lastElementChild?.textContent ?? '';
+    expect(allySpawn).toContain('Our');
+    expect(allySpawn).toContain('emerges from the steam');
+    expect(allySpawn).toContain(ally.id);
+
+    const foe = new Unit('steam-foe', { q: 1, r: 0 }, 'enemy', { ...baseStats });
+    eventBus.emit('unitSpawned', { unit: foe });
+    await flushLogs();
+
+    const foeSpawn = eventLog.lastElementChild?.textContent ?? '';
+    expect(foeSpawn).toContain('A rival');
+    expect(foeSpawn).toContain(foe.id);
+
+    eventBus.emit('unitDied', {
+      unitId: foe.id,
+      unitFaction: 'enemy',
+      attackerFaction: 'player'
+    });
+    await flushLogs();
+
+    const casualtyMessage = eventLog.lastElementChild?.textContent ?? '';
+    expect(casualtyMessage).toContain('a rival');
+    expect(casualtyMessage).toContain(foe.id);
   });
 });

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -204,6 +204,7 @@ export function setupRightPanel(state: GameState): {
   function addEvent(ev: GameEvent): void {
     events.push(ev);
     renderEvents();
+    log(`Event • ${ev.headline}`);
   }
 
   // --- Log ---


### PR DESCRIPTION
## Summary
- remove resource delta spam while adding sauna-themed spawn and casualty log entries
- mirror right panel events in the log and retheme policy messages
- extend game logging tests to cover resource HUD updates and unit lifecycle copy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca392a976c8330ba8f5474cb2443dd