### PR TITLE
Retheme roster HUD to track Saunoja units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Rebuild the HUD roster widget with a Saunoja battalion counter, live unit
+  lifecycle updates, refreshed sauna styling, and updated tests
 - Rebrand the HUD gold economy into sauna beer with new resource enums,
   UI strings, polished bottle iconography, and refreshed tests
 - Focus the event log on sauna-flavored narratives by muting resource gain spam,

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
     <div id="game-container">
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">
-        <div id="resource-bar">Resources: 0</div>
+        <div id="resource-bar">Saunoja Roster: 0</div>
         <footer
           id="build-id"
           aria-live="polite"

--- a/src/style.css
+++ b/src/style.css
@@ -291,41 +291,75 @@ body > #game-container {
 #resource-bar {
   pointer-events: auto;
   align-self: flex-end;
+}
+
+.sauna-roster {
+  pointer-events: auto;
   display: inline-flex;
   align-items: center;
-  gap: 16px;
-  padding: 12px 24px;
+  gap: 18px;
+  padding: 16px 28px;
   border-radius: var(--radius-pill);
-  border: 1px solid var(--hud-border);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
   background:
-    linear-gradient(135deg, rgba(15, 23, 42, 0.86), rgba(15, 23, 42, 0.62));
-  backdrop-filter: blur(18px) saturate(140%);
-  box-shadow: var(--shadow-soft);
+    radial-gradient(circle at -40% 0%, rgba(251, 191, 36, 0.18), transparent 60%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.65));
+  backdrop-filter: blur(20px) saturate(165%);
+  box-shadow: 0 28px 52px rgba(8, 25, 53, 0.55);
+  color: var(--color-foreground);
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  transition: box-shadow var(--transition-snappy), transform var(--transition-snappy),
+    border-color var(--transition-snappy);
 }
 
-.resource-icon {
-  width: 32px;
-  height: 32px;
-  filter: drop-shadow(0 0 18px rgba(56, 189, 248, 0.45));
+.sauna-roster::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 110% 50%, rgba(56, 189, 248, 0.16), transparent 55%);
+  opacity: 0.85;
+  pointer-events: none;
+  z-index: -1;
 }
 
-.resource-text {
+.sauna-roster:hover,
+.sauna-roster:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 36px 64px rgba(8, 25, 53, 0.6);
+  border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
+  outline: none;
+}
+
+.sauna-roster__icon {
+  width: 40px;
+  height: 40px;
+  filter: drop-shadow(0 0 18px rgba(251, 191, 36, 0.45));
+}
+
+.sauna-roster__text {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  align-items: flex-start;
+  gap: 4px;
 }
 
-.resource-label {
-  font-size: clamp(11px, 1vw, 12px);
-  letter-spacing: 0.18em;
+.sauna-roster__label {
+  font-size: clamp(11px, 1vw, 13px);
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--color-muted);
+  color: color-mix(in srgb, var(--color-muted) 70%, white 30%);
 }
 
-.resource-value {
-  font-size: clamp(20px, 2.6vw, 26px);
+.sauna-roster__value {
+  font-size: clamp(22px, 2.8vw, 30px);
   font-weight: 700;
-  text-shadow: 0 0 20px rgba(56, 189, 248, 0.4);
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, #fcd34d 80%, white 20%);
+  text-shadow:
+    0 0 24px rgba(251, 191, 36, 0.5),
+    0 0 32px rgba(56, 189, 248, 0.45);
 }
 
 #build-menu {


### PR DESCRIPTION
## Summary
- replace the HUD resource display with a Saunoja roster counter that reads active player-controlled units and reacts to spawn/death events
- refresh the roster widget structure, styling, tooltip copy, and fallback markup to match the sauna battalion aesthetic
- update HUD tests and changelog entries to exercise the new roster behaviour

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ca434bdd7c8330b6adeb98e044b6d6