### PR TITLE
Polish sauna beer HUD copy and brewing hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Polish sauna beer HUD terminology with bottle provisioning logs, refined badge
+  narration, and updated policy copy
 - Rebuild the HUD roster widget with a Saunoja battalion counter, live unit
   lifecycle updates, refreshed sauna styling, and updated tests
 - Rebrand the HUD gold economy into sauna beer with new resource enums,

--- a/src/buildings/Farm.ts
+++ b/src/buildings/Farm.ts
@@ -1,10 +1,10 @@
 import type { BuildingType } from '../hex/HexTile.ts';
 import type { Building } from './Building.ts';
 
-/** Simple economic building that increases food production. */
+/** Simple economic building that keeps sauna beer brewing. */
 export class Farm implements Building {
   readonly type: BuildingType = 'farm';
   readonly cost = 50;
-  /** Amount of food generated each tick. */
-  readonly foodPerTick = 1;
+  /** Amount of sauna beer bottled each tick. */
+  readonly beerPerTick = 1;
 }

--- a/src/buildings/effects.ts
+++ b/src/buildings/effects.ts
@@ -20,7 +20,7 @@ export type BuildingRemovedPayload = {
 
 const onBuildingPlaced = ({ building, coord, state }: BuildingPlacedPayload): void => {
   if (building instanceof Farm) {
-    state.modifyPassiveGeneration(Resource.SAUNA_BEER, building.foodPerTick);
+    state.modifyPassiveGeneration(Resource.SAUNA_BEER, building.beerPerTick);
   } else if (building instanceof Barracks) {
     // Spawn a basic unit for the player when barracks is placed
     import('../units/UnitFactory.ts').then(({ spawnUnit }) => {
@@ -31,7 +31,7 @@ const onBuildingPlaced = ({ building, coord, state }: BuildingPlacedPayload): vo
 
 const onBuildingRemoved = ({ building, state }: BuildingRemovedPayload): void => {
   if (building instanceof Farm) {
-    state.modifyPassiveGeneration(Resource.SAUNA_BEER, -building.foodPerTick);
+    state.modifyPassiveGeneration(Resource.SAUNA_BEER, -building.beerPerTick);
   }
 };
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -35,10 +35,16 @@ const uiIcons = {
   sound: `${PUBLIC_ASSET_BASE}assets/ui/sound.svg`
 };
 
+const INITIAL_SAUNA_BEER = 200;
 const INITIAL_SAUNAKUNNIA = 3;
 const SAUNAKUNNIA_AURA_INTERVAL = 2000;
 const SAUNAKUNNIA_AURA_GAIN = 1;
 const SAUNAKUNNIA_VICTORY_BONUS = 2;
+
+const RESOURCE_LABELS: Record<Resource, string> = {
+  [Resource.SAUNA_BEER]: 'Sauna Beer',
+  [Resource.SAUNAKUNNIA]: 'Saunakunnia'
+};
 
 let canvas: HTMLCanvasElement | null = null;
 let rosterBar: HTMLElement;
@@ -348,8 +354,14 @@ function handleSaunaAura(deltaMs: number): void {
   state.addResource(Resource.SAUNAKUNNIA, honorGain);
 }
 
-state.addResource(Resource.SAUNA_BEER, 200);
+state.addResource(Resource.SAUNA_BEER, INITIAL_SAUNA_BEER);
+log(
+  `Quartermaster stocks ${INITIAL_SAUNA_BEER} bottles of ${RESOURCE_LABELS[Resource.SAUNA_BEER]} to launch your campaign.`
+);
 state.addResource(Resource.SAUNAKUNNIA, INITIAL_SAUNAKUNNIA);
+log(
+  `Sauna elders honor your leadership with ${INITIAL_SAUNAKUNNIA} ${RESOURCE_LABELS[Resource.SAUNAKUNNIA]} to celebrate your arrival.`
+);
 
 let selected: AxialCoord | null = null;
 const storedSelection = saunojas.find((unit) => unit.selected);

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -102,7 +102,7 @@ export function setupRightPanel(state: GameState): {
   const numberFormatter = new Intl.NumberFormat('en-US');
 
   const resourceLabel: Record<Resource, string> = {
-    [Resource.SAUNA_BEER]: 'Sauna Beer',
+    [Resource.SAUNA_BEER]: 'Sauna Beer Bottles',
     [Resource.SAUNAKUNNIA]: 'Saunakunnia'
   };
 
@@ -110,7 +110,7 @@ export function setupRightPanel(state: GameState): {
     {
       id: 'eco',
       name: 'Eco Policy',
-      description: 'Increase sauna beer income by 1',
+      description: 'Increase passive sauna beer brewing by 1 bottle per tick',
       cost: 15,
       prerequisite: () => true
     },
@@ -124,7 +124,7 @@ export function setupRightPanel(state: GameState): {
     {
       id: 'steam-diplomats',
       name: 'Steam Diplomats',
-      description: '+1 Saunakunnia passive income',
+      description: '+1 Saunakunnia honor each tick',
       cost: 8,
       resource: Resource.SAUNAKUNNIA,
       prerequisite: () => true

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -86,7 +86,7 @@ export function setupTopbar(state: GameState, icons: TopbarIcons = {}): (deltaMs
 
   const resourceDescriptions: Record<Resource, string> = {
     [Resource.SAUNA_BEER]:
-      'Sauna beer stocked for construction trades and eager recruits.',
+      'Sauna beer bottles chilled for construction crews and eager recruits.',
     [Resource.SAUNAKUNNIA]:
       'Saunakunnia—prestige earned from sauna rituals and triumphant battles.'
   };
@@ -179,6 +179,10 @@ export function setupTopbar(state: GameState, icons: TopbarIcons = {}): (deltaMs
     [Resource.SAUNA_BEER]: 'Sauna Beer',
     [Resource.SAUNAKUNNIA]: 'Saunakunnia'
   };
+  const resourceUnits: Record<Resource, { singular: string; plural: string }> = {
+    [Resource.SAUNA_BEER]: { singular: 'bottle', plural: 'bottles' },
+    [Resource.SAUNAKUNNIA]: { singular: 'honor', plural: 'honor' }
+  };
   const deltaSuffix: Record<Resource, string> = {
     [Resource.SAUNA_BEER]: '🍺',
     [Resource.SAUNAKUNNIA]: '⚜️'
@@ -212,6 +216,11 @@ export function setupTopbar(state: GameState, icons: TopbarIcons = {}): (deltaMs
     }
     const verb = amount > 0 ? 'gained' : 'spent';
     const magnitude = numberFormatter.format(Math.abs(amount));
+    const units = resourceUnits[resource];
+    if (units) {
+      const unitLabel = Math.abs(amount) === 1 ? units.singular : units.plural;
+      return `${verb} ${magnitude} ${resourceNames[resource]} ${unitLabel}`.trim();
+    }
     return `${verb} ${magnitude} ${resourceNames[resource]}`;
   }
 


### PR DESCRIPTION
## Summary
- align the HUD and policy copy with sauna beer terminology, including badge descriptions, bottle units, and initial provisioning logs
- rename the farm production stat to `beerPerTick` and update building effects so passive generation reflects the brewing theme
- document the refreshed sauna beer wording in the changelog

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ca4a56fb2c8330b5fea329834cbe08