### PR TITLE
Hide inactive right panel sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Hide inactive right-panel sections by honoring the `[hidden]` attribute so
+  tab switches only render the active pane
 - Polish sauna beer HUD terminology with bottle provisioning logs, refined badge
   narration, and updated policy copy
 - Rebuild the HUD roster widget with a Saunoja battalion counter, live unit

--- a/src/style.css
+++ b/src/style.css
@@ -488,6 +488,10 @@ body > #game-container {
   min-height: 0;
 }
 
+.panel-section[hidden] {
+  display: none;
+}
+
 .panel-section--scroll {
   flex: 1 1 auto;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- hide right-panel sections flagged with the hidden attribute so only the active tab renders
- document the HUD visibility fix in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca58ea6e5c8330b952cf4a2aabc96b