### PR TITLE
Spawn sauna raiders as enemies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Spawn sauna raiders on the enemy faction so they leave the spa and challenge
+  the player's attendants
 - Hide inactive right-panel sections by honoring the `[hidden]` attribute so
   tab switches only render the active pane
 - Polish sauna beer HUD terminology with bottle provisioning logs, refined badge

--- a/src/sim/sauna.ts
+++ b/src/sim/sauna.ts
@@ -46,7 +46,7 @@ export function createSauna(pos: AxialCoord): Sauna {
       if (targets.length > 0) {
         const coord = targets[Math.floor(Math.random() * targets.length)];
         const id = `raider${units.length + 1}`;
-        const raider = new Raider(id, coord, 'player');
+        const raider = new Raider(id, coord, 'enemy');
         addUnit(raider);
       }
       this.timer = this.spawnCooldown;


### PR DESCRIPTION
## Summary
- flip the sauna raider spawns to use the enemy faction so they fight the player
- document the sauna balance change in the Unreleased changelog section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca6e6867488330bd8d4fc6dab01fd0