### PR TITLE
Track sauna heat-driven spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Replace the sauna spawn timer with heat-driven thresholds that escalate after
+  each Avanto Marauder emerges from the steam
 - Regenerate the production asset mirrors with the sauna beer build so hashed
   bundles, HUD styling, and SVG art reference the updated resource palette
 - Ensure sauna-spawned Avanto Marauders join the enemy faction so they march on


### PR DESCRIPTION
## Summary
- extend the sauna simulation state with heat accumulation and thresholds for spawns
- accumulate heat each tick, spawn marauders when the threshold is met, and raise the threshold after each spawn
- document the new heat-driven spawn behavior in the changelog

## Testing
- npm run build *(fails: Could not resolve "../assets/sprites/avanto-marauder.svg" from "src/game.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68ca85e3b44883309978c67b022bab13