### PR TITLE
Remove passive sauna aura honor gain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Retire the sauna aura's passive Saunakunnia trickle so idling near the steam no
+  longer grants honor automatically
 - Replace the sauna spawn timer with heat-driven thresholds that escalate after
   each Avanto Marauder emerges from the steam
 - Regenerate the production asset mirrors with the sauna beer build so hashed


### PR DESCRIPTION
## Summary
- remove the sauna aura timer and helper so idling near the sauna no longer grants passive Saunakunnia
- tidy the changelog with a note about retiring sauna-based honor accrual

## Testing
- npm run build *(fails: Could not resolve "../assets/sprites/avanto-marauder.svg" from "src/game.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68ca87db9fb48330840343e5aa839f2c