### PR TITLE
Sync Saunoja coordinates with live unit movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Sync stored Saunoja positions with allied unit movement so roster icons track
+  live battlefield coordinates and persist only when locations change
 - Replace the sauna spawn timer with heat-driven thresholds that escalate after
   each Avanto Marauder emerges from the steam
 - Regenerate the production asset mirrors with the sauna beer build so hashed

--- a/assets/sprites/avanto-marauder.svg
+++ b/assets/sprites/avanto-marauder.svg
@@ -1,0 +1,31 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="steam" x1="64" y1="12" x2="64" y2="116" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#E6F4FF" stop-opacity="0.95" />
+      <stop offset="0.45" stop-color="#9AC8FF" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#2155A6" stop-opacity="0.95" />
+    </linearGradient>
+    <radialGradient id="ember" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
+      gradientTransform="translate(64 80) scale(52 44)">
+      <stop offset="0" stop-color="#FFB86C" />
+      <stop offset="0.6" stop-color="#F26A2E" />
+      <stop offset="1" stop-color="#8C2F1F" />
+    </radialGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="4" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="10" y="18" width="108" height="92" rx="28" fill="url(#steam)" />
+  <path d="M64 20C52 20 42 28 42 40C42 48 48 56 56 60L48 96H80L72 60C80 56 86 48 86 40C86 28 76 20 64 20Z" fill="url(#ember)" filter="url(#glow)" />
+  <path d="M48 96L40 108C38 112 41 116 45 116H83C87 116 90 112 88 108L80 96H48Z" fill="#1A2A44" />
+  <path d="M48 52C52 60 58 64 64 64C70 64 76 60 80 52" stroke="#F5D7C4" stroke-width="5" stroke-linecap="round" />
+  <circle cx="49" cy="40" r="7" fill="#0B132B" />
+  <circle cx="79" cy="40" r="7" fill="#0B132B" />
+  <path d="M54 76C58 82 70 82 74 76" stroke="#FFD8B5" stroke-width="4" stroke-linecap="round" />
+  <path d="M36 30C30 38 34 54 44 60" stroke="#E6F4FF" stroke-width="6" stroke-linecap="round" stroke-opacity="0.55" />
+  <path d="M92 30C98 38 94 54 84 60" stroke="#E6F4FF" stroke-width="6" stroke-linecap="round" stroke-opacity="0.55" />
+</svg>


### PR DESCRIPTION
## Summary
- map player units to their stored Saunojas and sync coordinates after battle ticks while clearing roster entries on death
- expose Saunoja roster snapshots for testing, mock sprite imports, and add a regression spec that verifies position persistence
- restore the missing Avanto Marauder sprite asset and document the fix in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca881cd8888330b9bf32ec15128f52