### PR TITLE
Sync Saunoja coordinates with unit movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Sync stored Saunoja roster coordinates with live friendly unit movement so HUD
+  overlays track attendants as they reposition across the battlefield
 - Retire the sauna aura's passive Saunakunnia trickle so idling near the steam no
   longer grants honor automatically
 - Replace the sauna spawn timer with heat-driven thresholds that escalate after


### PR DESCRIPTION
## Summary
- track friendly Saunoja assignments via unit-to-roster mapping and keep stored coordinates in sync with live units while saving only when positions change
- expose a test helper and add a regression to confirm Saunoja storage updates after movement, along with clearing storage between game tests
- document the roster sync fix in the changelog

## Testing
- npm test *(fails: missing `assets/sprites/avanto-marauder.svg` import referenced by Vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8bb3820483309e329c8907dbc734