### PR TITLE
Refocus policy costs on Saunakunnia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Redirect policy investments to Saunakunnia honors, refresh Steam Diplomat
+  rewards, and remove passive Saunakunnia trickles so prestige is only earned
+  through deliberate play
 - Sync stored Saunoja roster coordinates with live friendly unit movement so HUD
   overlays track attendants as they reposition across the battlefield
 - Retire the sauna aura's passive Saunakunnia trickle so idling near the steam no

--- a/src/core/GameState.test.ts
+++ b/src/core/GameState.test.ts
@@ -51,6 +51,16 @@ describe('GameState', () => {
     expect(state.getResource(Resource.SAUNA_BEER)).toBe(2); // base 1 + eco policy
   });
 
+  it('spends Saunakunnia when applying policies by default', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.SAUNAKUNNIA, 10);
+
+    const applied = state.applyPolicy('grand-reveal', 4);
+
+    expect(applied).toBe(true);
+    expect(state.getResource(Resource.SAUNAKUNNIA)).toBe(6);
+  });
+
   it('constructs and upgrades buildings when affordable', () => {
     const state = new GameState(1000);
     state.addResource(Resource.SAUNA_BEER, 100);

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -243,7 +243,11 @@ export class GameState {
   }
 
   /** Spend resources to apply a policy. */
-  applyPolicy(policy: string, cost: number, res: Resource = Resource.SAUNA_BEER): boolean {
+  applyPolicy(
+    policy: string,
+    cost: number,
+    res: Resource = Resource.SAUNAKUNNIA
+  ): boolean {
     if (!this.spend(cost, res)) {
       return false;
     }

--- a/src/events/policies.ts
+++ b/src/events/policies.ts
@@ -19,7 +19,7 @@ const applyTemperance = ({ policy, state }: PolicyPayload): void => {
 
 const applySteamDiplomats = ({ policy, state }: PolicyPayload): void => {
   if (policy !== 'steam-diplomats') return;
-  state.modifyPassiveGeneration(Resource.SAUNAKUNNIA, 1);
+  state.modifyPassiveGeneration(Resource.SAUNA_BEER, 2);
   eventBus.off('policyApplied', applySteamDiplomats);
 };
 

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -95,7 +95,7 @@ export function setupRightPanel(state: GameState): {
     name: string;
     description: string;
     cost: number;
-    resource?: Resource;
+    resource: Resource;
     prerequisite: (s: GameState) => boolean;
   };
 
@@ -103,7 +103,7 @@ export function setupRightPanel(state: GameState): {
 
   const resourceLabel: Record<Resource, string> = {
     [Resource.SAUNA_BEER]: 'Sauna Beer Bottles',
-    [Resource.SAUNAKUNNIA]: 'Saunakunnia'
+    [Resource.SAUNAKUNNIA]: 'Saunakunnia Honors'
   };
 
   const policyDefs: PolicyDef[] = [
@@ -112,6 +112,7 @@ export function setupRightPanel(state: GameState): {
       name: 'Eco Policy',
       description: 'Increase passive sauna beer brewing by 1 bottle per tick',
       cost: 15,
+      resource: Resource.SAUNAKUNNIA,
       prerequisite: () => true
     },
     {
@@ -119,12 +120,13 @@ export function setupRightPanel(state: GameState): {
       name: 'Temperance',
       description: '+5% work speed at night',
       cost: 25,
+      resource: Resource.SAUNAKUNNIA,
       prerequisite: () => true
     },
     {
       id: 'steam-diplomats',
       name: 'Steam Diplomats',
-      description: '+1 Saunakunnia honor each tick',
+      description: 'Import +2 sauna beer bottles per tick through diplomatic envoys',
       cost: 8,
       resource: Resource.SAUNAKUNNIA,
       prerequisite: () => true
@@ -137,7 +139,7 @@ export function setupRightPanel(state: GameState): {
     policiesTab.innerHTML = '';
     for (const def of policyDefs) {
       const btn = document.createElement('button');
-      const resource = def.resource ?? Resource.SAUNA_BEER;
+      const resource = def.resource;
       btn.textContent = `${def.name} (${numberFormatter.format(def.cost)} ${resourceLabel[resource]})`;
       btn.title = `${def.description}. Costs ${numberFormatter.format(def.cost)} ${resourceLabel[resource]}.`;
       btn.classList.add('panel-action');
@@ -159,7 +161,7 @@ export function setupRightPanel(state: GameState): {
     for (const def of policyDefs) {
       const btn = policyButtons[def.id];
       if (btn) {
-        const resource = def.resource ?? Resource.SAUNA_BEER;
+        const resource = def.resource;
         btn.disabled =
           !def.prerequisite(state) ||
           state.hasPolicy(def.id) ||


### PR DESCRIPTION
## Summary
- route policy spending through Saunakunnia by default and cover the change with a regression test
- refresh right panel policy copy to highlight honor costs and upgraded Steam Diplomat shipments
- remove passive Saunakunnia generation from policy events and record the design shift in the changelog

## Testing
- npm test *(fails: missing ../assets/sprites/avanto-marauder.svg referenced by src/game.ts)*
- npm run build *(fails: missing ../assets/sprites/avanto-marauder.svg referenced by src/game.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8f10d8c48330a0675cb3d96959b5