### PR TITLE
Add Saunoja roster crest and preload icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Replace the Saunoja roster badge with a dedicated warrior crest and preload
+  the SVG so the HUD reflects the new insignia instantly
 - Redirect policy investments to Saunakunnia honors, refresh Steam Diplomat
   rewards, and remove passive Saunakunnia trickles so prestige is only earned
   through deliberate play

--- a/assets/sprites/avanto-marauder.svg
+++ b/assets/sprites/avanto-marauder.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Avanto Marauder</title>
+  <desc id="desc">Frost-clad marauder icon with jagged pauldrons, icy beard, and polar glow.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#082f49" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+    <linearGradient id="armor" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e2e8f0" />
+      <stop offset="60%" stop-color="#94a3b8" />
+      <stop offset="100%" stop-color="#1f2937" />
+    </linearGradient>
+    <linearGradient id="beard" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e0f2fe" />
+      <stop offset="100%" stop-color="#bae6fd" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="20%" r="60%">
+      <stop offset="0%" stop-color="rgba(191, 219, 254, 0.85)" />
+      <stop offset="100%" stop-color="rgba(14, 116, 144, 0)" />
+    </radialGradient>
+  </defs>
+  <rect width="128" height="128" rx="20" fill="url(#bg)" />
+  <circle cx="64" cy="46" r="38" fill="url(#glow)" opacity="0.85" />
+  <path d="M64 18c-14 0-26 8-32 20l10 4c6-8 14-12 22-12s16 4 22 12l10-4C90 26 78 18 64 18z" fill="#cffafe" opacity="0.4" />
+  <path d="M64 36c-14 0-28 10-28 28v10l-12 16 18 10 22-10 22 10 18-10-12-16V64c0-18-14-28-28-28z" fill="url(#armor)" stroke="#0f172a" stroke-width="2" stroke-linejoin="round" />
+  <path d="M48 90l-12 6-10 20 20-8 18 8 18-8 20 8-10-20-12-6" fill="#0f172a" opacity="0.85" />
+  <path d="M64 46c-10 0-18 8-18 18v10c12-8 24-8 36 0V64c0-10-8-18-18-18z" fill="#0f172a" />
+  <path d="M64 50c-8 0-14 6-14 14 6-4 12-6 14-6s8 2 14 6c0-8-6-14-14-14z" fill="#bae6fd" opacity="0.85" />
+  <path d="M58 84c-4 0-8 2-10 6 4 0 8 0 10-2s4-2 6-2 4 0 6 2 6 2 10 2c-2-4-6-6-10-6h-12z" fill="#f8fafc" opacity="0.75" />
+  <path d="M64 86c-6 0-12 4-14 10 4 2 10 4 14 4s10-2 14-4c-2-6-8-10-14-10z" fill="url(#beard)" stroke="#bae6fd" stroke-width="1.4" stroke-linejoin="round" />
+  <path d="M42 64c-4-8-6-18-6-28-6 8-10 18-10 30 4-2 10-2 16-2z" fill="#0ea5e9" opacity="0.5" />
+  <path d="M86 64c4-8 6-18 6-28 6 8 10 18 10 30-4-2-10-2-16-2z" fill="#0ea5e9" opacity="0.5" />
+  <path d="M34 98c-6 2-12 6-14 12 6 0 12-2 18-4" stroke="#bae6fd" stroke-width="2" stroke-linecap="round" />
+  <path d="M94 106c6 2 12 4 18 4-2-6-8-10-14-12" stroke="#bae6fd" stroke-width="2" stroke-linecap="round" />
+</svg>

--- a/assets/ui/saunoja-roster.svg
+++ b/assets/ui/saunoja-roster.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Saunoja roster crest</title>
+  <desc id="desc">A polished dark shield crest featuring a vigilant Saunoja warrior framed by steam plumes.</desc>
+  <defs>
+    <linearGradient id="outer-frame" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9" />
+      <stop offset="38%" stop-color="#cbd5f5" />
+      <stop offset="100%" stop-color="#64748b" />
+    </linearGradient>
+    <linearGradient id="shield-body" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="48%" stop-color="#111827" />
+      <stop offset="100%" stop-color="#020617" />
+    </linearGradient>
+    <linearGradient id="shield-sheen" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(255, 255, 255, 0.58)" />
+      <stop offset="25%" stop-color="rgba(255, 255, 255, 0.16)" />
+      <stop offset="70%" stop-color="rgba(15, 118, 110, 0.0)" />
+      <stop offset="100%" stop-color="rgba(59, 130, 246, 0.35)" />
+    </linearGradient>
+    <linearGradient id="helm-grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8fafc" />
+      <stop offset="45%" stop-color="#cbd5f5" />
+      <stop offset="100%" stop-color="#94a3b8" />
+    </linearGradient>
+    <linearGradient id="visor-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+    <linearGradient id="sigil-flame" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="55%" stop-color="#ea580c" />
+      <stop offset="100%" stop-color="#b91c1c" />
+    </linearGradient>
+    <radialGradient id="inner-glow" cx="50%" cy="42%" r="62%">
+      <stop offset="0%" stop-color="rgba(148, 163, 184, 0.65)" />
+      <stop offset="100%" stop-color="rgba(15, 23, 42, 0)" />
+    </radialGradient>
+  </defs>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M80 6c34 0 62 26 62 58v30c0 36-20 58-62 74-42-16-62-38-62-74V64C18 32 46 6 80 6z" fill="url(#outer-frame)" stroke="rgba(15, 23, 42, 0.65)" stroke-width="2.5" />
+    <path d="M80 14c-28 0-52 20-52 46v28c0 31 18 48 52 62 34-14 52-31 52-62V60C132 34 108 14 80 14z" fill="url(#shield-body)" stroke="rgba(15, 23, 42, 0.9)" stroke-width="1.8" />
+    <path d="M80 18c-24 0-46 18-46 40v24c0 26 16 41 46 53 30-12 46-27 46-53V58C126 36 104 18 80 18z" fill="url(#inner-glow)" opacity="0.8" />
+    <path d="M80 18c-24 0-46 18-46 40 12-16 32-22 46-22s34 6 46 22c0-22-22-40-46-40z" fill="url(#shield-sheen)" opacity="0.6" />
+    <path d="M80 36c-18 0-32 14-32 32v16c0 18 14 32 32 32s32-14 32-32V68c0-18-14-32-32-32z" fill="url(#helm-grad)" stroke="rgba(15, 23, 42, 0.6)" stroke-width="1.6" />
+    <path d="M60 90c10 9 30 9 40 0" stroke="rgba(15, 23, 42, 0.5)" stroke-width="4" />
+    <path d="M80 46c-12 0-22 8-22 20v12c6-6 14-10 22-10s16 4 22 10V66c0-12-10-20-22-20z" fill="url(#visor-grad)" />
+    <path d="M80 54c-9 0-16 6-16 14 6-4 10-6 16-6s10 2 16 6c0-8-7-14-16-14z" fill="#1d4ed8" opacity="0.65" />
+    <path d="M80 100c-6 0-10 4-10 10 4-2 6-3 10-3s6 1 10 3c0-6-4-10-10-10z" fill="#475569" opacity="0.75" />
+    <path d="M80 112c0 8-4 16-10 22 6 2 14 2 20 0-6-6-10-14-10-22z" fill="url(#sigil-flame)" stroke="rgba(124, 45, 18, 0.85)" stroke-width="1.2" />
+    <path d="M70 130c3 4 6 6 10 6s7-2 10-6" stroke="rgba(249, 250, 251, 0.7)" stroke-width="2" />
+    <g stroke="rgba(148, 163, 184, 0.65)" stroke-width="3.2">
+      <path d="M44 66c-8 10-12 22-12 36 6-4 12-6 18-6" />
+      <path d="M116 66c8 10 12 22 12 36-6-4-12-6-18-6" />
+    </g>
+    <g stroke="#e2e8f0" stroke-width="2.4" opacity="0.85">
+      <path d="M50 44c-6 6-10 14-10 24 6-4 12-6 18-6" />
+      <path d="M110 44c6 6 10 14 10 24-6-4-12-6-18-6" />
+    </g>
+    <g stroke="#38bdf8" stroke-width="2.2" opacity="0.75">
+      <path d="M46 94c-6 6-8 14-8 24 6-4 12-6 18-4" />
+      <path d="M114 94c6 6 8 14 8 24-6-4-12-6-18-4" />
+    </g>
+    <path d="M80 32l6-16M80 32l-6-16" stroke="#e2e8f0" stroke-width="2.4" />
+    <path d="M64 128c-12 4-22 10-28 18 10 2 22 0 34-6" stroke="rgba(15, 23, 42, 0.35)" stroke-width="2" />
+    <path d="M96 128c12 4 22 10 28 18-10 2-22 0-34-6" stroke="rgba(15, 23, 42, 0.35)" stroke-width="2" />
+  </g>
+</svg>

--- a/src/game.ts
+++ b/src/game.ts
@@ -31,6 +31,7 @@ import { drawSaunojas, preloadSaunojaIcon } from './units/renderSaunoja.ts';
 const PUBLIC_ASSET_BASE = import.meta.env.BASE_URL;
 const uiIcons = {
   saunaBeer: `${PUBLIC_ASSET_BASE}assets/ui/sauna-beer.svg`,
+  saunojaRoster: `${PUBLIC_ASSET_BASE}assets/ui/saunoja-roster.svg`,
   resource: `${PUBLIC_ASSET_BASE}assets/ui/resource.svg`,
   sound: `${PUBLIC_ASSET_BASE}assets/ui/sound.svg`
 };
@@ -158,7 +159,7 @@ export function setupGame(canvasEl: HTMLCanvasElement, resourceBarEl: HTMLElemen
   rosterBar.replaceChildren();
 
   const icon = document.createElement('img');
-  icon.src = uiIcons.saunaBeer;
+  icon.src = uiIcons.saunojaRoster;
   icon.alt = 'Saunoja roster crest';
   icon.decoding = 'async';
   icon.classList.add('sauna-roster__icon');
@@ -191,6 +192,7 @@ export const assetPaths: AssetPaths = {
     'unit-archer': archer,
     'unit-avanto-marauder': avantoMarauder,
     'icon-sauna-beer': uiIcons.saunaBeer,
+    'icon-saunoja-roster': uiIcons.saunojaRoster,
     'icon-resource': uiIcons.resource,
     'icon-sound': uiIcons.sound
   }


### PR DESCRIPTION
## Summary
- add a bespoke Saunoja roster crest SVG and wire the UI to use it
- extend the asset loader and changelog to reference the new roster insignia
- supply the missing Avanto Marauder sprite so builds can resolve all unit art

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca91072a708330be95ab47711d7c6b