### PR TITLE
Track Saunoja traits, upkeep, and XP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Extend Saunoja attendants with trait, upkeep, and experience tracking while
+  normalizing stored data and persisting the new fields across sessions
 - Replace the Saunoja roster badge with a dedicated warrior crest and preload
   the SVG so the HUD reflects the new insignia instantly
 - Redirect policy investments to Saunakunnia honors, refresh Steam Diplomat

--- a/src/game.ts
+++ b/src/game.ts
@@ -107,6 +107,14 @@ export function loadUnits(): Saunoja[] {
           ? { q: coordSource.q, r: coordSource.r }
           : undefined;
 
+      const traitsSource = data.traits;
+      const traits = Array.isArray(traitsSource)
+        ? traitsSource.filter((trait): trait is string => typeof trait === 'string')
+        : undefined;
+
+      const upkeepValue = typeof data.upkeep === 'number' ? data.upkeep : undefined;
+      const xpValue = typeof data.xp === 'number' ? data.xp : undefined;
+
       restored.push(
         makeSaunoja({
           id: idValue,
@@ -115,6 +123,9 @@ export function loadUnits(): Saunoja[] {
           maxHp: typeof data.maxHp === 'number' ? data.maxHp : undefined,
           hp: typeof data.hp === 'number' ? data.hp : undefined,
           steam: typeof data.steam === 'number' ? data.steam : undefined,
+          traits,
+          upkeep: upkeepValue,
+          xp: xpValue,
           selected: Boolean(data.selected)
         })
       );
@@ -141,6 +152,9 @@ export function saveUnits(): void {
       maxHp: unit.maxHp,
       hp: unit.hp,
       steam: unit.steam,
+      traits: [...unit.traits],
+      upkeep: unit.upkeep,
+      xp: unit.xp,
       selected: unit.selected
     }));
     storage.setItem(SAUNOJA_STORAGE_KEY, JSON.stringify(payload));

--- a/src/units/saunoja.ts
+++ b/src/units/saunoja.ts
@@ -13,6 +13,12 @@ export interface Saunoja {
   hp: number;
   /** Steam intensity from 0 (idle) to 1 (billowing). */
   steam: number;
+  /** Collection of flavorful descriptors applied to the Saunoja. */
+  traits: string[];
+  /** Sauna beer upkeep required to keep the attendant active. */
+  upkeep: number;
+  /** Earned experience points. */
+  xp: number;
   /** Timestamp in milliseconds of the most recent damage event. */
   lastHitAt: number;
   /** Whether the unit is currently selected in the UI. */
@@ -26,6 +32,9 @@ export interface SaunojaInit {
   maxHp?: number;
   hp?: number;
   steam?: number;
+  traits?: ReadonlyArray<unknown>;
+  upkeep?: number;
+  xp?: number;
   lastHitAt?: number;
   selected?: boolean;
 }
@@ -34,6 +43,9 @@ const DEFAULT_COORD: AxialCoord = { q: 0, r: 0 };
 const DEFAULT_NAME = 'Saunoja';
 const DEFAULT_MAX_HP = 18;
 const DEFAULT_LAST_HIT_AT = 0;
+export const SAUNOJA_UPKEEP_MIN = 0;
+export const SAUNOJA_UPKEEP_MAX = 10;
+export const SAUNOJA_DEFAULT_UPKEEP = 1;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
@@ -51,6 +63,9 @@ export function makeSaunoja(init: SaunojaInit): Saunoja {
     maxHp = DEFAULT_MAX_HP,
     hp = maxHp,
     steam = 0,
+    traits = [],
+    upkeep = SAUNOJA_DEFAULT_UPKEEP,
+    xp = 0,
     lastHitAt = DEFAULT_LAST_HIT_AT,
     selected = false
   } = init;
@@ -60,6 +75,17 @@ export function makeSaunoja(init: SaunojaInit): Saunoja {
   const clampedHp = clamp(normalizedHpSource, 0, normalizedMaxHp);
   const normalizedSteamSource = Number.isFinite(steam) ? steam : 0;
   const clampedSteam = clamp(normalizedSteamSource, 0, 1);
+  const normalizedTraitsSource = Array.isArray(traits) ? traits : [];
+  const sanitizedTraits = normalizedTraitsSource
+    .filter((trait): trait is string => typeof trait === 'string')
+    .map((trait) => trait.trim())
+    .filter((trait) => trait.length > 0);
+  const normalizedUpkeepSource = Number.isFinite(upkeep)
+    ? upkeep
+    : SAUNOJA_DEFAULT_UPKEEP;
+  const clampedUpkeep = clamp(normalizedUpkeepSource, SAUNOJA_UPKEEP_MIN, SAUNOJA_UPKEEP_MAX);
+  const normalizedXpSource = Number.isFinite(xp) ? xp : 0;
+  const clampedXp = Math.max(0, normalizedXpSource);
   const normalizedLastHitSource = Number.isFinite(lastHitAt) ? lastHitAt : DEFAULT_LAST_HIT_AT;
   const clampedLastHitAt = Math.max(0, normalizedLastHitSource);
 
@@ -70,6 +96,9 @@ export function makeSaunoja(init: SaunojaInit): Saunoja {
     maxHp: normalizedMaxHp,
     hp: clampedHp,
     steam: clampedSteam,
+    traits: [...sanitizedTraits],
+    upkeep: clampedUpkeep,
+    xp: clampedXp,
     lastHitAt: clampedLastHitAt,
     selected
   };


### PR DESCRIPTION
## Summary
- extend Saunoja models with traits, upkeep, and XP plus defensive normalization
- persist and restore the new fields with load/save helpers and refreshed tests
- document the changes in the changelog

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ca9260d8288330bd19c1ed5ee2b78b