### PR TITLE
Avoid double-awarding starting resources after reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Detect restored save files before granting starting resource windfalls so reloads resume progress without duplicate rewards
 - Mirror the Saunoja roster crest into `public/assets/ui/` so the HUD loads the
   polished icon without 404 warnings
 - Regenerate the GitHub Pages bundle so Steam Diplomats boost sauna beer

--- a/src/core/GameState.test.ts
+++ b/src/core/GameState.test.ts
@@ -29,6 +29,28 @@ describe('GameState', () => {
     expect(loaded.getResource(Resource.SAUNA_BEER)).toBe(6); // 1 saved + 5 offline ticks
   });
 
+  it('reports whether a saved game was restored', () => {
+    const initialBeer = 200;
+    const initialHonor = 3;
+    const fresh = new GameState(1000);
+    expect(fresh.load()).toBe(false);
+    fresh.addResource(Resource.SAUNA_BEER, initialBeer);
+    fresh.addResource(Resource.SAUNAKUNNIA, initialHonor);
+    fresh.save();
+
+    const loaded = new GameState(1000);
+    const restored = loaded.load();
+    expect(restored).toBe(true);
+
+    if (!restored) {
+      loaded.addResource(Resource.SAUNA_BEER, initialBeer);
+      loaded.addResource(Resource.SAUNAKUNNIA, initialHonor);
+    }
+
+    expect(loaded.getResource(Resource.SAUNA_BEER)).toBe(initialBeer);
+    expect(loaded.getResource(Resource.SAUNAKUNNIA)).toBe(initialHonor);
+  });
+
   it('persists Saunakunnia alongside other resources', () => {
     const state = new GameState(1000);
     state.addResource(Resource.SAUNAKUNNIA, 5);

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -95,13 +95,13 @@ export class GameState {
     localStorage.setItem(this.storageKey, JSON.stringify(serialized));
   }
 
-  load(map?: HexMap): void {
+  load(map?: HexMap): boolean {
     const data = safeLoadJSON<Partial<SerializedState>>(this.storageKey);
     if (!data) {
       this.lastSaved = Date.now();
-      return;
+      return false;
     }
-    this.resources = { ...this.resources, ...data.resources };
+    this.resources = { ...this.resources, ...(data.resources ?? {}) };
     (Object.keys(this.resources) as Resource[]).forEach((res) => {
       if (!Number.isFinite(this.resources[res])) {
         this.resources[res] = 0;
@@ -136,6 +136,7 @@ export class GameState {
     (Object.keys(this.passiveGeneration) as Resource[]).forEach((res) => {
       this.resources[res] += offlineTicks * this.passiveGeneration[res];
     });
+    return true;
   }
 
   /** Current amount of a resource. */

--- a/src/game.ts
+++ b/src/game.ts
@@ -332,7 +332,7 @@ const onUnitSpawned = ({ unit }: UnitSpawnedPayload): void => {
 eventBus.on('unitSpawned', onUnitSpawned);
 
 const state = new GameState(1000);
-state.load(map);
+const restoredSave = state.load(map);
 const VISION_RADIUS = 2;
 const clock = new GameClock(1000, () => {
   state.tick();
@@ -411,14 +411,16 @@ function spawn(type: UnitType, coord: AxialCoord): void {
   }
 }
 
-state.addResource(Resource.SAUNA_BEER, INITIAL_SAUNA_BEER);
-log(
-  `Quartermaster stocks ${INITIAL_SAUNA_BEER} bottles of ${RESOURCE_LABELS[Resource.SAUNA_BEER]} to launch your campaign.`
-);
-state.addResource(Resource.SAUNAKUNNIA, INITIAL_SAUNAKUNNIA);
-log(
-  `Sauna elders honor your leadership with ${INITIAL_SAUNAKUNNIA} ${RESOURCE_LABELS[Resource.SAUNAKUNNIA]} to celebrate your arrival.`
-);
+if (!restoredSave) {
+  state.addResource(Resource.SAUNA_BEER, INITIAL_SAUNA_BEER);
+  log(
+    `Quartermaster stocks ${INITIAL_SAUNA_BEER} bottles of ${RESOURCE_LABELS[Resource.SAUNA_BEER]} to launch your campaign.`
+  );
+  state.addResource(Resource.SAUNAKUNNIA, INITIAL_SAUNAKUNNIA);
+  log(
+    `Sauna elders honor your leadership with ${INITIAL_SAUNAKUNNIA} ${RESOURCE_LABELS[Resource.SAUNAKUNNIA]} to celebrate your arrival.`
+  );
+}
 
 const storedSelection = saunojas.find((unit) => unit.selected);
 if (storedSelection) {


### PR DESCRIPTION
## Summary
- have `GameState.load` report when it restores an existing save
- gate the starting resource grants behind the restored-save check in `setupGame`
- extend the GameState tests to cover the new return value and prevent duplicate starting rewards

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ca9f7f61988330a6fb3982ecb28286