### PR TITLE
Shorten Saunakunnia policy label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Shorten the Saunakunnia policy cost label so the right panel references the
+  prestige track without the redundant "Honors" suffix
 - Ship the Saunoja roster crest within `docs/assets/ui/` so the published site
   serves the polished icon bundle without 404 regressions
 - Detect restored save files before granting starting resource windfalls so reloads resume progress without duplicate rewards

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -103,7 +103,7 @@ export function setupRightPanel(state: GameState): {
 
   const resourceLabel: Record<Resource, string> = {
     [Resource.SAUNA_BEER]: 'Sauna Beer Bottles',
-    [Resource.SAUNAKUNNIA]: 'Saunakunnia Honors'
+    [Resource.SAUNAKUNNIA]: 'Saunakunnia'
   };
 
   const policyDefs: PolicyDef[] = [


### PR DESCRIPTION
## Summary
- trim the right panel Saunakunnia policy cost label to drop the redundant Honors suffix
- document the UI terminology tweak in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caa3656a9c8330afd666ee38b8df2d