### PR TITLE
Refine Saunakunnia badge labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Retitle the Saunakunnia badge and narration copy to drop the honor suffix while
+  keeping accessibility labels polished and concise
 - Shorten the Saunakunnia policy cost label so the right panel references the
   prestige track without the redundant "Honors" suffix
 - Ship the Saunoja roster crest within `docs/assets/ui/` so the published site

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -94,7 +94,7 @@ export function setupTopbar(state: GameState, icons: TopbarIcons = {}): (deltaMs
   const saunakunnia = createBadge('Saunakunnia', {
     iconSrc: icons.saunakunnia,
     description: resourceDescriptions[Resource.SAUNAKUNNIA],
-    srLabel: 'Saunakunnia honor'
+    srLabel: 'Saunakunnia'
   });
   saunakunnia.container.classList.add('badge-sauna');
   const sisu = createBadge('SISU🔥', {
@@ -181,7 +181,7 @@ export function setupTopbar(state: GameState, icons: TopbarIcons = {}): (deltaMs
   };
   const resourceUnits: Record<Resource, { singular: string; plural: string }> = {
     [Resource.SAUNA_BEER]: { singular: 'bottle', plural: 'bottles' },
-    [Resource.SAUNAKUNNIA]: { singular: 'honor', plural: 'honor' }
+    [Resource.SAUNAKUNNIA]: { singular: 'Saunakunnia', plural: 'Saunakunnia' }
   };
   const deltaSuffix: Record<Resource, string> = {
     [Resource.SAUNA_BEER]: '🍺',
@@ -219,9 +219,16 @@ export function setupTopbar(state: GameState, icons: TopbarIcons = {}): (deltaMs
     const units = resourceUnits[resource];
     if (units) {
       const unitLabel = Math.abs(amount) === 1 ? units.singular : units.plural;
-      return `${verb} ${magnitude} ${resourceNames[resource]} ${unitLabel}`.trim();
+      const resourceLabel = resourceNames[resource];
+      const detailParts = [resourceLabel];
+      if (unitLabel && unitLabel !== resourceLabel) {
+        detailParts.push(unitLabel);
+      }
+      const detailText = detailParts.filter(Boolean).join(' ');
+      return `${verb} ${magnitude}${detailText ? ` ${detailText}` : ''}`;
     }
-    return `${verb} ${magnitude} ${resourceNames[resource]}`;
+    const resourceLabel = resourceNames[resource];
+    return `${verb} ${magnitude}${resourceLabel ? ` ${resourceLabel}` : ''}`;
   }
 
   function updateResourceBadge(resource: Resource, total: number, amount = 0): void {


### PR DESCRIPTION
## Summary
- align the Saunakunnia badge screen-reader label with the on-screen title
- update Saunakunnia narration units to drop the honor wording and avoid duplicated phrasing
- document the Saunakunnia badge copy refresh in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caa80779848330a4d798846b943aa4