### PR TITLE
Refocus sauna heat on rallying player soldiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Channel sauna heat into rallying allied soldiers, surface player-facing spawn
+  thresholds, and reuse the HUD countdown for the friendly reinforcements
 - Retitle the Saunakunnia badge and narration copy to drop the honor suffix while
   keeping accessibility labels polished and concise
 - Shorten the Saunakunnia policy cost label so the right panel references the

--- a/src/game.ts
+++ b/src/game.ts
@@ -582,7 +582,7 @@ export async function start(): Promise<void> {
     const delta = now - last;
     last = now;
     clock.tick(delta);
-    sauna.update(delta / 1000, units, (u) => {
+    sauna.update(delta / 1000, state, units, (u) => {
       registerUnit(u);
     });
     updateSaunaUI();

--- a/src/render/saunaOverlay.ts
+++ b/src/render/saunaOverlay.ts
@@ -196,8 +196,12 @@ export function drawSaunaOverlay(
   ctx.stroke();
   ctx.restore();
 
-  const cooldown = sauna.spawnCooldown > 0 ? sauna.spawnCooldown : 1;
-  const remainingRatio = Math.min(1, Math.max(0, sauna.timer / cooldown));
+  const cooldown =
+    sauna.playerSpawnCooldown > 0 ? sauna.playerSpawnCooldown : 1;
+  const remainingRatio = Math.min(
+    1,
+    Math.max(0, sauna.playerSpawnTimer / cooldown)
+  );
   const progress = 1 - remainingRatio;
   const startAngle = -Math.PI / 2;
   const endAngle = startAngle + Math.PI * 2 * progress;
@@ -223,7 +227,7 @@ export function drawSaunaOverlay(
     ctx.restore();
   }
 
-  const secondsRemaining = Math.max(0, sauna.timer);
+  const secondsRemaining = Math.max(0, sauna.playerSpawnTimer);
   const countdown = Math.ceil(secondsRemaining);
 
   ctx.save();

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -75,7 +75,9 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   });
 
   return () => {
-    const progress = 1 - sauna.timer / sauna.spawnCooldown;
+    const cooldown =
+      sauna.playerSpawnCooldown > 0 ? sauna.playerSpawnCooldown : 1;
+    const progress = 1 - sauna.playerSpawnTimer / cooldown;
     barFill.style.width = `${Math.max(0, Math.min(progress, 1)) * 100}%`;
     checkbox.checked = sauna.rallyToFront;
   };


### PR DESCRIPTION
## Summary
- expose player-focused sauna spawn fields including the dynamic player spawn threshold
- reroute sauna heat into allied soldier spawns that consume resources via the UnitFactory helper
- refresh the HUD overlay, sauna toggle, and changelog to track the new player timer metrics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caad40dd508330bdbe5b03201e87b9