### PR TITLE
Ensure sauna spawns fallback soldier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Guarantee the battlefield opens with a steadfast sauna guard by auto-spawning a
+  player soldier when no active attendants remain, preventing targetless combat
 - Channel sauna heat into rallying allied soldiers, surface player-facing spawn
   thresholds, and reuse the HUD countdown for the friendly reinforcements
 - Retitle the Saunakunnia badge and narration copy to drop the honor suffix while

--- a/src/game.ts
+++ b/src/game.ts
@@ -28,6 +28,7 @@ import { HexMapRenderer } from './render/HexMapRenderer.ts';
 import type { Saunoja } from './units/saunoja.ts';
 import { makeSaunoja } from './units/saunoja.ts';
 import { drawSaunojas, preloadSaunojaIcon } from './units/renderSaunoja.ts';
+import { SOLDIER_COST } from './units/Soldier.ts';
 
 const PUBLIC_ASSET_BASE = import.meta.env.BASE_URL;
 const uiIcons = {
@@ -391,6 +392,17 @@ const sauna = createSauna({
   q: Math.floor(map.width / 2),
   r: Math.floor(map.height / 2)
 });
+const hasActivePlayerUnit = units.some((unit) => unit.faction === 'player' && !unit.isDead());
+if (!hasActivePlayerUnit) {
+  if (!state.canAfford(SOLDIER_COST, Resource.SAUNA_BEER)) {
+    state.addResource(Resource.SAUNA_BEER, SOLDIER_COST);
+  }
+  const fallbackId = `u${units.length + 1}`;
+  const fallbackUnit = spawnUnit(state, 'soldier', fallbackId, sauna.pos, 'player');
+  if (fallbackUnit) {
+    registerUnit(fallbackUnit);
+  }
+}
 const enemySpawner = new EnemySpawner(pickRandomEdgeFreeTile);
 map.revealAround(sauna.pos, 3);
 saunojas = loadUnits();


### PR DESCRIPTION
## Summary
- import the soldier cost and ensure the sauna spawns a fallback friendly soldier when no active player units exist
- top off sauna beer as needed so the automatic soldier spawn succeeds and enters the roster
- document the new safety net in the unreleased changelog section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab15292dc8330acba488854902ec0