### PR TITLE
Reveal fog of war from active units each tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Sync fog-of-war reveals with each combat tick by updating player vision and
+  limiting enemy scouting before the renderer draws the battlefield
 - Guarantee the battlefield opens with a steadfast sauna guard by auto-spawning a
   player soldier when no active attendants remain, preventing targetless combat
 - Channel sauna heat into rallying allied soldiers, surface player-facing spawn

--- a/src/game.ts
+++ b/src/game.ts
@@ -374,16 +374,21 @@ eventBus.on('unitSpawned', onUnitSpawned);
 
 const state = new GameState(1000);
 const restoredSave = state.load(map);
-const VISION_RADIUS = 2;
 const clock = new GameClock(1000, () => {
   state.tick();
   battleManager.tick(units);
   syncSaunojaRosterWithUnits();
   state.save();
-  // Reveal around all friendly units each tick
+  // Reveal around all active units before rendering so fog-of-war keeps pace with combat
   for (const unit of units) {
-    if (!unit.isDead() && unit.faction === 'player') {
-      map.revealAround(unit.coord, VISION_RADIUS);
+    if (unit.isDead()) {
+      continue;
+    }
+
+    if (unit.faction === 'player') {
+      map.revealAround(unit.coord, 2);
+    } else if (unit.faction === 'enemy') {
+      map.revealAround(unit.coord, 1);
     }
   }
   draw();


### PR DESCRIPTION
## Summary
- reveal fog of war around every living player and enemy unit during the clock tick before rendering
- record the fog-of-war synchronization in the unreleased changelog entry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab2b9a598833098b4200eb85f12c5