### PR TITLE
Nudge stalled units toward open adjacent hexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Let BattleManager nudge stalled units into adjacent free hexes when pathfinding
+  cannot advance them yet keeps targets out of range
 - Sync fog-of-war reveals with each combat tick by updating player vision and
   limiting enemy scouting before the renderer draws the battlefield
 - Guarantee the battlefield opens with a steadfast sauna guard by auto-spawning a

--- a/src/battle/BattleManager.ts
+++ b/src/battle/BattleManager.ts
@@ -1,6 +1,8 @@
 import { Unit } from '../units/Unit.ts';
 import { HexMap } from '../hexmap.ts';
 import { Targeting } from '../ai/Targeting.ts';
+import { getNeighbors } from '../hex/HexUtils.ts';
+import { TerrainId } from '../map/terrain.ts';
 
 function coordKey(c: { q: number; r: number }): string {
   return `${c.q},${c.r}`;
@@ -34,6 +36,19 @@ export class BattleManager {
         const path = unit.moveTowards(target.coord, this.map, occupied);
         if (path.length > 0) {
           unit.coord = path[path.length - 1];
+        } else if (unit.distanceTo(target.coord) > unit.stats.attackRange) {
+          for (const neighbor of getNeighbors(unit.coord)) {
+            const neighborKey = coordKey(neighbor);
+            if (occupied.has(neighborKey)) {
+              continue;
+            }
+            const tile = this.map.getTile(neighbor.q, neighbor.r);
+            if (tile.terrain === TerrainId.Lake) {
+              continue;
+            }
+            unit.coord = neighbor;
+            break;
+          }
         }
       }
       if (unit.distanceTo(target.coord) <= unit.stats.attackRange && !target.isDead()) {


### PR DESCRIPTION
## Summary
- allow BattleManager to try nearby free tiles when a path ends before reaching attack range
- guard nudge movement against occupied or lake tiles to keep collision tracking consistent
- document the new behavior in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab39548e0833086a2b05c519d322a