### PR TITLE
Add saunoja traits and upkeep drain to roster UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Introduce randomized Saunoja trait rolls, daily beer upkeep drain, and a roster
+  card readout so attendants surface their quirks and maintenance costs at a glance
 - Let BattleManager nudge stalled units into adjacent free hexes when pathfinding
   cannot advance them yet keeps targets out of range
 - Sync fog-of-war reveals with each combat tick by updating player vision and

--- a/src/data/traits.test.ts
+++ b/src/data/traits.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { generateTraits, NEG, POS } from './traits.ts';
+
+const makeDeterministicRandom = (sequence: number[]): (() => number) => {
+  let index = 0;
+  return () => {
+    const value = sequence[index] ?? sequence[sequence.length - 1] ?? 0;
+    index += 1;
+    return value;
+  };
+};
+
+describe('generateTraits', () => {
+  it('returns a mix of positive and negative traits without duplicates', () => {
+    const rng = makeDeterministicRandom([0.1, 0.6, 0.2, 0.8, 0.4]);
+    const traits = generateTraits(rng);
+    expect(traits.length).toBeGreaterThan(0);
+    expect(traits.length).toBeLessThanOrEqual(3);
+    const positives = traits.filter((trait) => POS.includes(trait as (typeof POS)[number]));
+    const negatives = traits.filter((trait) => NEG.includes(trait as (typeof NEG)[number]));
+    expect(positives.length).toBeGreaterThanOrEqual(1);
+    expect(negatives.length).toBeGreaterThanOrEqual(1);
+    expect(new Set(traits).size).toBe(traits.length);
+  });
+
+  it('falls back to Math.random when the provided source is invalid', () => {
+    const traits = generateTraits(null as unknown as () => number);
+    expect(Array.isArray(traits)).toBe(true);
+    expect(traits.length).toBeGreaterThan(0);
+  });
+});

--- a/src/data/traits.ts
+++ b/src/data/traits.ts
@@ -1,0 +1,67 @@
+export const POS = [
+  'Resolute Sauna Guardian',
+  'Steam Scholar',
+  'Frost-Hardened',
+  'Loyal Watchbearer',
+  'Aura Whisperer',
+  'Shield Brother',
+  'Stonefooted Scout',
+  'Sisu-Forged Veteran',
+  'Brewmaster Quartermaster',
+  'Icebreaker Herald',
+  'Runic Tactician',
+  'Torchbearer'
+] as const;
+
+export const NEG = [
+  'Heat Fickle',
+  'Soot Allergic',
+  'Slow to Spark',
+  'Overconfident',
+  'Distracted Dreamer',
+  'Stubborn Stoker',
+  'Thirsty Between Battles',
+  'Clumsy Footwork',
+  'Rust-Prone Gear',
+  'Echo-Lost Listener'
+] as const;
+
+type RandomSource = () => number;
+
+function pickUnique(source: readonly string[], count: number, random: RandomSource): string[] {
+  const pool = [...source];
+  const picked: string[] = [];
+  const safeCount = Math.max(0, Math.min(count, pool.length));
+  for (let i = 0; i < safeCount; i++) {
+    const index = Math.floor(random() * pool.length);
+    const [trait] = pool.splice(index, 1);
+    if (trait) {
+      picked.push(trait);
+    }
+  }
+  return picked;
+}
+
+function shuffle<T>(values: T[], random: RandomSource): T[] {
+  for (let i = values.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [values[i], values[j]] = [values[j], values[i]];
+  }
+  return values;
+}
+
+/**
+ * Generate a flavorful collection of Saunoja personality traits.
+ * Returns a shuffled mix of positive and negative quirks.
+ */
+export function generateTraits(random: RandomSource = Math.random): string[] {
+  if (typeof random !== 'function') {
+    random = Math.random;
+  }
+  const positives = pickUnique(POS, 2, random);
+  const negatives = pickUnique(NEG, 1, random);
+  const traits = [...positives, ...negatives];
+  return shuffle(traits, random)
+    .map((trait) => trait.trim())
+    .filter((trait) => trait.length > 0);
+}

--- a/src/style.css
+++ b/src/style.css
@@ -296,9 +296,10 @@ body > #game-container {
 .sauna-roster {
   pointer-events: auto;
   display: inline-flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 18px;
-  padding: 16px 28px;
+  padding: 20px 28px 24px;
   border-radius: var(--radius-pill);
   border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
   background:
@@ -332,6 +333,12 @@ body > #game-container {
   outline: none;
 }
 
+.sauna-roster__summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 18px;
+}
+
 .sauna-roster__icon {
   width: 40px;
   height: 40px;
@@ -360,6 +367,61 @@ body > #game-container {
   text-shadow:
     0 0 24px rgba(251, 191, 36, 0.5),
     0 0 32px rgba(56, 189, 248, 0.45);
+}
+
+.saunoja-card {
+  position: relative;
+  display: grid;
+  gap: 10px;
+  padding: 18px 20px 20px;
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 22%, transparent);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(56, 189, 248, 0.12), transparent 55%),
+    linear-gradient(150deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.6));
+  box-shadow: 0 26px 46px rgba(8, 25, 53, 0.5);
+  color: var(--color-foreground);
+  isolation: isolate;
+}
+
+.saunoja-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.65;
+}
+
+.saunoja-card[hidden] {
+  display: none;
+}
+
+.saunoja-card__name {
+  margin: 0;
+  font-size: clamp(16px, 1.8vw, 18px);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, #f8fafc 80%, #38bdf8 20%);
+}
+
+.saunoja-card__traits {
+  margin: 0;
+  font-size: clamp(12px, 1.6vw, 13px);
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--color-muted) 70%, white 30%);
+}
+
+.saunoja-card__upkeep {
+  margin: 0;
+  font-size: clamp(13px, 1.8vw, 14px);
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, #fcd34d 75%, #fde68a 25%);
 }
 
 #build-menu {


### PR DESCRIPTION
## Summary
- add a trait data module and deterministic tests so saunojas can roll flavorful positive and negative quirks
- refresh saunoja assignment logic to reroll traits, reset experience, randomize upkeep, and drain sauna beer upkeep during the game clock
- extend the HUD roster card with trait and upkeep details and update persistence tests for the new dynamic values

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cab6d14ad483309a09386e39ef1a6d