### PR TITLE
Add SISU economy and abilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Introduce SISU as a persistent resource, award it for battlefield victories, and
+  surface polished HUD controls for the new burst and Torille! abilities that
+  spend the grit to empower or regroup allied units
 - Introduce randomized Saunoja trait rolls, daily beer upkeep drain, and a roster
   card readout so attendants surface their quirks and maintenance costs at a glance
 - Let BattleManager nudge stalled units into adjacent free hexes when pathfinding

--- a/src/core/GameState.ts
+++ b/src/core/GameState.ts
@@ -25,13 +25,15 @@ function createBuilding(type: string): Building | undefined {
 /** Available resource types. */
 export enum Resource {
   SAUNA_BEER = 'sauna-beer',
-  SAUNAKUNNIA = 'saunakunnia'
+  SAUNAKUNNIA = 'saunakunnia',
+  SISU = 'sisu'
 }
 
 /** Default passive generation per tick for each resource. */
 export const PASSIVE_GENERATION: Record<Resource, number> = {
   [Resource.SAUNA_BEER]: 1,
-  [Resource.SAUNAKUNNIA]: 0
+  [Resource.SAUNAKUNNIA]: 0,
+  [Resource.SISU]: 0
 };
 
 // Shape of the serialized game state stored in localStorage.
@@ -46,7 +48,8 @@ export class GameState {
   /** Current amounts of each resource. */
   resources: Record<Resource, number> = {
     [Resource.SAUNA_BEER]: 0,
-    [Resource.SAUNAKUNNIA]: 0
+    [Resource.SAUNAKUNNIA]: 0,
+    [Resource.SISU]: 0
   };
 
   /** Passive generation applied each tick. */
@@ -147,6 +150,11 @@ export class GameState {
   /** Determine if the player can afford a cost. */
   canAfford(cost: number, res: Resource = Resource.SAUNA_BEER): boolean {
     return this.resources[res] >= cost;
+  }
+
+  /** Attempt to spend a resource cost. Returns true if the transaction succeeds. */
+  spendResource(cost: number, res: Resource = Resource.SAUNA_BEER): boolean {
+    return this.spend(cost, res);
   }
 
   private spend(cost: number, res: Resource = Resource.SAUNA_BEER): boolean {

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -3,7 +3,7 @@ import { axialToPixel } from '../hex/HexUtils.ts';
 import { getHexDimensions } from '../hex/HexDimensions.ts';
 import type { LoadedAssets } from '../loader.ts';
 import type { Unit } from '../unit.ts';
-import { isSisuActive } from '../sim/sisu.ts';
+import { isSisuBurstActive } from '../sim/sisu.ts';
 import type { Sauna } from '../sim/sauna.ts';
 import { HexMapRenderer } from './HexMapRenderer.ts';
 import { camera } from '../camera/autoFrame.ts';
@@ -89,7 +89,7 @@ export function drawUnits(
       ctx.filter = 'saturate(0)';
     }
     ctx.drawImage(img, drawX, drawY, hexWidth, hexHeight);
-    if (isSisuActive() && unit.faction === 'player') {
+    if (isSisuBurstActive() && unit.faction === 'player') {
       ctx.strokeStyle = 'rgba(255,255,255,0.5)';
       ctx.lineWidth = 2;
       ctx.strokeRect(drawX, drawY, hexWidth, hexHeight);

--- a/src/sim/sisu.ts
+++ b/src/sim/sisu.ts
@@ -1,49 +1,143 @@
+import type { AxialCoord } from '../hex/HexUtils.ts';
 import type { GameState } from '../core/GameState.ts';
+import { Resource } from '../core/GameState.ts';
+import type { HexMap } from '../hexmap.ts';
 import type { Unit } from '../units/Unit.ts';
+import { pickFreeTileAround } from './sauna.ts';
 import { eventBus } from '../events';
 
-let active = false;
-let onCooldown = false;
+const SISU_BURST_DURATION_SECONDS = 10;
+const SISU_BURST_ATTACK_MULTIPLIER = 1.25;
+const SISU_BURST_MOVEMENT_MULTIPLIER = 1.5;
+const TORILLE_HEAL_RATIO = 0.6;
 
-export function isSisuActive(): boolean {
-  return active;
+export const SISU_BURST_COST = 5;
+export const TORILLE_COST = 3;
+
+type BurstState = {
+  endTime: number;
+  affected: Array<{ unit: Unit; attack: number; movement: number }>;
+  tickTimer: ReturnType<typeof setInterval> | null;
+  timeout: ReturnType<typeof setTimeout> | null;
+};
+
+let burstState: BurstState | null = null;
+
+function clearBurstState(): void {
+  if (!burstState) {
+    return;
+  }
+  if (burstState.tickTimer) {
+    clearInterval(burstState.tickTimer);
+  }
+  if (burstState.timeout) {
+    clearTimeout(burstState.timeout);
+  }
+  burstState = null;
 }
 
-export function activateSisuPulse(state: GameState, units: Unit[]): void {
-  void state;
-  if (active || onCooldown) return;
-  active = true;
-  onCooldown = true;
-  let remaining = 10;
-  eventBus.emit('sisuPulseStart', { remaining });
+export function isSisuBurstActive(): boolean {
+  return burstState !== null;
+}
 
-  const affected: { unit: Unit; move: number; attack: number }[] = [];
-  for (const u of units) {
-    if (u.faction !== 'player' || u.isDead()) continue;
-    affected.push({ unit: u, move: u.stats.movementRange, attack: u.stats.attackDamage });
-    u.stats.movementRange *= 1.2;
-    u.stats.attackDamage *= 1.2;
-    (u as any).fearless = true;
+export function getSisuBurstRemaining(): number {
+  if (!burstState) {
+    return 0;
+  }
+  const remainingMs = Math.max(0, burstState.endTime - performance.now());
+  return remainingMs / 1000;
+}
+
+export function useSisuBurst(state: GameState, units: Unit[]): boolean {
+  if (isSisuBurstActive()) {
+    return false;
+  }
+  if (!state.spendResource(SISU_BURST_COST, Resource.SISU)) {
+    return false;
   }
 
-  const interval = setInterval(() => {
-    remaining -= 1;
-    if (remaining > 0) {
-      eventBus.emit('sisuPulseTick', { remaining });
+  const affected: BurstState['affected'] = [];
+  for (const unit of units) {
+    if (unit.faction !== 'player' || unit.isDead()) {
+      continue;
+    }
+    affected.push({
+      unit,
+      attack: unit.stats.attackDamage,
+      movement: unit.stats.movementRange
+    });
+    unit.stats.attackDamage = Math.round(unit.stats.attackDamage * SISU_BURST_ATTACK_MULTIPLIER);
+    unit.stats.movementRange = Math.max(
+      1,
+      Math.round(unit.stats.movementRange * SISU_BURST_MOVEMENT_MULTIPLIER)
+    );
+    (unit as Record<string, unknown>).fearless = true;
+  }
+
+  const endTime = performance.now() + SISU_BURST_DURATION_SECONDS * 1000;
+  burstState = {
+    endTime,
+    affected,
+    tickTimer: null,
+    timeout: null
+  };
+
+  eventBus.emit('sisuBurstStart', { remaining: SISU_BURST_DURATION_SECONDS });
+
+  burstState.tickTimer = setInterval(() => {
+    if (!burstState) {
       return;
     }
-    clearInterval(interval);
-    active = false;
-    for (const a of affected) {
-      a.unit.stats.movementRange = a.move;
-      a.unit.stats.attackDamage = a.attack;
-      delete (a.unit as any).fearless;
+    const remaining = Math.max(0, Math.ceil(getSisuBurstRemaining()));
+    if (remaining > 0) {
+      eventBus.emit('sisuBurstTick', { remaining });
     }
-    eventBus.emit('sisuPulseEnd', {});
-    setTimeout(() => {
-      onCooldown = false;
-      eventBus.emit('sisuCooldownEnd', {});
-    }, 120_000);
-  }, 1_000);
+  }, 1000);
+
+  burstState.timeout = setTimeout(() => {
+    endSisuBurst();
+  }, SISU_BURST_DURATION_SECONDS * 1000);
+
+  return true;
 }
 
+export function endSisuBurst(): void {
+  if (!burstState) {
+    return;
+  }
+
+  for (const entry of burstState.affected) {
+    entry.unit.stats.attackDamage = entry.attack;
+    entry.unit.stats.movementRange = entry.movement;
+    delete (entry.unit as Record<string, unknown>).fearless;
+  }
+
+  clearBurstState();
+  eventBus.emit('sisuBurstEnd', {});
+}
+
+export function torille(
+  state: GameState,
+  units: Unit[],
+  saunaPos: AxialCoord,
+  map: HexMap
+): boolean {
+  const living = units.filter((unit) => unit.faction === 'player' && !unit.isDead());
+  if (living.length === 0) {
+    return false;
+  }
+  if (!state.spendResource(TORILLE_COST, Resource.SISU)) {
+    return false;
+  }
+
+  for (const unit of living) {
+    const target = pickFreeTileAround(saunaPos, 3, units) ?? { ...saunaPos };
+    unit.coord = target;
+    const healAmount = Math.round(unit.getMaxHealth() * TORILLE_HEAL_RATIO);
+    unit.stats.health = Math.min(unit.getMaxHealth(), Math.max(unit.stats.health, healAmount));
+  }
+
+  map.revealAround(saunaPos, 3);
+  eventBus.emit('torilleRecalled', { count: living.length });
+  return true;
+}


### PR DESCRIPTION
## Summary
- add the SISU resource to game state persistence and document the new economy in the changelog
- award SISU when players defeat enemies, expose burst and Torille controls in the HUD, and highlight boosted units while the surge is active

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caba5bc1d88330a5a0f91cf71182d8