### PR TITLE
Ensure units expose sprite type metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Attach sprite identifiers to every unit instance and thread them through
+  factories so the renderer can resolve polished SVG art without fallbacks
 - Introduce SISU as a persistent resource, award it for battlefield victories, and
   surface polished HUD controls for the new burst and Torille! abilities that
   spend the grit to empower or regroup allied units

--- a/src/ai/Targeting.test.ts
+++ b/src/ai/Targeting.test.ts
@@ -9,7 +9,7 @@ function createUnit(
   stats: UnitStats,
   priorityFactions: string[] = []
 ): Unit {
-  return new Unit(id, coord, faction, { ...stats }, priorityFactions);
+  return new Unit(id, 'test', coord, faction, { ...stats }, priorityFactions);
 }
 
 describe('Targeting', () => {

--- a/src/battle/BattleManager.test.ts
+++ b/src/battle/BattleManager.test.ts
@@ -11,7 +11,7 @@ function createUnit(
   stats: UnitStats,
   priorityFactions: string[] = []
 ): Unit {
-  return new Unit(id, coord, faction, { ...stats }, priorityFactions);
+  return new Unit(id, 'test', coord, faction, { ...stats }, priorityFactions);
 }
 
 describe('BattleManager', () => {

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -53,12 +53,12 @@ describe('game logging', () => {
 
     expect(rosterValue()).toBe('2');
 
-    const ally = new Unit('steam-ally', { q: 0, r: 0 }, 'player', { ...baseStats });
+    const ally = new Unit('steam-ally', 'soldier', { q: 0, r: 0 }, 'player', { ...baseStats });
     eventBus.emit('unitSpawned', { unit: ally });
     await flushLogs();
     expect(rosterValue()).toBe('4');
 
-    const foe = new Unit('steam-foe', { q: 1, r: 0 }, 'enemy', { ...baseStats });
+    const foe = new Unit('steam-foe', 'soldier', { q: 1, r: 0 }, 'enemy', { ...baseStats });
     eventBus.emit('unitSpawned', { unit: foe });
     await flushLogs();
     expect(rosterValue()).toBe('4');
@@ -77,7 +77,7 @@ describe('game logging', () => {
     const { Unit } = await import('./units/Unit.ts');
     const baseStats = { health: 10, attackDamage: 1, attackRange: 1, movementRange: 1 };
 
-    const ally = new Unit('steam-ally', { q: 0, r: 0 }, 'player', { ...baseStats });
+    const ally = new Unit('steam-ally', 'soldier', { q: 0, r: 0 }, 'player', { ...baseStats });
     eventBus.emit('unitSpawned', { unit: ally });
     await flushLogs();
 
@@ -87,7 +87,7 @@ describe('game logging', () => {
     expect(allySpawn).toContain('emerges from the steam');
     expect(allySpawn).toContain(ally.id);
 
-    const foe = new Unit('steam-foe', { q: 1, r: 0 }, 'enemy', { ...baseStats });
+    const foe = new Unit('steam-foe', 'soldier', { q: 1, r: 0 }, 'enemy', { ...baseStats });
     eventBus.emit('unitSpawned', { unit: foe });
     await flushLogs();
 
@@ -112,7 +112,7 @@ describe('game logging', () => {
     const { Unit } = await import('./units/Unit.ts');
     const baseStats = { health: 10, attackDamage: 1, attackRange: 1, movementRange: 1 };
 
-    const ally = new Unit('steam-ally', { q: 0, r: 0 }, 'player', { ...baseStats });
+    const ally = new Unit('steam-ally', 'soldier', { q: 0, r: 0 }, 'player', { ...baseStats });
     eventBus.emit('unitSpawned', { unit: ally });
     await flushLogs();
 

--- a/src/units/Archer.ts
+++ b/src/units/Archer.ts
@@ -13,7 +13,7 @@ export const ARCHER_COST = 75;
 
 export class Archer extends Unit {
   constructor(id: string, coord: AxialCoord, faction: string) {
-    super(id, coord, faction, { ...ARCHER_STATS });
+    super(id, 'archer', coord, faction, { ...ARCHER_STATS });
   }
 }
 

--- a/src/units/AvantoMarauder.ts
+++ b/src/units/AvantoMarauder.ts
@@ -11,7 +11,7 @@ export const AVANTO_MARAUDER_STATS: UnitStats = {
 
 export class AvantoMarauder extends Unit {
   constructor(id: string, coord: AxialCoord, faction: string) {
-    super(id, coord, faction, { ...AVANTO_MARAUDER_STATS });
+    super(id, 'avanto-marauder', coord, faction, { ...AVANTO_MARAUDER_STATS });
   }
 }
 

--- a/src/units/Soldier.ts
+++ b/src/units/Soldier.ts
@@ -13,7 +13,7 @@ export const SOLDIER_COST = 50;
 
 export class Soldier extends Unit {
   constructor(id: string, coord: AxialCoord, faction: string) {
-    super(id, coord, faction, { ...SOLDIER_STATS });
+    super(id, 'soldier', coord, faction, { ...SOLDIER_STATS });
   }
 }
 

--- a/src/units/Unit.test.ts
+++ b/src/units/Unit.test.ts
@@ -11,7 +11,7 @@ function coordKey(c: AxialCoord): string {
 }
 
 function createUnit(id: string, coord: AxialCoord, stats: UnitStats): Unit {
-  return new Unit(id, coord, 'faction', { ...stats });
+  return new Unit(id, 'test', coord, 'faction', { ...stats });
 }
 
 describe('Unit combat', () => {

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -42,6 +42,7 @@ export class Unit {
 
   constructor(
     public readonly id: string,
+    public readonly type: string,
     public coord: AxialCoord,
     public readonly faction: string,
     public readonly stats: UnitStats,

--- a/src/units/UnitFactory.test.ts
+++ b/src/units/UnitFactory.test.ts
@@ -14,6 +14,7 @@ describe('UnitFactory', () => {
     const unit = spawnUnit(state, 'soldier', 's1', origin, 'player');
     expect(unit).not.toBeNull();
     expect(unit!.stats).toEqual(SOLDIER_STATS);
+    expect(unit!.type).toBe('soldier');
     expect(state.getResource(Resource.SAUNA_BEER)).toBe(100 - SOLDIER_COST);
   });
 
@@ -23,6 +24,7 @@ describe('UnitFactory', () => {
     const unit = spawnUnit(state, 'archer', 'a1', origin, 'player');
     expect(unit).not.toBeNull();
     expect(unit!.stats).toEqual(ARCHER_STATS);
+    expect(unit!.type).toBe('archer');
     expect(state.getResource(Resource.SAUNA_BEER)).toBe(200 - ARCHER_COST);
   });
 


### PR DESCRIPTION
## Summary
- add a readonly sprite type identifier to the Unit base class and supply it from each concrete unit
- update factory helpers and tests to expect the unit type so rendering resolves the correct asset
- document the unit type propagation in the changelog

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cabe4b58448330a2eb26cc6645e225