### PR TITLE
Limit enemy reinforcements and decouple sauna spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Cap battlefield marauders at thirty concurrent enemies, route their arrivals
+  through a dedicated edge spawner, and let sauna heat summon only allied troops
+  with escalating thresholds so reinforcements stay balanced and readable
 - Attach sprite identifiers to every unit instance and thread them through
   factories so the renderer can resolve polished SVG art without fallbacks
 - Introduce SISU as a persistent resource, award it for battlefield victories, and

--- a/src/battle/BattleManager.ts
+++ b/src/battle/BattleManager.ts
@@ -4,6 +4,8 @@ import { Targeting } from '../ai/Targeting.ts';
 import { getNeighbors } from '../hex/HexUtils.ts';
 import { TerrainId } from '../map/terrain.ts';
 
+export const MAX_ENEMIES = 30;
+
 function coordKey(c: { q: number; r: number }): string {
   return `${c.q},${c.r}`;
 }

--- a/src/sim/EnemySpawner.ts
+++ b/src/sim/EnemySpawner.ts
@@ -1,78 +1,32 @@
 import type { AxialCoord } from '../hex/HexUtils.ts';
-import type { Unit } from '../units/Unit.ts';
+import { MAX_ENEMIES } from '../battle/BattleManager.ts';
 import { AvantoMarauder } from '../units/AvantoMarauder.ts';
+import type { Unit } from '../units/Unit.ts';
 
-export type SpawnTilePicker = (units: Unit[]) => AxialCoord | null;
-
-export interface EnemySpawnerConfig {
-  /** Heat generated per simulated second. */
-  heatPerTick?: number;
-  /** Initial heat threshold required to spawn a marauder. */
-  initialThreshold?: number;
-  /** Multiplier applied to the threshold after each spawn. */
-  thresholdGrowth?: number;
-}
-
-const DEFAULT_HEAT_PER_TICK = 50 / 30;
-const DEFAULT_INITIAL_THRESHOLD = 50;
-const DEFAULT_THRESHOLD_GROWTH = 1.05;
-
-/**
- * Drives periodic Avanto Marauder reinforcements using a heat-based timer.
- */
 export class EnemySpawner {
-  /** Accumulated heat towards the next reinforcement. */
-  private heat = 0;
-  /** Current heat requirement to deploy another marauder. */
-  private spawnThreshold: number;
-  /** Precomputed cooldown derived from the active threshold and heat gain. */
-  spawnCooldown: number;
-  /** Countdown (in seconds) until the next spawn fires, surfaced for HUD use. */
-  timer: number;
-  private readonly heatPerTick: number;
-  private readonly thresholdGrowth: number;
-  private spawnCounter = 0;
+  private timer = 30; // seconds
+  private interval = 30; // cadence
 
-  constructor(
-    private readonly pickSpawnTile: SpawnTilePicker,
-    config: EnemySpawnerConfig = {}
-  ) {
-    this.heatPerTick = config.heatPerTick ?? DEFAULT_HEAT_PER_TICK;
-    this.spawnThreshold = config.initialThreshold ?? DEFAULT_INITIAL_THRESHOLD;
-    this.thresholdGrowth = config.thresholdGrowth ?? DEFAULT_THRESHOLD_GROWTH;
-    this.spawnCooldown = this.spawnThreshold / this.heatPerTick;
-    this.timer = this.spawnCooldown;
-  }
-
-  update(dt: number, units: Unit[], onSpawn: (unit: Unit) => void): void {
-    if (dt <= 0) {
+  update(
+    dt: number,
+    units: Unit[],
+    addUnit: (unit: Unit) => void,
+    pickEdge: () => AxialCoord | undefined
+  ): void {
+    this.timer -= dt;
+    if (this.timer > 0) {
       return;
     }
 
-    this.heat += this.heatPerTick * dt;
-    this.spawnCooldown = this.spawnThreshold / this.heatPerTick;
-
-    if (this.heat < this.spawnThreshold) {
-      this.timer = Math.max((this.spawnThreshold - this.heat) / this.heatPerTick, 0);
-      return;
-    }
-
-    while (this.heat >= this.spawnThreshold) {
-      const spawnCoord = this.pickSpawnTile(units);
-      if (!spawnCoord) {
-        this.timer = 0;
-        break;
+    const enemyCount = units.filter((unit) => unit.faction === 'enemy' && !unit.isDead()).length;
+    if (enemyCount < MAX_ENEMIES) {
+      const at = pickEdge();
+      if (at) {
+        addUnit(new AvantoMarauder(`e${Date.now()}`, at, 'enemy'));
       }
-
-      const id = `avanto-marauder-${++this.spawnCounter}`;
-      const unit = new AvantoMarauder(id, spawnCoord, 'enemy');
-      onSpawn(unit);
-
-      const previousThreshold = this.spawnThreshold;
-      this.heat = Math.max(0, this.heat - previousThreshold);
-      this.spawnThreshold = previousThreshold * this.thresholdGrowth;
-      this.spawnCooldown = this.spawnThreshold / this.heatPerTick;
-      this.timer = Math.max((this.spawnThreshold - this.heat) / this.heatPerTick, 0);
     }
+
+    this.interval = Math.max(10, this.interval * 0.95);
+    this.timer = this.interval;
   }
 }


### PR DESCRIPTION
## Summary
- cap active enemy units at 30 and channel reinforcements through the new timer-based enemy spawner
- streamline sauna heat logic so it only summons allied soldiers with escalating thresholds
- drive both spawners from the fixed tick loop and surface the changes in the changelog

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cac1ee0aec83309e9894e69601f3ba