### PR TITLE
Persist game state during cleanup before removing listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Persist the latest game state and Saunoja roster during cleanup before
+  detaching event hooks so storage restrictions cannot drop late-session
+  progress
 - Cap battlefield marauders at thirty concurrent enemies, route their arrivals
   through a dedicated edge spawner, and let sauna heat summon only allied troops
   with escalating thresholds so reinforcements stay balanced and readable

--- a/src/game.ts
+++ b/src/game.ts
@@ -727,6 +727,18 @@ const onUnitDied = ({
 eventBus.on('unitDied', onUnitDied);
 
 export function cleanup(): void {
+  try {
+    state.save();
+  } catch (error) {
+    console.warn('Failed to persist game state during cleanup', error);
+  }
+
+  try {
+    saveUnits();
+  } catch (error) {
+    console.warn('Failed to persist Saunoja roster during cleanup', error);
+  }
+
   eventBus.off('policyApplied', onPolicyApplied);
   eventBus.off('unitDied', onUnitDied);
   eventBus.off('unitSpawned', onUnitSpawned);


### PR DESCRIPTION
## Summary
- ensure the game cleanup routine saves the main state and Saunoja roster synchronously
- guard the persistence calls with warnings so event listener teardown still completes if storage is blocked
- document the cleanup persistence adjustment in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cac55c28a88330a4e71c086c497be2