### PR TITLE
Cache static terrain layer in renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Cache the static hex terrain layer on an offscreen canvas, refreshing it only
+  when tiles mutate so the renderer blits a polished base map each frame while
+  drawing fog, highlights, and units as overlays
 - Persist the latest game state and Saunoja roster during cleanup before
   detaching event hooks so storage restrictions cannot drop late-session
   progress

--- a/src/game.ts
+++ b/src/game.ts
@@ -273,6 +273,12 @@ export function setAssets(loaded: LoadedAssets): void {
 const map = new HexMap(10, 10, 32);
 const battleManager = new BattleManager(map);
 const mapRenderer = new HexMapRenderer(map);
+const invalidateTerrainCache = (): void => {
+  mapRenderer.invalidateCache();
+  draw();
+};
+eventBus.on('buildingPlaced', invalidateTerrainCache);
+eventBus.on('buildingRemoved', invalidateTerrainCache);
 // Ensure all tiles start fogged
 map.forEachTile((t) => t.setFogged(true));
 resetAutoFrame();
@@ -742,6 +748,8 @@ export function cleanup(): void {
   eventBus.off('policyApplied', onPolicyApplied);
   eventBus.off('unitDied', onUnitDied);
   eventBus.off('unitSpawned', onUnitSpawned);
+  eventBus.off('buildingPlaced', invalidateTerrainCache);
+  eventBus.off('buildingRemoved', invalidateTerrainCache);
 }
 
 export async function start(): Promise<void> {

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -51,6 +51,15 @@ export function draw(
   const origin = mapRenderer.getOrigin();
   ctx.translate(-(camera.x - origin.x), -(camera.y - origin.y));
 
+  if (!mapRenderer.cachedCanvas) {
+    mapRenderer.buildCache(assets);
+  }
+  const cachedTerrain = mapRenderer.cachedCanvas;
+  if (cachedTerrain) {
+    const offset = mapRenderer.cachedOffset;
+    ctx.drawImage(cachedTerrain, -origin.x - offset.x, -origin.y - offset.y);
+  }
+
   mapRenderer.draw(ctx, assets, selected ?? undefined);
   const saunojaLayer = options?.saunojas;
   if (saunojaLayer && Array.isArray(saunojaLayer.units) && saunojaLayer.units.length > 0) {


### PR DESCRIPTION
## Summary
- cache the static hex terrain and building art on an offscreen canvas with polished fog overlays
- draw the cached terrain in the main renderer and rebuild only when the hex size changes
- invalidate the cache whenever building placement mutates tiles and document the optimization

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cac71915848330b4a2d1e930d6091c