### PR TITLE
Optimize pathfinding with caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Upgrade unit pathfinding to an A*-driven, cached system and stagger battle
+  processing each tick so movement stays responsive even with crowded hexes
 - Cache the static hex terrain layer on an offscreen canvas, refreshing it only
   when tiles mutate so the renderer blits a polished base map each frame while
   drawing fog, highlights, and units as overlays

--- a/src/hex/HexUtils.ts
+++ b/src/hex/HexUtils.ts
@@ -51,6 +51,17 @@ export function getNeighbor(hex: AxialCoord, direction: number): AxialCoord {
   return { q: hex.q + dir.q, r: hex.r + dir.r };
 }
 
+/** Compute the hex distance between two axial coordinates. */
+export function hexDistance(a: AxialCoord, b: AxialCoord): number {
+  const ay = -a.q - a.r;
+  const by = -b.q - b.r;
+  return Math.max(
+    Math.abs(a.q - b.q),
+    Math.abs(a.r - b.r),
+    Math.abs(ay - by)
+  );
+}
+
 /** Round a fractional axial coordinate to the nearest valid hex. */
 export function hexRound(frac: AxialCoord): AxialCoord {
   let x = frac.q;

--- a/src/units/Unit.test.ts
+++ b/src/units/Unit.test.ts
@@ -166,6 +166,32 @@ describe('Unit movement', () => {
     expect(path).toEqual([]);
     expect(unit.coord).toEqual({ q: 0, r: 0 });
   });
+
+  it('caches paths and invalidates when blocked', () => {
+    const map = new HexMap(3, 3);
+    const unit = createUnit('a', { q: 0, r: 0 }, {
+      health: 10,
+      attackDamage: 2,
+      attackRange: 1,
+      movementRange: 2
+    });
+    const target: AxialCoord = { q: 2, r: 0 };
+    const occupied = new Set<string>();
+    const spy = vi.spyOn(unit, 'findPath');
+
+    unit.getPathTo(target, map, occupied);
+    unit.getPathTo(target, map, occupied);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    occupied.add(coordKey({ q: 1, r: 0 }));
+    unit.moveTowards(target, map, occupied);
+    occupied.clear();
+
+    unit.getPathTo(target, map, occupied);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    spy.mockRestore();
+  });
 });
 
 describe('Unit sauna regeneration', () => {


### PR DESCRIPTION
## Summary
- replace unit BFS pathfinding with A* using a shared hex-distance helper and add per-unit path caching
- update the battle manager to consume cached paths, invalidate stale routes, and process units in round-robin chunks for steadier ticks
- expand unit tests to cover the cache behavior and document the optimization in the changelog

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cacc1a14748330a519506036f52075