### PR TITLE
Hide enemy units outside friendly vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Keep rival armies cloaked until allied scouts enter their three-hex vision
+  radius so fog-of-war respects live battlefield awareness and polished pacing
 - Upgrade unit pathfinding to an A*-driven, cached system and stagger battle
   processing each tick so movement stays responsive even with crowded hexes
 - Cache the static hex terrain layer on an offscreen canvas, refreshing it only

--- a/src/game.ts
+++ b/src/game.ts
@@ -466,15 +466,11 @@ const clock = new GameClock(1000, (deltaMs) => {
   state.save();
   // Reveal around all active units before rendering so fog-of-war keeps pace with combat
   for (const unit of units) {
-    if (unit.isDead()) {
+    if (unit.isDead() || unit.faction !== 'player') {
       continue;
     }
 
-    if (unit.faction === 'player') {
-      map.revealAround(unit.coord, 2);
-    } else if (unit.faction === 'enemy') {
-      map.revealAround(unit.coord, 1);
-    }
+    map.revealAround(unit.coord, unit.getVisionRange());
   }
   draw();
 });

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1,5 +1,5 @@
 import type { AxialCoord, PixelCoord } from '../hex/HexUtils.ts';
-import { axialToPixel } from '../hex/HexUtils.ts';
+import { axialToPixel, hexDistance } from '../hex/HexUtils.ts';
 import { getHexDimensions } from '../hex/HexDimensions.ts';
 import type { LoadedAssets } from '../loader.ts';
 import type { Unit } from '../unit.ts';
@@ -87,7 +87,21 @@ export function drawUnits(
   origin: PixelCoord
 ): void {
   const { width: hexWidth, height: hexHeight } = getHexDimensions(mapRenderer.hexSize);
+  const friendlyVisionSources = units
+    .filter((unit) => unit.faction === 'player' && !unit.isDead())
+    .map((unit) => ({ coord: unit.coord, range: unit.getVisionRange() }));
   for (const unit of units) {
+    if (unit.isDead()) {
+      continue;
+    }
+    if (
+      unit.faction === 'enemy' &&
+      !friendlyVisionSources.some(
+        ({ coord, range }) => hexDistance(coord, unit.coord) <= range
+      )
+    ) {
+      continue;
+    }
     const { x, y } = axialToPixel(unit.coord, mapRenderer.hexSize);
     const drawX = x - origin.x;
     const drawY = y - origin.y;

--- a/src/units/Archer.ts
+++ b/src/units/Archer.ts
@@ -6,7 +6,8 @@ export const ARCHER_STATS: UnitStats = {
   health: 15,
   attackDamage: 3,
   attackRange: 3,
-  movementRange: 2
+  movementRange: 2,
+  visionRange: 3
 };
 
 export const ARCHER_COST = 75;

--- a/src/units/AvantoMarauder.ts
+++ b/src/units/AvantoMarauder.ts
@@ -6,7 +6,8 @@ export const AVANTO_MARAUDER_STATS: UnitStats = {
   health: 12,
   attackDamage: 4,
   attackRange: 1,
-  movementRange: 2
+  movementRange: 2,
+  visionRange: 3
 };
 
 export class AvantoMarauder extends Unit {

--- a/src/units/Soldier.ts
+++ b/src/units/Soldier.ts
@@ -6,7 +6,8 @@ export const SOLDIER_STATS: UnitStats = {
   health: 20,
   attackDamage: 5,
   attackRange: 1,
-  movementRange: 2
+  movementRange: 2,
+  visionRange: 3
 };
 
 export const SOLDIER_COST = 50;

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -10,6 +10,7 @@ export interface UnitStats {
   attackDamage: number;
   attackRange: number;
   movementRange: number;
+  visionRange?: number;
 }
 
 type Listener = () => void;
@@ -66,6 +67,12 @@ export class Unit {
 
   distanceTo(coord: AxialCoord): number {
     return hexDistance(this.coord, coord);
+  }
+
+  /** Return how far this unit can see other actors on the battlefield. */
+  getVisionRange(): number {
+    const { visionRange } = this.stats;
+    return Number.isFinite(visionRange) ? (visionRange as number) : 3;
   }
 
   attack(target: Unit): void {


### PR DESCRIPTION
## Summary
- add a default three-hex vision range to unit stats and expose a helper on Unit
- reveal fog each tick using the active player's vision and stop enemies from contributing sight
- filter rendered enemies so they only appear when a friendly unit has them within vision and document the change

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cad0ae921483309bf8bbad92e63d92