### PR TITLE
Implement lazy hex tile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Generate hex tiles lazily upon reveal so the battlefield only materializes
+  around explored territory and active frontiers
 - Cull hex tile terrain and fog rendering to the active camera viewport so
   each frame iterates only the polished, on-screen hexes
 - Keep rival armies cloaked until allied scouts enter their three-hex vision

--- a/src/battle/BattleManager.test.ts
+++ b/src/battle/BattleManager.test.ts
@@ -4,6 +4,12 @@ import { Unit, UnitStats } from '../units/Unit.ts';
 import { HexMap } from '../hexmap.ts';
 import { eventBus } from '../events';
 
+function seedTiles(map: HexMap, coords: { q: number; r: number }[]): void {
+  for (const coord of coords) {
+    map.ensureTile(coord.q, coord.r);
+  }
+}
+
 function createUnit(
   id: string,
   coord: { q: number; r: number },
@@ -17,6 +23,11 @@ function createUnit(
 describe('BattleManager', () => {
   it('moves units toward enemies and handles combat events', () => {
     const map = new HexMap(5, 5);
+    seedTiles(map, [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: 0 },
+    ]);
     const attacker = createUnit('a', { q: 0, r: 0 }, 'A', {
       health: 10,
       attackDamage: 5,
@@ -64,6 +75,11 @@ describe('BattleManager', () => {
 
   it('prioritizes targets based on faction when multiple enemies are in range', () => {
     const map = new HexMap(5, 5);
+    seedTiles(map, [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 0, r: 1 },
+    ]);
     const attacker = createUnit('a', { q: 0, r: 0 }, 'A', {
       health: 10,
       attackDamage: 5,

--- a/src/buildings/effects.test.ts
+++ b/src/buildings/effects.test.ts
@@ -26,6 +26,7 @@ describe('building effects', () => {
     const state = new GameState(1000);
     state.addResource(Resource.SAUNA_BEER, 100);
     const map = new HexMap(3, 3, 1);
+    map.ensureTile(coordFarm.q, coordFarm.r).reveal();
     expect(state.placeBuilding(new Farm(), coordFarm, map)).toBe(true);
     state.tick();
     // 100 start - 50 cost + (1 base + 1 farm) = 52
@@ -36,6 +37,7 @@ describe('building effects', () => {
     const state = new GameState(1000);
     state.addResource(Resource.SAUNA_BEER, 500);
     const map = new HexMap(3, 3, 1);
+    map.ensureTile(coordBarracks.q, coordBarracks.r).reveal();
     expect(state.placeBuilding(new Barracks(), coordBarracks, map)).toBe(true);
     await new Promise((r) => setTimeout(r, 0));
     expect(spawnUnitSpy).toHaveBeenCalledWith(
@@ -51,6 +53,7 @@ describe('building effects', () => {
     const state = new GameState(1000);
     state.addResource(Resource.SAUNA_BEER, 100);
     const map = new HexMap(3, 3, 1);
+    map.ensureTile(coordFarm.q, coordFarm.r).reveal();
     expect(state.placeBuilding(new Farm(), coordFarm, map)).toBe(true);
     state.tick();
     expect(state.getResource(Resource.SAUNA_BEER)).toBe(52);

--- a/src/core/GameState.test.ts
+++ b/src/core/GameState.test.ts
@@ -4,6 +4,11 @@ import { HexMap } from '../hexmap.ts';
 import { Farm } from '../buildings/index.ts';
 import '../events';
 
+function ensureRevealed(map: HexMap, coord: { q: number; r: number }): void {
+  const tile = map.ensureTile(coord.q, coord.r);
+  tile.reveal();
+}
+
 describe('GameState', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -116,6 +121,7 @@ describe('GameState', () => {
     const state = new GameState(1000);
     state.addResource(Resource.SAUNA_BEER, 100);
     const coord = { q: 1, r: 1 };
+    ensureRevealed(map1, coord);
     expect(state.placeBuilding(new Farm(), coord, map1)).toBe(true);
     state.save();
 
@@ -132,6 +138,7 @@ describe('GameState', () => {
     const state = new GameState(1000);
     state.addResource(Resource.SAUNA_BEER, 100);
     const coord = { q: 0, r: 0 };
+    ensureRevealed(map1, coord);
     expect(state.placeBuilding(new Farm(), coord, map1)).toBe(true);
     state.save();
 
@@ -148,6 +155,7 @@ describe('GameState', () => {
     const state = new GameState(1000);
     state.addResource(Resource.SAUNA_BEER, 100);
     const coord = { q: 0, r: 0 };
+    ensureRevealed(map1, coord);
     expect(state.placeBuilding(new Farm(), coord, map1)).toBe(true);
     state.save();
 
@@ -169,6 +177,7 @@ describe('GameState', () => {
     localStorage.setItem('gameState', JSON.stringify(serialized));
 
     const map = new HexMap(3, 3, 1);
+    map.ensureTile(0, 0);
     const state = new GameState(1000);
     state.load(map);
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -321,7 +321,9 @@ function pickRandomEdgeFreeTile(): AxialCoord | undefined {
   }
 
   const index = Math.floor(Math.random() * candidates.length);
-  return candidates[index];
+  const choice = candidates[index];
+  map.ensureTile(choice.q, choice.r);
+  return choice;
 }
 
 type UnitSpawnedPayload = { unit: Unit };

--- a/src/hex/HexTile.test.ts
+++ b/src/hex/HexTile.test.ts
@@ -22,6 +22,6 @@ describe('HexTile', () => {
     map.revealAround({ q: 2, r: 2 }, 1);
     expect(map.getTile(2, 2)?.isFogged).toBe(false);
     expect(map.getTile(2, 3)?.isFogged).toBe(false); // neighbor within radius
-    expect(map.getTile(4, 2)?.isFogged).toBe(true); // outside radius
+    expect(map.getTile(4, 2)).toBeUndefined(); // tiles beyond the reveal radius remain ungenerated
   });
 });

--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -12,16 +12,20 @@ describe('HexMap', () => {
     expect(height).toBe(size * 2);
   });
 
-  it('generates a grid of tiles', () => {
+  it('creates tiles lazily as they are requested', () => {
     const map = new HexMap(3, 3);
+    expect(map.getTile(0, 0)).toBeUndefined();
+    const created = map.ensureTile(0, 0);
+    expect(created).toBeInstanceOf(HexTile);
+    expect(map.getTile(0, 0)).toBe(created);
     let count = 0;
     map.forEachTile(() => count++);
-    expect(count).toBe(9);
-    expect(map.getTile(0, 0)).toBeInstanceOf(HexTile);
+    expect(count).toBe(1);
   });
 
   it('returns neighboring tiles', () => {
     const map = new HexMap(3, 3);
+    map.ensureTile(1, 1);
     const neighbors = map.getNeighbors(1, 1);
     expect(neighbors).toHaveLength(6);
     neighbors.forEach((tile) => expect(tile).toBeInstanceOf(HexTile));
@@ -29,7 +33,7 @@ describe('HexMap', () => {
 
   it('draws a barracks image when tile has a barracks building', () => {
     const map = new HexMap(1, 1);
-    const tile = map.getTile(0, 0)!;
+    const tile = map.ensureTile(0, 0);
     tile.placeBuilding('barracks');
     // stub canvas context
     const gradient = { addColorStop: vi.fn() };
@@ -77,12 +81,13 @@ describe('HexMap', () => {
 
   it('expands bounds when accessing tiles outside initial area', () => {
     const map = new HexMap(1, 1);
-    const tile = map.getTile(2, -1);
+    map.ensureTile(0, 0);
+    const tile = map.ensureTile(2, -1);
     expect(tile).toBeInstanceOf(HexTile);
     let count = 0;
     map.forEachTile(() => count++);
     expect(map.width).toBe(3);
     expect(map.height).toBe(2);
-    expect(count).toBe(6);
+    expect(count).toBe(2);
   });
 });

--- a/src/hexmap.ts
+++ b/src/hexmap.ts
@@ -25,11 +25,6 @@ export class HexMap {
     this.minR = 0;
     this.maxQ = width - 1;
     this.maxR = height - 1;
-    for (let r = this.minR; r <= this.maxR; r++) {
-      for (let q = this.minQ; q <= this.maxQ; q++) {
-        this.tiles.set(this.key(q, r), new HexTile(terrainAt(q, r, seed)));
-      }
-    }
   }
 
   /** Current width derived from tracked bounds. */
@@ -64,16 +59,14 @@ export class HexMap {
     return tile;
   }
 
-  getTile(q: number, r: number): HexTile {
-    return this.ensureTile(q, r);
+  getTile(q: number, r: number): HexTile | undefined {
+    return this.tiles.get(this.key(q, r));
   }
 
   forEachTile(cb: (tile: HexTile, coord: AxialCoord) => void): void {
-    for (let r = this.minR; r <= this.maxR; r++) {
-      for (let q = this.minQ; q <= this.maxQ; q++) {
-        const tile = this.ensureTile(q, r);
-        cb(tile, { q, r });
-      }
+    for (const [key, tile] of this.tiles) {
+      const [q, r] = key.split(',').map(Number);
+      cb(tile, { q, r });
     }
   }
 

--- a/src/render/HexMapRenderer.ts
+++ b/src/render/HexMapRenderer.ts
@@ -308,7 +308,7 @@ export class HexMapRenderer {
     const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
     for (let r = bounds.rMin; r <= bounds.rMax; r++) {
       for (let q = bounds.qMin; q <= bounds.qMax; q++) {
-        const tile = this.mapRef.tiles.get(`${q},${r}`);
+        const tile = this.mapRef.getTile(q, r);
         if (!tile) {
           continue;
         }
@@ -412,7 +412,7 @@ export class HexMapRenderer {
   ): void {
     for (let r = bounds.rMin; r <= bounds.rMax; r++) {
       for (let q = bounds.qMin; q <= bounds.qMax; q++) {
-        const tile = this.mapRef.tiles.get(`${q},${r}`);
+        const tile = this.mapRef.getTile(q, r);
         if (!tile || !tile.isFogged) {
           continue;
         }

--- a/src/units/Unit.test.ts
+++ b/src/units/Unit.test.ts
@@ -14,6 +14,12 @@ function createUnit(id: string, coord: AxialCoord, stats: UnitStats): Unit {
   return new Unit(id, 'test', coord, 'faction', { ...stats });
 }
 
+function ensureTiles(map: HexMap, coords: AxialCoord[]): void {
+  for (const coord of coords) {
+    map.ensureTile(coord.q, coord.r);
+  }
+}
+
 describe('Unit combat', () => {
   it('deals damage within range', () => {
     const attacker = createUnit('a', { q: 0, r: 0 }, {
@@ -105,7 +111,14 @@ describe('Unit combat', () => {
 describe('Unit movement', () => {
   it('moves around impassable terrain', () => {
     const map = new HexMap(3, 3);
-    map.getTile(1, 0)!.terrain = TerrainId.Lake;
+    ensureTiles(map, [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 0, r: 1 },
+      { q: 1, r: 1 },
+      { q: 2, r: 0 },
+    ]);
+    map.ensureTile(1, 0).terrain = TerrainId.Lake;
     const unit = createUnit('a', { q: 0, r: 0 }, {
       health: 10,
       attackDamage: 2,
@@ -123,7 +136,15 @@ describe('Unit movement', () => {
 
   it('selects the nearest reachable enemy', () => {
     const map = new HexMap(3, 3);
-    map.getTile(1, 0)!.terrain = TerrainId.Lake;
+    ensureTiles(map, [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 0, r: 1 },
+      { q: 0, r: 2 },
+      { q: 1, r: 1 },
+      { q: 2, r: 0 },
+    ]);
+    map.ensureTile(1, 0).terrain = TerrainId.Lake;
     const unit = createUnit('a', { q: 0, r: 0 }, {
       health: 10,
       attackDamage: 2,
@@ -149,6 +170,10 @@ describe('Unit movement', () => {
 
   it('does not move into occupied tiles', () => {
     const map = new HexMap(3, 3);
+    ensureTiles(map, [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+    ]);
     const unit = createUnit('a', { q: 0, r: 0 }, {
       health: 10,
       attackDamage: 2,
@@ -169,6 +194,11 @@ describe('Unit movement', () => {
 
   it('caches paths and invalidates when blocked', () => {
     const map = new HexMap(3, 3);
+    ensureTiles(map, [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: 0 },
+    ]);
     const unit = createUnit('a', { q: 0, r: 0 }, {
       health: 10,
       attackDamage: 2,


### PR DESCRIPTION
## Summary
- create hex tiles lazily via ensureTile while exposing getTile for optional lookups and adjust renderer culling to avoid generating fogged regions
- seed required tiles during gameplay and test scenarios, ensuring enemy spawns and pathfinding only instantiate explored or frontier hexes
- document the lazy generation change in the changelog

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cad5f95258833083873890b0e4be0c