### PR TITLE
Chunk terrain cache into revealed tile canvases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Cache the static hex terrain layer on an offscreen canvas, refreshing it only
   when tiles mutate so the renderer blits a polished base map each frame while
   drawing fog, highlights, and units as overlays
+- Chunk the cached terrain into 16-hex canvases, redrawing only newly revealed
+  sections before compositing them onto the polished base map each frame
 - Persist the latest game state and Saunoja roster during cleanup before
   detaching event hooks so storage restrictions cannot drop late-session
   progress

--- a/src/render/HexMapRenderer.ts
+++ b/src/render/HexMapRenderer.ts
@@ -16,6 +16,23 @@ const DEFAULT_HIGHLIGHT_GLOW = 'rgba(56, 189, 248, 0.45)';
 let highlightStroke: string | null = null;
 let highlightGlow: string | null = null;
 
+const CHUNK = 16; // hexes per side
+type ChunkKey = string;
+
+interface ChunkCanvas {
+  canvas: HTMLCanvasElement;
+  origin: PixelCoord; // position relative to the map origin
+}
+
+function chunkKey(q: number, r: number): ChunkKey {
+  return `${Math.floor(q / CHUNK)},${Math.floor(r / CHUNK)}`;
+}
+
+function parseTileKey(key: string): { q: number; r: number } {
+  const [q, r] = key.split(',').map(Number);
+  return { q, r };
+}
+
 const TERRAIN_PATTERNS: Record<TerrainId, (options: HexPatternOptions) => void> = {
   [TerrainId.Plains]: drawPlains,
   [TerrainId.Forest]: drawForest,
@@ -169,6 +186,10 @@ export class HexMapRenderer {
   private cachedCanvasElement?: HTMLCanvasElement;
   private cachedCanvasOffset: PixelCoord = { x: 0, y: 0 };
   private cachedHexSize: number | null = null;
+  private readonly chunkCanvases = new Map<ChunkKey, ChunkCanvas>();
+  private readonly dirtyChunks = new Set<ChunkKey>();
+  private readonly tileRenderState = new Map<string, string>();
+  private cachedImages?: Record<string, HTMLImageElement>;
 
   constructor(private readonly mapRef: HexMap) {}
 
@@ -181,6 +202,7 @@ export class HexMapRenderer {
   }
 
   get cachedCanvas(): HTMLCanvasElement | undefined {
+    this.ensureChunkCache();
     return this.cachedCanvasElement;
   }
 
@@ -226,29 +248,27 @@ export class HexMapRenderer {
     if (!ctx) {
       throw new Error('Canvas 2D context not available for cache rendering');
     }
-
-    ctx.translate(-minX, -minY);
-
-    for (const [key, tile] of this.mapRef.tiles) {
-      const [q, r] = key.split(',').map(Number);
-      const { x, y } = axialToPixel({ q, r }, this.hexSize);
-      const drawX = x - origin.x;
-      const drawY = y - origin.y;
-      ctx.save();
-      this.drawTerrainAndBuilding(ctx, tile, images, drawX, drawY, hexWidth, hexHeight);
-      this.strokeHex(ctx, drawX + this.hexSize, drawY + this.hexSize, this.hexSize, false);
-      ctx.restore();
-    }
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, cacheWidth, cacheHeight);
 
     this.cachedCanvasElement = canvas;
     this.cachedCanvasOffset = { x: minX, y: minY };
     this.cachedHexSize = this.hexSize;
+    this.cachedImages = images;
+    this.chunkCanvases.clear();
+    this.dirtyChunks.clear();
+    this.tileRenderState.clear();
+    this.ensureChunkCache(images);
   }
 
   invalidateCache(): void {
     this.cachedCanvasElement = undefined;
     this.cachedCanvasOffset = { x: 0, y: 0 };
     this.cachedHexSize = null;
+    this.chunkCanvases.clear();
+    this.dirtyChunks.clear();
+    this.tileRenderState.clear();
+    this.cachedImages = undefined;
   }
 
   draw(
@@ -258,6 +278,10 @@ export class HexMapRenderer {
   ): void {
     if (this.cachedCanvasElement && this.cachedHexSize !== this.hexSize) {
       this.invalidateCache();
+    }
+    this.cachedImages = images;
+    if (this.cachedCanvasElement) {
+      this.ensureChunkCache(images);
     }
     const origin = this.getOrigin();
     const bounds = resolveVisibleBounds(ctx, this.mapRef, this.hexSize);
@@ -486,5 +510,146 @@ export class HexMapRenderer {
       }
     }
     ctx.closePath();
+  }
+
+  private ensureChunkCache(images?: Record<string, HTMLImageElement>): void {
+    if (!this.cachedCanvasElement) {
+      return;
+    }
+    if (images) {
+      this.cachedImages = images;
+    }
+    this.refreshDirtyChunks();
+    if (this.dirtyChunks.size === 0) {
+      return;
+    }
+
+    const terrainCtx = this.cachedCanvasElement.getContext('2d');
+    if (!terrainCtx) {
+      throw new Error('Canvas 2D context not available for terrain cache');
+    }
+
+    terrainCtx.save();
+    terrainCtx.setTransform(1, 0, 0, 1, 0, 0);
+
+    const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
+    const assets = this.cachedImages!;
+    for (const key of this.dirtyChunks) {
+      const previous = this.chunkCanvases.get(key);
+      const chunk = this.renderChunk(key, hexWidth, hexHeight, assets);
+      if (!chunk) {
+        if (previous) {
+          const clearX = previous.origin.x - this.cachedCanvasOffset.x;
+          const clearY = previous.origin.y - this.cachedCanvasOffset.y;
+          terrainCtx.clearRect(clearX, clearY, previous.canvas.width, previous.canvas.height);
+          this.chunkCanvases.delete(key);
+        }
+        continue;
+      }
+
+      this.chunkCanvases.set(key, chunk);
+      const drawX = chunk.origin.x - this.cachedCanvasOffset.x;
+      const drawY = chunk.origin.y - this.cachedCanvasOffset.y;
+      terrainCtx.clearRect(drawX, drawY, chunk.canvas.width, chunk.canvas.height);
+      terrainCtx.drawImage(chunk.canvas, drawX, drawY);
+    }
+
+    terrainCtx.restore();
+    this.dirtyChunks.clear();
+  }
+
+  private refreshDirtyChunks(): void {
+    for (const [key, tile] of this.mapRef.tiles) {
+      const signature = tile.isFogged ? 'fogged' : `${tile.terrain}:${tile.building ?? ''}`;
+      const previousSignature = this.tileRenderState.get(key);
+      if (previousSignature !== signature) {
+        this.tileRenderState.set(key, signature);
+        const { q, r } = parseTileKey(key);
+        this.dirtyChunks.add(chunkKey(q, r));
+      }
+    }
+
+    for (const key of Array.from(this.tileRenderState.keys())) {
+      if (!this.mapRef.tiles.has(key)) {
+        this.tileRenderState.delete(key);
+        const { q, r } = parseTileKey(key);
+        this.dirtyChunks.add(chunkKey(q, r));
+      }
+    }
+  }
+
+  private renderChunk(
+    key: ChunkKey,
+    hexWidth: number,
+    hexHeight: number,
+    images: Record<string, HTMLImageElement>
+  ): ChunkCanvas | null {
+    const [chunkQ, chunkR] = key.split(',').map(Number);
+    const qStart = chunkQ * CHUNK;
+    const qEnd = qStart + CHUNK - 1;
+    const rStart = chunkR * CHUNK;
+    const rEnd = rStart + CHUNK - 1;
+    const origin = this.getOrigin();
+
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    const tiles: Array<{ tile: { terrain: TerrainId; building: string | null }; x: number; y: number }>
+      = [];
+
+    for (let q = qStart; q <= qEnd; q++) {
+      for (let r = rStart; r <= rEnd; r++) {
+        const tile = this.mapRef.getTile(q, r);
+        if (!tile || tile.isFogged) {
+          continue;
+        }
+
+        const { x, y } = axialToPixel({ q, r }, this.hexSize);
+        const drawX = x - origin.x;
+        const drawY = y - origin.y;
+        minX = Math.min(minX, drawX);
+        minY = Math.min(minY, drawY);
+        maxX = Math.max(maxX, drawX + hexWidth);
+        maxY = Math.max(maxY, drawY + hexHeight);
+        tiles.push({ tile, x: drawX, y: drawY });
+      }
+    }
+
+    if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+      return null;
+    }
+
+    const width = Math.max(1, Math.ceil(maxX - minX));
+    const height = Math.max(1, Math.ceil(maxY - minY));
+
+    let canvas = this.chunkCanvases.get(key)?.canvas;
+    if (!canvas || canvas.width !== width || canvas.height !== height) {
+      canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+    }
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas 2D context not available for chunk rendering');
+    }
+
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+
+    for (const { tile, x, y } of tiles) {
+      const drawX = x - minX;
+      const drawY = y - minY;
+      ctx.save();
+      this.drawTerrainAndBuilding(ctx, tile, images, drawX, drawY, hexWidth, hexHeight);
+      this.strokeHex(ctx, drawX + this.hexSize, drawY + this.hexSize, this.hexSize, false);
+      ctx.restore();
+    }
+
+    return {
+      canvas,
+      origin: { x: minX, y: minY },
+    };
   }
 }


### PR DESCRIPTION
## Summary
- chunk the terrain cache into 16-hex canvases that redraw only when tiles reveal or change before blitting to the aggregate map layer
- manage chunk cache bookkeeping by tracking tile signatures, reusing canvases, and refreshing the terrain cache lazily during draw
- document the chunked terrain cache approach in the changelog

## Testing
- npm run build
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cadf0a0a88833080cd53c93e7ca47f