### PR TITLE
Spawn enemies along fog frontier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- March enemy spawns along the fog frontier so marauders emerge just beyond
+  revealed territory and keep battles focused on the explored sauna perimeter
 - Generate hex tiles lazily upon reveal so the battlefield only materializes
   around explored territory and active frontiers
 - Cull hex tile terrain and fog rendering to the active camera viewport so

--- a/src/game.ts
+++ b/src/game.ts
@@ -285,47 +285,6 @@ resetAutoFrame();
 
 const units: Unit[] = [];
 
-function pickRandomEdgeFreeTile(): AxialCoord | undefined {
-  const occupied = new Set<string>();
-  for (const unit of units) {
-    if (!unit.isDead()) {
-      occupied.add(`${unit.coord.q},${unit.coord.r}`);
-    }
-  }
-
-  const candidates: AxialCoord[] = [];
-  const seen = new Set<string>();
-  const pushIfFree = (q: number, r: number) => {
-    const key = `${q},${r}`;
-    if (seen.has(key)) {
-      return;
-    }
-    seen.add(key);
-    if (!occupied.has(key)) {
-      candidates.push({ q, r });
-    }
-  };
-
-  for (let q = map.minQ; q <= map.maxQ; q++) {
-    pushIfFree(q, map.minR);
-    pushIfFree(q, map.maxR);
-  }
-
-  for (let r = map.minR; r <= map.maxR; r++) {
-    pushIfFree(map.minQ, r);
-    pushIfFree(map.maxQ, r);
-  }
-
-  if (candidates.length === 0) {
-    return undefined;
-  }
-
-  const index = Math.floor(Math.random() * candidates.length);
-  const choice = candidates[index];
-  map.ensureTile(choice.q, choice.r);
-  return choice;
-}
-
 type UnitSpawnedPayload = { unit: Unit };
 
 function detachSaunoja(unitId: string): void {
@@ -445,7 +404,7 @@ const clock = new GameClock(1000, (deltaMs) => {
   });
   enemySpawner.update(dtSeconds, units, (unit) => {
     registerUnit(unit);
-  }, pickRandomEdgeFreeTile);
+  });
   battleManager.tick(units);
   syncSaunojaRosterWithUnits();
   let upkeepDrain = 0;
@@ -491,7 +450,7 @@ if (!hasActivePlayerUnit) {
     registerUnit(fallbackUnit);
   }
 }
-const enemySpawner = new EnemySpawner();
+const enemySpawner = new EnemySpawner(map);
 map.revealAround(sauna.pos, 3);
 saunojas = loadUnits();
 if (saunojas.length === 0) {

--- a/src/sim/EnemySpawner.ts
+++ b/src/sim/EnemySpawner.ts
@@ -1,17 +1,60 @@
 import type { AxialCoord } from '../hex/HexUtils.ts';
+import { getNeighbors } from '../hex/HexUtils.ts';
 import { MAX_ENEMIES } from '../battle/BattleManager.ts';
 import { AvantoMarauder } from '../units/AvantoMarauder.ts';
 import type { Unit } from '../units/Unit.ts';
+import type { HexMap } from '../hexmap.ts';
+import { revealedHexes } from '../camera/autoFrame.ts';
 
 export class EnemySpawner {
   private timer = 30; // seconds
   private interval = 30; // cadence
 
+  constructor(private readonly map: HexMap) {}
+
+  private coordKey(coord: AxialCoord): string {
+    return `${coord.q},${coord.r}`;
+  }
+
+  private pickFrontierSpawn(units: Unit[]): AxialCoord | undefined {
+    const occupied = new Set<string>();
+    for (const unit of units) {
+      if (!unit.isDead()) {
+        occupied.add(this.coordKey(unit.coord));
+      }
+    }
+
+    const candidates: AxialCoord[] = [];
+    const seen = new Set<string>();
+
+    for (const key of revealedHexes) {
+      const [q, r] = key.split(',').map(Number);
+      if (!Number.isFinite(q) || !Number.isFinite(r)) {
+        continue;
+      }
+      const center = { q, r };
+      for (const neighbor of getNeighbors(center)) {
+        const neighborKey = this.coordKey(neighbor);
+        if (revealedHexes.has(neighborKey) || occupied.has(neighborKey) || seen.has(neighborKey)) {
+          continue;
+        }
+        seen.add(neighborKey);
+        candidates.push(neighbor);
+      }
+    }
+
+    if (candidates.length === 0) {
+      return undefined;
+    }
+
+    const index = Math.floor(Math.random() * candidates.length);
+    return candidates[index];
+  }
+
   update(
     dt: number,
     units: Unit[],
-    addUnit: (unit: Unit) => void,
-    pickEdge: () => AxialCoord | undefined
+    addUnit: (unit: Unit) => void
   ): void {
     this.timer -= dt;
     if (this.timer > 0) {
@@ -19,12 +62,19 @@ export class EnemySpawner {
     }
 
     const enemyCount = units.filter((unit) => unit.faction === 'enemy' && !unit.isDead()).length;
-    if (enemyCount < MAX_ENEMIES) {
-      const at = pickEdge();
-      if (at) {
-        addUnit(new AvantoMarauder(`e${Date.now()}`, at, 'enemy'));
-      }
+    if (enemyCount >= MAX_ENEMIES) {
+      this.timer = 1;
+      return;
     }
+
+    const at = this.pickFrontierSpawn(units);
+    if (!at) {
+      this.timer = 0.5;
+      return;
+    }
+
+    this.map.ensureTile(at.q, at.r);
+    addUnit(new AvantoMarauder(`e${Date.now()}`, at, 'enemy'));
 
     this.interval = Math.max(10, this.interval * 0.95);
     this.timer = this.interval;


### PR DESCRIPTION
## Summary
- spawn rivals on the fog frontier by scanning revealed tiles and picking free neighboring hexes
- ensure new spawn hexes are instantiated on the map before adding marauders and retry quickly when no frontier exists
- update game loop and changelog to reflect frontier-based spawns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae2b883c4833086b81b4f133e034e