### PR TITLE
Add roster tab and unique Saunoja names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Mount a dedicated roster tab on the right-hand command board with polished
+  attendant cards, status chips, trait ribbons, and health meters so the HUD
+  surfaces the full battalion alongside policies, events, and the log
+- Forge Finland-flavoured Saunoja names from curated name tables, ensure
+  existing saves receive unique monikers, and thread the identities through
+  the roster UI and combat narration
 - Generate hex tiles lazily upon reveal so the battlefield only materializes
   around explored territory and active frontiers
 - Cull hex tile terrain and fog rendering to the active camera viewport so

--- a/src/data/names.ts
+++ b/src/data/names.ts
@@ -1,0 +1,102 @@
+const GIVEN_NAMES = [
+  'Aino',
+  'Eero',
+  'Ilona',
+  'Kalevi',
+  'Maija',
+  'Sami',
+  'Noora',
+  'Tuomas',
+  'Veera',
+  'Lauri',
+  'Sanna',
+  'Tapio',
+  'Eira',
+  'Janne',
+  'Kaisa',
+  'Oskari',
+  'Riikka',
+  'Saara',
+  'Ville',
+  'Arvo',
+  'Helmi',
+  'Juhani',
+  'Lumi',
+  'Mika',
+  'Otso',
+  'Petra',
+  'Taimi',
+  'Ukko',
+  'Väinö'
+] as const;
+
+const CLAN_NAMES = [
+  'Aurinkiranta',
+  'Frostwarden',
+  'Havukoski',
+  'Järvituuli',
+  'Karhula',
+  'Korventie',
+  'Kuusimäki',
+  'Löylymäki',
+  'Metsämaa',
+  'Niemelä',
+  'Revontuli',
+  'Saunamaa',
+  'Silakkala',
+  'Sisalintu',
+  'Suomenvirta',
+  'Talvilinna',
+  'Ukonaho',
+  'Vesiluoto',
+  'Virtaniemi',
+  'Yrttipelto'
+] as const;
+
+const EPITHETS = [
+  'the Ember-Tender',
+  'the Frost-Forged',
+  'the Löyly Keeper',
+  'the Steam-Seeker',
+  'the Sauna Sage',
+  'the Sisu-Bound',
+  'the Birchbinder',
+  'the Icebreaker',
+  'the Stonebather',
+  'the Hearth-Warden'
+] as const;
+
+function pick<T>(values: readonly T[], random: () => number): T | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+  const index = Math.floor(random() * values.length);
+  return values[Math.max(0, Math.min(values.length - 1, index))];
+}
+
+function combineName(parts: string[]): string {
+  return parts
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function generateSaunojaName(random: () => number = Math.random): string {
+  if (typeof random !== 'function') {
+    random = Math.random;
+  }
+
+  const given = pick(GIVEN_NAMES, random) ?? '';
+  const clan = pick(CLAN_NAMES, random) ?? '';
+  const useEpithet = random() > 0.6;
+  const epithet = useEpithet ? pick(EPITHETS, random) ?? '' : '';
+
+  const name = combineName([given, clan, epithet]);
+  return name.length > 0 ? name : 'Saunoja';
+}
+
+export function __testables() {
+  return { GIVEN_NAMES, CLAN_NAMES, EPITHETS, pick, combineName };
+}

--- a/src/style.css
+++ b/src/style.css
@@ -629,6 +629,131 @@ body > #game-container {
   font-size: 13px;
 }
 
+.panel-roster {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.panel-roster__empty {
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--color-surface) 60%, transparent);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+  color: var(--color-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.panel-roster__unit {
+  display: grid;
+  gap: 12px;
+  padding: 16px 18px;
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.82), rgba(30, 64, 175, 0.28));
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.24),
+    0 18px 28px rgba(15, 23, 42, 0.45);
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.panel-roster__unit.is-active {
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 38%, transparent),
+    0 22px 36px rgba(56, 189, 248, 0.28);
+}
+
+.panel-roster__unit.is-selected {
+  transform: translateY(-2px);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 52%, transparent),
+    0 26px 42px rgba(56, 189, 248, 0.35);
+}
+
+.panel-roster__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel-roster__name {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-foreground);
+}
+
+.panel-roster__status {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-foreground) 85%, transparent);
+  white-space: nowrap;
+}
+
+.panel-roster__health {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-surface) 55%, transparent);
+  overflow: hidden;
+}
+
+.panel-roster__health-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.85), rgba(59, 130, 246, 0.95));
+  box-shadow: 0 6px 16px rgba(56, 189, 248, 0.4);
+}
+
+.panel-roster__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  color: var(--color-muted);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.panel-roster__metric {
+  padding: 6px 10px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--color-surface) 62%, transparent);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.22);
+}
+
+.panel-roster__traits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.panel-roster__trait {
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, rgba(56, 189, 248, 0.32) 60%, transparent);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.24);
+  color: var(--color-foreground);
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.panel-roster__trait.is-empty {
+  background: color-mix(in srgb, var(--color-surface) 60%, transparent);
+  color: var(--color-muted);
+  letter-spacing: 0.08em;
+}
+
 .sauna-control {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
## Summary
- add a roster tab to the right HUD panel with detailed cards, health meters, and trait chips fed from live unit data
- generate Finland-flavoured names for Saunoja attendants, persist them across saves, and surface them in logs and the roster UI
- refresh styling assets and documentation to capture the new roster presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae1d744bc8330a1795b291d859b49