### PR TITLE
Add fog exploration fallback for idle units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Elevate the right panel into a sauna command console with a dedicated roster
   tab that highlights attendant status, live health bars, polished trait
   summaries, and direct selection alongside the policies, events, and log panes
+- Let unattended ticks send idle scouts toward the nearest fogged hex, caching
+  partial paths yet clearing them once exploration goals are reached so units
+  keep uncovering the battlefield without drifting aimlessly
 - Generate flavorful Saunoja names when attendants join the roster so every HUD
   entry reads as a distinct warrior rather than a generic placeholder
 - March enemy spawns along the fog frontier so marauders emerge just beyond

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -314,6 +314,14 @@ export class Unit {
     return null;
   }
 
+  canTraverse(
+    coord: AxialCoord,
+    map: HexMap,
+    occupied?: Set<string>
+  ): boolean {
+    return this.isPassable(coord, map, occupied);
+  }
+
   private isPassable(
     coord: AxialCoord,
     map: HexMap,


### PR DESCRIPTION
## Summary
- add a breadth-first exploration goal finder so idle units walk toward nearby fog
- expose a reusable passability check and clear cached paths once exploration goals are reached
- extend BattleManager tests and document the exploration fallback in the changelog

## Testing
- npm run test -- BattleManager
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf09e1c44833082f0515a0c7cf7f2