### PR TITLE
Adjust auto-framing for right HUD occlusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Offset auto-framing calculations to subtract the right HUD occlusion, keeping
+  newly revealed tiles centered within the unobscured canvas when the command
+  console is open
 - Elevate the right panel into a sauna command console with a dedicated roster
   tab that highlights attendant status, live health bars, polished trait
   summaries, and direct selection alongside the policies, events, and log panes

--- a/src/camera/autoFrame.test.ts
+++ b/src/camera/autoFrame.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { autoFrame, markRevealed, resetAutoFrame } from './autoFrame.ts';
+
+describe('autoFrame', () => {
+  beforeEach(() => {
+    resetAutoFrame();
+  });
+
+  afterEach(() => {
+    resetAutoFrame();
+  });
+
+  it('reduces zoom and shifts the center when the right HUD column occludes the view', () => {
+    markRevealed({ q: 0, r: 0 }, 32);
+    markRevealed({ q: 1, r: 0 }, 32);
+
+    const viewport = { width: 600, height: 2000 };
+    const baseFrame = autoFrame(viewport);
+
+    const safeRight = 200;
+    const occludedFrame = autoFrame({ ...viewport, safeRight });
+
+    expect(occludedFrame.zoom).toBeLessThan(baseFrame.zoom);
+
+    const expectedShift = safeRight / (2 * occludedFrame.zoom);
+    expect(occludedFrame.center.x).toBeCloseTo(baseFrame.center.x - expectedShift, 5);
+    expect(occludedFrame.center.y).toBeCloseTo(baseFrame.center.y, 5);
+  });
+});

--- a/src/camera/autoFrame.ts
+++ b/src/camera/autoFrame.ts
@@ -18,6 +18,11 @@ export function markRevealed(coord: AxialCoord, hexSize: number): void {
 export interface ViewportSize {
   width: number;
   height: number;
+  /**
+   * Portion of the viewport width that is obscured by HUD overlays on the
+   * right-hand side (for example the command console panel).
+   */
+  safeRight?: number;
 }
 
 export interface CameraFrame {
@@ -55,10 +60,16 @@ export function autoFrame(viewport: ViewportSize): CameraFrame {
   const height = maxY - minY;
   const padding = 96;
   const center = { x: minX + width / 2, y: minY + height / 2 };
-  const zoomX = viewport.width / (width + padding * 2);
+  const safeRight = Math.max(0, Math.min(viewport.safeRight ?? 0, viewport.width));
+  const effectiveWidth = Math.max(viewport.width - safeRight, 1);
+  const zoomX = effectiveWidth / (width + padding * 2);
   const zoomY = viewport.height / (height + padding * 2);
   const zoom = Math.min(zoomX, zoomY);
-  return { center, zoom };
+  const adjustedCenterX = zoom > 0 ? center.x - safeRight / (2 * zoom) : center.x;
+  return {
+    center: { x: adjustedCenterX, y: center.y },
+    zoom,
+  };
 }
 
 export interface CameraState {


### PR DESCRIPTION
## Summary
- measure the right-side HUD occlusion before triggering auto-framing so the map viewport reflects the visible canvas
- extend the camera autoFrame helper with a safeRight margin, subtract it from zoom calculations, and translate the camera center accordingly
- add regression coverage for occluded viewports and document the change in the changelog

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf478e2a88330a4360eb54c6439f0