### PR TITLE
Persist policy upgrades across save/load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Persist applied policy upgrades across saves, replaying their effects on load so eco beer production and temperance night shifts stay active after reloading
 - Pace battle movement with per-unit cooldowns so units only step once every
   five seconds, aligning pathfinding, stats, and tests with the slower cadence
 - Offset auto-framing calculations to subtract the right HUD occlusion, keeping


### PR DESCRIPTION
## Summary
- persist applied policy ids and derived modifiers when saving game state
- replay saved policies while loading so passive income and night work speed reflect purchased upgrades
- add tests covering policy persistence and update changelog entry

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cb846abb148330bbd2042f509c9694