### PR TITLE
Persist right panel logs across sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Remember the sauna command console log between sessions with polished storage so the right panel rehydrates prior narration on reload
 - Persist applied policy upgrades across saves, replaying their effects on load so eco beer production and temperance night shifts stay active after reloading
 - Pace battle movement with per-unit cooldowns so units only step once every
   five seconds, aligning pathfinding, stats, and tests with the slower cadence


### PR DESCRIPTION
## Summary
- hydrate the right panel log from storage on setup and persist entries after each flush while maintaining the 100 message cap
- add helper utilities for sanitizing stored log history and ensure DOM trimming mirrors the saved list
- cover log persistence with a reload integration test and document the change in the changelog

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb877c42e88330979979d8fa52bd73