### PR TITLE
Use roster names for spawn logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Refine battle log narration to greet arriving Saunojas by their roster names
+  while skipping rival spawn callouts for a cleaner feed
 - Collapse the sauna command console by default on sub-960px viewports,
   surface a HUD toggle, and slide the panel off-canvas so the map stays
   interactive on mobile


### PR DESCRIPTION
## Summary
- Announce allied arrivals in the event log with their roster names and stop logging rival spawns to keep the feed focused
- Preserve roster names for casualty logs by capturing the Saunoja persona before detachments and providing a matchMedia stub for tests
- Refresh the event log unit tests and changelog to cover the new messaging expectations

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb919949b483308d4663fcc0573139