### PR TITLE
Reset roster renderer after rebuilding right panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Reset the command console roster renderer whenever the panel rebuilds so the
+  Saunoja list repopulates after DOM swaps, and lock the behavior with a
+  regression test that rebuilds the UI shell
 - Decouple frontier raiders into a dedicated edge spawner that honors the 30-unit
   cap while sauna heat now summons only allied reinforcements with escalating
   thresholds

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -199,6 +199,21 @@ describe('game logging', () => {
 
     expect(updatedCoords).toContain(targetKey);
   });
+
+  it('re-renders the roster after rebuilding the right panel UI', async () => {
+    const { __rebuildRightPanelForTest } = await initGame();
+
+    const rosterRows = () =>
+      Array.from(document.querySelectorAll<HTMLLIElement>('.panel-roster__row'));
+
+    await flushLogs();
+    expect(rosterRows().length).toBeGreaterThan(0);
+
+    __rebuildRightPanelForTest();
+
+    await flushLogs();
+    expect(rosterRows().length).toBeGreaterThan(0);
+  });
 });
 
 describe('saunoja persistence', () => {

--- a/src/game.ts
+++ b/src/game.ts
@@ -67,6 +67,11 @@ let addEvent: (event: GameEvent) => void = () => {};
 let renderRosterView: ((entries: RosterEntry[]) => void) | null = null;
 let rosterSignature: string | null = null;
 
+function installRosterRenderer(renderer: (entries: RosterEntry[]) => void): void {
+  rosterSignature = null;
+  renderRosterView = renderer;
+}
+
 const SAUNOJA_STORAGE_KEY = 'autobattles:saunojas';
 
 function rollSaunojaUpkeep(random: () => number = Math.random): number {
@@ -586,12 +591,17 @@ const updateTopbar = setupTopbar(
     }
   }
 );
-const rightPanel = setupRightPanel(state, {
-  onRosterSelect: focusSaunojaById
-});
-log = rightPanel.log;
-addEvent = rightPanel.addEvent;
-renderRosterView = rightPanel.renderRoster;
+function initializeRightPanel(): void {
+  const rightPanel = setupRightPanel(state, {
+    onRosterSelect: focusSaunojaById,
+    onRosterRendererReady: installRosterRenderer
+  });
+  log = rightPanel.log;
+  addEvent = rightPanel.addEvent;
+  installRosterRenderer(rightPanel.renderRoster);
+}
+
+initializeRightPanel();
 updateRosterDisplay();
 
 
@@ -816,6 +826,11 @@ export async function start(): Promise<void> {
 }
 
 export { log };
+
+export function __rebuildRightPanelForTest(): void {
+  initializeRightPanel();
+  updateRosterDisplay();
+}
 
 export function __syncSaunojaRosterForTest(): boolean {
   return syncSaunojaRosterWithUnits();

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -22,6 +22,7 @@ export type RosterEntry = {
 
 type RightPanelOptions = {
   onRosterSelect?: (unitId: string) => void;
+  onRosterRendererReady?: (renderer: (entries: RosterEntry[]) => void) => void;
 };
 
 export function setupRightPanel(
@@ -160,7 +161,7 @@ export function setupRightPanel(
     Log: logTab
   };
 
-  const { onRosterSelect } = options;
+  const { onRosterSelect, onRosterRendererReady } = options;
   const numberFormatter = new Intl.NumberFormat('en-US');
   const rosterCountFormatter = new Intl.NumberFormat('en-US', {
     maximumFractionDigits: 0
@@ -338,6 +339,10 @@ export function setupRightPanel(
   }
 
   renderRoster([]);
+
+  if (typeof onRosterRendererReady === 'function') {
+    onRosterRendererReady(renderRoster);
+  }
 
   // --- Policies ---
   type PolicyDef = {


### PR DESCRIPTION
## Summary
- reset the stored roster renderer whenever a new right panel instance is mounted so roster refreshes target the latest DOM
- expose a rebuild helper through `setupRightPanel` and use it from the game module to immediately invalidate the roster signature
- document the fix in the changelog and add a regression test that rebuilds the right panel to verify the roster repopulates

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9b3c1cb88330bf445aa5f1c10094