### PR TITLE
Expand terrain cache when map bounds grow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Expand the cached hex terrain canvas whenever exploration pushes map bounds
+  beyond the last render rectangle so fog clearing immediately reveals freshly
+  rendered tiles
 - Reset the command console roster renderer whenever the panel rebuilds so the
   Saunoja list repopulates after DOM swaps, and lock the behavior with a
   regression test that rebuilds the UI shell


### PR DESCRIPTION
## Summary
- track the pixel bounds used for the cached hex terrain canvas and recompute the live map bounds from the current axial range
- invalidate and rebuild the cached terrain when the map expands so exploration immediately reveals new tiles
- document the cache resizing behavior in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbb7d9bccc833085b3acc6bab6491d