### PR TITLE
Unify unit stat progression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Introduce a shared unit stat model with dedicated types, leveling curves, and
+  calculators, replace archetype subclasses with data-driven definitions, route
+  factories through the new adapters, and verify deterministic progression
+  across soldiers, archers, and marauders
 - Preserve stored Saunoja personas when reattaching to new sessions so reloads
   keep their earned traits, upkeep, and experience intact
 - Expand the cached hex terrain canvas whenever exploration pushes map bounds

--- a/src/ai/Targeting.test.ts
+++ b/src/ai/Targeting.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Targeting } from './Targeting.ts';
-import { Unit, UnitStats } from '../units/Unit.ts';
+import { Unit } from '../units/Unit.ts';
+import type { UnitStats } from '../unit/types.ts';
 
 function createUnit(
   id: string,

--- a/src/sim/EnemySpawner.ts
+++ b/src/sim/EnemySpawner.ts
@@ -1,7 +1,7 @@
-import { AvantoMarauder } from '../units/AvantoMarauder.ts';
 import type { Unit } from '../units/Unit.ts';
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import { MAX_ENEMIES } from '../battle/BattleManager.ts';
+import { createUnit } from '../units/UnitFactory.ts';
 
 export class EnemySpawner {
   private timer = 30; // seconds
@@ -22,7 +22,10 @@ export class EnemySpawner {
     if (enemyCount < MAX_ENEMIES) {
       const at = pickEdge();
       if (at) {
-        addUnit(new AvantoMarauder(`e${Date.now()}`, at, 'enemy'));
+        const unit = createUnit('avanto-marauder', `e${Date.now()}`, at, 'enemy');
+        if (unit) {
+          addUnit(unit);
+        }
       }
     }
 

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -1,3 +1,7 @@
+export * from './unit/types.ts';
+export * from './unit/level.ts';
+export * from './unit/calc.ts';
+export * from './unit/archetypes.ts';
 export * from './units/Unit.ts';
 export * from './units/Soldier.ts';
 export * from './units/Archer.ts';

--- a/src/unit/archetypes.ts
+++ b/src/unit/archetypes.ts
@@ -1,0 +1,70 @@
+import type { UnitArchetypeDefinition, UnitArchetypeId } from './types.ts';
+
+const soldierDefinition: UnitArchetypeDefinition = Object.freeze({
+  id: 'soldier',
+  displayName: 'Sauna Soldier',
+  cost: 50,
+  tags: ['infantry', 'melee'],
+  stats: {
+    health: { base: 20, growth: 6, curve: 'linear', round: 'round' },
+    attackDamage: { base: 5, growth: 1, curve: 'linear', round: 'round' },
+    attackRange: { base: 1, growth: 0, round: 'round' },
+    movementRange: { base: 1, growth: 0, round: 'round' },
+    visionRange: { base: 3, growth: 0, round: 'round' }
+  }
+} satisfies UnitArchetypeDefinition);
+
+const archerDefinition: UnitArchetypeDefinition = Object.freeze({
+  id: 'archer',
+  displayName: 'Sauna Archer',
+  cost: 75,
+  tags: ['ranged'],
+  stats: {
+    health: { base: 15, growth: 4, curve: 'linear', round: 'round' },
+    attackDamage: { base: 3, growth: 0.4, curve: 'accelerating', round: 'ceil' },
+    attackRange: { base: 3, growth: 0.5, curve: 'diminishing', round: 'ceil', max: 5 },
+    movementRange: { base: 1, growth: 0, round: 'round' },
+    visionRange: { base: 3, growth: 0.25, curve: 'linear', round: 'round', max: 5 }
+  }
+} satisfies UnitArchetypeDefinition);
+
+const marauderDefinition: UnitArchetypeDefinition = Object.freeze({
+  id: 'avanto-marauder',
+  displayName: 'Avanto Marauder',
+  cost: 0,
+  tags: ['enemy', 'melee'],
+  stats: {
+    health: { base: 12, growth: 5, curve: 'linear', round: 'round' },
+    attackDamage: { base: 4, growth: 0.6, curve: 'accelerating', round: 'ceil' },
+    attackRange: { base: 1, growth: 0, round: 'round' },
+    movementRange: { base: 1, growth: 0.25, curve: 'linear', round: 'round', max: 2 },
+    visionRange: { base: 3, growth: 0, round: 'round' }
+  }
+} satisfies UnitArchetypeDefinition);
+
+const UNIT_ARCHETYPES: Record<UnitArchetypeId, UnitArchetypeDefinition> = Object.freeze({
+  soldier: soldierDefinition,
+  archer: archerDefinition,
+  'avanto-marauder': marauderDefinition
+});
+
+export function getUnitArchetype(id: UnitArchetypeId): UnitArchetypeDefinition {
+  const archetype = UNIT_ARCHETYPES[id];
+  if (!archetype) {
+    throw new Error(`Unknown unit archetype: ${id}`);
+  }
+  return archetype;
+}
+
+export function tryGetUnitArchetype(id: UnitArchetypeId | string): UnitArchetypeDefinition | null {
+  const archetype = UNIT_ARCHETYPES[id as UnitArchetypeId];
+  return archetype ?? null;
+}
+
+export const UNIT_ARCHETYPE_IDS: readonly UnitArchetypeId[] = Object.freeze(
+  Object.keys(UNIT_ARCHETYPES) as UnitArchetypeId[]
+);
+
+export { soldierDefinition as SOLDIER_ARCHETYPE };
+export { archerDefinition as ARCHER_ARCHETYPE };
+export { marauderDefinition as AVANTO_MARAUDER_ARCHETYPE };

--- a/src/unit/calc.test.ts
+++ b/src/unit/calc.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { computeUnitStats } from './calc.ts';
+import {
+  SOLDIER_ARCHETYPE,
+  ARCHER_ARCHETYPE,
+  AVANTO_MARAUDER_ARCHETYPE
+} from './archetypes.ts';
+import { SOLDIER_STATS } from '../units/Soldier.ts';
+import { ARCHER_STATS } from '../units/Archer.ts';
+import { AVANTO_MARAUDER_STATS } from '../units/AvantoMarauder.ts';
+
+describe('computeUnitStats', () => {
+  it('returns base archetype stats at level 1', () => {
+    expect(computeUnitStats(SOLDIER_ARCHETYPE, 1)).toEqual(SOLDIER_STATS);
+    expect(computeUnitStats(ARCHER_ARCHETYPE, 1)).toEqual(ARCHER_STATS);
+    expect(computeUnitStats(AVANTO_MARAUDER_ARCHETYPE, 1)).toEqual(AVANTO_MARAUDER_STATS);
+  });
+
+  it('normalizes invalid levels to the base level', () => {
+    expect(computeUnitStats(SOLDIER_ARCHETYPE, 0)).toEqual(SOLDIER_STATS);
+    expect(computeUnitStats(SOLDIER_ARCHETYPE, -5)).toEqual(SOLDIER_STATS);
+    expect(computeUnitStats(ARCHER_ARCHETYPE, 1.9)).toEqual(ARCHER_STATS);
+  });
+
+  it('scales soldier stats linearly', () => {
+    expect(computeUnitStats(SOLDIER_ARCHETYPE, 3)).toEqual({
+      health: 32,
+      attackDamage: 7,
+      attackRange: 1,
+      movementRange: 1,
+      visionRange: 3
+    });
+    expect(computeUnitStats(SOLDIER_ARCHETYPE, 5)).toEqual({
+      health: 44,
+      attackDamage: 9,
+      attackRange: 1,
+      movementRange: 1,
+      visionRange: 3
+    });
+  });
+
+  it('applies archer acceleration and diminishing returns curves', () => {
+    expect(computeUnitStats(ARCHER_ARCHETYPE, 3)).toEqual({
+      health: 23,
+      attackDamage: 5,
+      attackRange: 4,
+      movementRange: 1,
+      visionRange: 4
+    });
+    expect(computeUnitStats(ARCHER_ARCHETYPE, 5)).toEqual({
+      health: 31,
+      attackDamage: 7,
+      attackRange: 5,
+      movementRange: 1,
+      visionRange: 4
+    });
+  });
+
+  it('caps marauder movement while accelerating damage', () => {
+    expect(computeUnitStats(AVANTO_MARAUDER_ARCHETYPE, 3)).toEqual({
+      health: 22,
+      attackDamage: 6,
+      attackRange: 1,
+      movementRange: 2,
+      visionRange: 3
+    });
+    expect(computeUnitStats(AVANTO_MARAUDER_ARCHETYPE, 7)).toEqual({
+      health: 42,
+      attackDamage: 17,
+      attackRange: 1,
+      movementRange: 2,
+      visionRange: 3
+    });
+  });
+});

--- a/src/unit/calc.ts
+++ b/src/unit/calc.ts
@@ -1,0 +1,53 @@
+import type { StatProgression, UnitArchetypeDefinition, UnitStats } from './types.ts';
+import type { RoundingMode } from './types.ts';
+import { curveProgress, normalizeLevel } from './level.ts';
+
+function applyRounding(value: number, mode: RoundingMode = 'round'): number {
+  switch (mode) {
+    case 'floor':
+      return Math.floor(value);
+    case 'ceil':
+      return Math.ceil(value);
+    case 'none':
+      return value;
+    case 'round':
+    default:
+      return Math.round(value);
+  }
+}
+
+function clamp(value: number, min?: number, max?: number): number {
+  let result = value;
+  if (Number.isFinite(min)) {
+    result = Math.max(result, min as number);
+  }
+  if (Number.isFinite(max)) {
+    result = Math.min(result, max as number);
+  }
+  return result;
+}
+
+export function evaluateProgression(progression: StatProgression, level?: number): number {
+  const resolvedLevel = normalizeLevel(level);
+  const curve = progression.curve ?? 'linear';
+  const progress = curveProgress(resolvedLevel, curve);
+  const value = progression.base + progression.growth * progress;
+  const bounded = clamp(value, progression.min, progression.max);
+  return applyRounding(bounded, progression.round ?? 'round');
+}
+
+export function computeUnitStats(definition: UnitArchetypeDefinition, level?: number): UnitStats {
+  const resolvedLevel = normalizeLevel(level);
+  const stats = definition.stats;
+  const base: UnitStats = {
+    health: evaluateProgression(stats.health, resolvedLevel),
+    attackDamage: evaluateProgression(stats.attackDamage, resolvedLevel),
+    attackRange: evaluateProgression(stats.attackRange, resolvedLevel),
+    movementRange: evaluateProgression(stats.movementRange, resolvedLevel)
+  };
+  if (stats.visionRange) {
+    base.visionRange = evaluateProgression(stats.visionRange, resolvedLevel);
+  }
+  return base;
+}
+

--- a/src/unit/level.ts
+++ b/src/unit/level.ts
@@ -1,0 +1,26 @@
+import type { LevelCurve } from './types.ts';
+
+export function normalizeLevel(level?: number): number {
+  if (!Number.isFinite(level ?? NaN)) {
+    return 1;
+  }
+  const normalized = Math.floor(level as number);
+  return Math.max(1, normalized);
+}
+
+export function levelIndex(level?: number): number {
+  return Math.max(0, normalizeLevel(level) - 1);
+}
+
+export function curveProgress(level: number, curve: LevelCurve = 'linear'): number {
+  const index = levelIndex(level);
+  switch (curve) {
+    case 'accelerating':
+      return (index * (index + 1)) / 2;
+    case 'diminishing':
+      return index === 0 ? 0 : Math.log2(index + 1);
+    case 'linear':
+    default:
+      return index;
+  }
+}

--- a/src/unit/types.ts
+++ b/src/unit/types.ts
@@ -1,0 +1,51 @@
+export interface UnitStats {
+  health: number;
+  attackDamage: number;
+  attackRange: number;
+  movementRange: number;
+  visionRange?: number;
+}
+
+export type LevelCurve = 'linear' | 'accelerating' | 'diminishing';
+
+export type RoundingMode = 'floor' | 'ceil' | 'round' | 'none';
+
+export interface StatProgression {
+  /** Base value applied at level 1. */
+  base: number;
+  /** Increment applied according to {@link curve} for each level beyond 1. */
+  growth: number;
+  /** Curve to apply when scaling beyond the base level. */
+  curve?: LevelCurve;
+  /** Minimum bound applied after growth and rounding. */
+  min?: number;
+  /** Maximum bound applied after growth and rounding. */
+  max?: number;
+  /** How the computed value should be rounded. */
+  round?: RoundingMode;
+}
+
+export interface UnitProgressionMap {
+  health: StatProgression;
+  attackDamage: StatProgression;
+  attackRange: StatProgression;
+  movementRange: StatProgression;
+  visionRange?: StatProgression;
+}
+
+export type UnitArchetypeId = 'soldier' | 'archer' | 'avanto-marauder';
+
+export interface UnitArchetypeDefinition {
+  id: UnitArchetypeId;
+  displayName: string;
+  description?: string;
+  cost: number;
+  tags?: string[];
+  priorityFactions?: string[];
+  stats: UnitProgressionMap;
+}
+
+export interface UnitBuildOptions {
+  /** Optional level override; defaults to 1. */
+  level?: number;
+}

--- a/src/units/Archer.ts
+++ b/src/units/Archer.ts
@@ -1,20 +1,35 @@
-import { Unit } from './Unit.ts';
-import type { UnitStats } from './Unit.ts';
 import type { AxialCoord } from '../hex/HexUtils.ts';
+import { Unit } from './Unit.ts';
+import { computeUnitStats } from '../unit/calc.ts';
+import { ARCHER_ARCHETYPE } from '../unit/archetypes.ts';
+import type { UnitBuildOptions, UnitStats } from '../unit/types.ts';
 
-export const ARCHER_STATS: UnitStats = {
-  health: 15,
-  attackDamage: 3,
-  attackRange: 3,
-  movementRange: 1,
-  visionRange: 3
-};
+export const ARCHER_COST = ARCHER_ARCHETYPE.cost;
 
-export const ARCHER_COST = 75;
+export const ARCHER_STATS: UnitStats = Object.freeze(
+  computeUnitStats(ARCHER_ARCHETYPE, 1)
+) as UnitStats;
+
+export interface ArcherOptions extends UnitBuildOptions {}
+
+export function createArcher(
+  id: string,
+  coord: AxialCoord,
+  faction: string,
+  options?: ArcherOptions
+): Unit {
+  const stats = computeUnitStats(ARCHER_ARCHETYPE, options?.level);
+  return new Unit(id, ARCHER_ARCHETYPE.id, coord, faction, stats, ARCHER_ARCHETYPE.priorityFactions);
+}
+
+export function getArcherStats(level?: number): UnitStats {
+  return computeUnitStats(ARCHER_ARCHETYPE, level);
+}
 
 export class Archer extends Unit {
-  constructor(id: string, coord: AxialCoord, faction: string) {
-    super(id, 'archer', coord, faction, { ...ARCHER_STATS });
+  constructor(id: string, coord: AxialCoord, faction: string, options?: ArcherOptions) {
+    const stats = computeUnitStats(ARCHER_ARCHETYPE, options?.level);
+    super(id, ARCHER_ARCHETYPE.id, coord, faction, stats, ARCHER_ARCHETYPE.priorityFactions);
   }
 }
 

--- a/src/units/AvantoMarauder.ts
+++ b/src/units/AvantoMarauder.ts
@@ -1,18 +1,33 @@
-import { Unit } from './Unit.ts';
-import type { UnitStats } from './Unit.ts';
 import type { AxialCoord } from '../hex/HexUtils.ts';
+import { Unit } from './Unit.ts';
+import { computeUnitStats } from '../unit/calc.ts';
+import { AVANTO_MARAUDER_ARCHETYPE } from '../unit/archetypes.ts';
+import type { UnitBuildOptions, UnitStats } from '../unit/types.ts';
 
-export const AVANTO_MARAUDER_STATS: UnitStats = {
-  health: 12,
-  attackDamage: 4,
-  attackRange: 1,
-  movementRange: 1,
-  visionRange: 3
-};
+export const AVANTO_MARAUDER_STATS: UnitStats = Object.freeze(
+  computeUnitStats(AVANTO_MARAUDER_ARCHETYPE, 1)
+) as UnitStats;
+
+export interface AvantoMarauderOptions extends UnitBuildOptions {}
+
+export function createAvantoMarauder(
+  id: string,
+  coord: AxialCoord,
+  faction: string,
+  options?: AvantoMarauderOptions
+): Unit {
+  const stats = computeUnitStats(AVANTO_MARAUDER_ARCHETYPE, options?.level);
+  return new Unit(id, AVANTO_MARAUDER_ARCHETYPE.id, coord, faction, stats, AVANTO_MARAUDER_ARCHETYPE.priorityFactions);
+}
+
+export function getAvantoMarauderStats(level?: number): UnitStats {
+  return computeUnitStats(AVANTO_MARAUDER_ARCHETYPE, level);
+}
 
 export class AvantoMarauder extends Unit {
-  constructor(id: string, coord: AxialCoord, faction: string) {
-    super(id, 'avanto-marauder', coord, faction, { ...AVANTO_MARAUDER_STATS });
+  constructor(id: string, coord: AxialCoord, faction: string, options?: AvantoMarauderOptions) {
+    const stats = computeUnitStats(AVANTO_MARAUDER_ARCHETYPE, options?.level);
+    super(id, AVANTO_MARAUDER_ARCHETYPE.id, coord, faction, stats, AVANTO_MARAUDER_ARCHETYPE.priorityFactions);
   }
 }
 

--- a/src/units/Soldier.ts
+++ b/src/units/Soldier.ts
@@ -1,20 +1,35 @@
-import { Unit } from './Unit.ts';
-import type { UnitStats } from './Unit.ts';
 import type { AxialCoord } from '../hex/HexUtils.ts';
+import { Unit } from './Unit.ts';
+import { computeUnitStats } from '../unit/calc.ts';
+import { SOLDIER_ARCHETYPE } from '../unit/archetypes.ts';
+import type { UnitBuildOptions, UnitStats } from '../unit/types.ts';
 
-export const SOLDIER_STATS: UnitStats = {
-  health: 20,
-  attackDamage: 5,
-  attackRange: 1,
-  movementRange: 1,
-  visionRange: 3
-};
+export const SOLDIER_COST = SOLDIER_ARCHETYPE.cost;
 
-export const SOLDIER_COST = 50;
+export const SOLDIER_STATS: UnitStats = Object.freeze(
+  computeUnitStats(SOLDIER_ARCHETYPE, 1)
+) as UnitStats;
+
+export interface SoldierOptions extends UnitBuildOptions {}
+
+export function createSoldier(
+  id: string,
+  coord: AxialCoord,
+  faction: string,
+  options?: SoldierOptions
+): Unit {
+  const stats = computeUnitStats(SOLDIER_ARCHETYPE, options?.level);
+  return new Unit(id, SOLDIER_ARCHETYPE.id, coord, faction, stats, SOLDIER_ARCHETYPE.priorityFactions);
+}
+
+export function getSoldierStats(level?: number): UnitStats {
+  return computeUnitStats(SOLDIER_ARCHETYPE, level);
+}
 
 export class Soldier extends Unit {
-  constructor(id: string, coord: AxialCoord, faction: string) {
-    super(id, 'soldier', coord, faction, { ...SOLDIER_STATS });
+  constructor(id: string, coord: AxialCoord, faction: string, options?: SoldierOptions) {
+    const stats = computeUnitStats(SOLDIER_ARCHETYPE, options?.level);
+    super(id, SOLDIER_ARCHETYPE.id, coord, faction, stats, SOLDIER_ARCHETYPE.priorityFactions);
   }
 }
 

--- a/src/units/Unit.test.ts
+++ b/src/units/Unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Unit, UnitStats } from './Unit.ts';
+import { Unit } from './Unit.ts';
+import type { UnitStats } from '../unit/types.ts';
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import { HexMap } from '../hexmap.ts';
 import { TerrainId } from '../map/terrain.ts';

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -4,14 +4,7 @@ import { HexMap } from '../hexmap.ts';
 import { TerrainId } from '../map/terrain.ts';
 import { eventBus } from '../events';
 import type { Sauna } from '../buildings/Sauna.ts';
-
-export interface UnitStats {
-  health: number;
-  attackDamage: number;
-  attackRange: number;
-  movementRange: number;
-  visionRange?: number;
-}
+import type { UnitStats } from '../unit/types.ts';
 
 export const UNIT_MOVEMENT_STEP_SECONDS = 5;
 

--- a/src/units/UnitFactory.test.ts
+++ b/src/units/UnitFactory.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { GameState, Resource } from '../core/GameState.ts';
-import { spawnUnit } from './UnitFactory.ts';
-import { SOLDIER_STATS, SOLDIER_COST } from './Soldier.ts';
+import { createUnit, spawnUnit } from './UnitFactory.ts';
+import { SOLDIER_STATS, SOLDIER_COST, getSoldierStats } from './Soldier.ts';
 import { ARCHER_STATS, ARCHER_COST } from './Archer.ts';
+import { getAvantoMarauderStats } from './AvantoMarauder.ts';
 import { eventBus } from '../events/EventBus.ts';
 
 const origin = { q: 0, r: 0 };
@@ -52,6 +53,20 @@ describe('UnitFactory', () => {
     }
     expect(unit).not.toBeNull();
     expect(received).toEqual(['s1']);
+  });
+
+  it('creates leveled stats deterministically', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.SAUNA_BEER, 500);
+    const unit = spawnUnit(state, 'soldier', 's2', origin, 'player', { level: 4 });
+    expect(unit).not.toBeNull();
+    expect(unit!.stats).toEqual(getSoldierStats(4));
+  });
+
+  it('creates archetype instances without spending resources', () => {
+    const unit = createUnit('avanto-marauder', 'enemy1', origin, 'enemy', { level: 3 });
+    expect(unit).not.toBeNull();
+    expect(unit!.stats).toEqual(getAvantoMarauderStats(3));
   });
 });
 


### PR DESCRIPTION
## Summary
- add shared unit stat types, leveling helpers, and calculators with soldier, archer, and marauder archetype definitions
- instantiate units via the new data-driven model across adapters, the factory, and the enemy spawner
- verify deterministic stat progressions and leveled spawns with new tests and changelog coverage

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbc7b39aa08330b475ba72728d6738