### PR TITLE
feat: add faction bundle driven enemy spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Catalog faction spawn bundles in JSON, expose weighted selection helpers, and
+  drive enemy wave spawns through the bundle system with cadence and identity
+  tests
 - Introduce a shared combat resolver that applies the max(1, atk - def) formula,
   tracks shield absorption, fires keyword hooks for both sides, and routes
   modifier callbacks so Saunoja and battlefield units share consistent

--- a/src/content/factions/deepwood.json
+++ b/src/content/factions/deepwood.json
@@ -1,0 +1,28 @@
+{
+  "id": "deepwood",
+  "name": "Deepwood Wardens",
+  "description": "Reclusive guardians attuned to sauna spirits.",
+  "bundles": [
+    {
+      "id": "warding-circle",
+      "label": "Warding Circle",
+      "weight": 2,
+      "units": [
+        { "unit": "soldier", "level": 1, "quantity": 2 },
+        { "unit": "archer", "level": 1, "quantity": 1 }
+      ],
+      "items": ["spirit-oak-charm", "sauna-incense"],
+      "modifiers": ["barkskin-ritual"]
+    },
+    {
+      "id": "spirit-strike",
+      "label": "Spirit Strike",
+      "weight": 1,
+      "units": [
+        { "unit": "archer", "level": 2, "quantity": 2 }
+      ],
+      "items": ["emberglass-arrow"],
+      "modifiers": ["searing-chant", "windstep"]
+    }
+  ]
+}

--- a/src/content/factions/enemy.json
+++ b/src/content/factions/enemy.json
@@ -1,0 +1,37 @@
+{
+  "id": "enemy",
+  "name": "Avanto Marauders",
+  "description": "Frostbitten raiders who harry the sauna frontier.",
+  "bundles": [
+    {
+      "id": "iceblade-scouts",
+      "label": "Iceblade Scouts",
+      "weight": 3,
+      "units": [
+        { "unit": "avanto-marauder", "level": 1, "quantity": 1 }
+      ],
+      "items": ["cracked-ice-amulet"],
+      "modifiers": ["frost-resilience"]
+    },
+    {
+      "id": "raiding-party",
+      "label": "Raiding Party",
+      "weight": 2,
+      "units": [
+        { "unit": "avanto-marauder", "level": 1, "quantity": 2 }
+      ],
+      "items": ["stolen-sauna-tokens"],
+      "modifiers": ["berserker-drift"]
+    },
+    {
+      "id": "frost-champion",
+      "label": "Frost Champion",
+      "weight": 1,
+      "units": [
+        { "unit": "avanto-marauder", "level": 2, "quantity": 1 }
+      ],
+      "items": ["glacier-brand"],
+      "modifiers": ["glacial-ward"]
+    }
+  ]
+}

--- a/src/factions/bundles.test.ts
+++ b/src/factions/bundles.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  FACTION_IDS,
+  getFaction,
+  getFactionBundles,
+  pickFactionBundle
+} from './bundles.ts';
+
+describe('faction bundles', () => {
+  it('exposes loaded faction identities', () => {
+    expect(FACTION_IDS).toContain('enemy');
+    expect(getFaction('deepwood')?.name).toBe('Deepwood Wardens');
+  });
+
+  it('only selects bundles from the requested faction', () => {
+    const bundle = pickFactionBundle('deepwood', () => 0);
+    expect(bundle.id).toBe('warding-circle');
+    expect(bundle.units.every((unit) => unit.unit !== 'avanto-marauder')).toBe(true);
+  });
+
+  it('respects bundle weights during selection', () => {
+    const bundle = pickFactionBundle('enemy', () => 0.99);
+    expect(bundle.id).toBe('frost-champion');
+  });
+
+  it('falls back to Math.random when a provided source is invalid', () => {
+    const randomSpy = vi.spyOn(Math, 'random');
+    randomSpy.mockReturnValue(0.5);
+    const bundles = getFactionBundles('enemy');
+    expect(() => pickFactionBundle('enemy', () => Number.NaN)).not.toThrow();
+    expect(randomSpy).toHaveBeenCalled();
+    expect(bundles).not.toHaveLength(0);
+    randomSpy.mockRestore();
+  });
+});

--- a/src/factions/bundles.ts
+++ b/src/factions/bundles.ts
@@ -1,0 +1,223 @@
+import type { UnitArchetypeId } from '../unit/types.ts';
+
+export type RandomSource = () => number;
+
+export interface FactionBundleUnitDefinition {
+  readonly unit: UnitArchetypeId;
+  readonly level: number;
+  readonly quantity: number;
+}
+
+export interface FactionBundleDefinition {
+  readonly id: string;
+  readonly label: string;
+  readonly weight: number;
+  readonly units: readonly FactionBundleUnitDefinition[];
+  readonly items: readonly string[];
+  readonly modifiers: readonly string[];
+}
+
+export interface FactionDefinition {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly bundles: readonly FactionBundleDefinition[];
+}
+
+type JsonModule = { default: unknown } | unknown;
+
+const factionModules = import.meta.glob('../content/factions/*.json', { eager: true }) as Record<
+  string,
+  JsonModule
+>;
+
+const factionRegistry = new Map<string, FactionDefinition>();
+
+for (const [path, module] of Object.entries(factionModules)) {
+  const data = extractDefaultExport(module);
+  const faction = parseFactionDefinition(data, path);
+  if (factionRegistry.has(faction.id)) {
+    throw new Error(`Duplicate faction bundle id: ${faction.id}`);
+  }
+  factionRegistry.set(faction.id, faction);
+}
+
+function extractDefaultExport(module: JsonModule): unknown {
+  if (typeof module === 'object' && module !== null && 'default' in module) {
+    return (module as { default: unknown }).default;
+  }
+  return module;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function toNonEmptyString(value: unknown, context: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Expected string at ${context}`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`Expected non-empty string at ${context}`);
+  }
+  return trimmed;
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function toStringArray(value: unknown, context: string): readonly string[] {
+  if (value === undefined) {
+    return Object.freeze([]);
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected array at ${context}`);
+  }
+  const items = value.map((entry, index) => {
+    if (typeof entry !== 'string') {
+      throw new Error(`Expected string at ${context}[${index}]`);
+    }
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      throw new Error(`Expected non-empty string at ${context}[${index}]`);
+    }
+    return trimmed;
+  });
+  return Object.freeze(items);
+}
+
+function sanitizePositiveNumber(value: unknown, fallback: number): number {
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return fallback;
+  }
+  return numeric;
+}
+
+function sanitizePositiveInteger(value: unknown, fallback: number): number {
+  const numeric = Math.floor(sanitizePositiveNumber(value, fallback));
+  return numeric > 0 ? numeric : fallback;
+}
+
+function parseUnitDefinition(
+  value: unknown,
+  context: string
+): FactionBundleUnitDefinition {
+  if (!isRecord(value)) {
+    throw new Error(`Expected object at ${context}`);
+  }
+  const unit = toNonEmptyString(value.unit, `${context}.unit`) as UnitArchetypeId;
+  const level = sanitizePositiveInteger(value.level, 1);
+  const quantity = sanitizePositiveInteger(value.quantity, 1);
+  return Object.freeze({ unit, level, quantity });
+}
+
+function parseBundleDefinition(
+  value: unknown,
+  context: string,
+  fallbackId: string
+): FactionBundleDefinition {
+  if (!isRecord(value)) {
+    throw new Error(`Expected object at ${context}`);
+  }
+  const id = toOptionalString(value.id) ?? `${fallbackId}-bundle`;
+  const label = toOptionalString(value.label) ?? id;
+  const weight = sanitizePositiveNumber(value.weight, 1);
+  const unitsValue = value.units;
+  if (!Array.isArray(unitsValue) || unitsValue.length === 0) {
+    throw new Error(`Expected non-empty units array at ${context}.units`);
+  }
+  const units = unitsValue.map((entry, index) =>
+    parseUnitDefinition(entry, `${context}.units[${index}]`)
+  );
+  const items = toStringArray(value.items, `${context}.items`);
+  const modifiers = toStringArray(value.modifiers, `${context}.modifiers`);
+  return Object.freeze({
+    id,
+    label,
+    weight,
+    units: Object.freeze(units),
+    items,
+    modifiers
+  });
+}
+
+function parseFactionDefinition(value: unknown, context: string): FactionDefinition {
+  if (!isRecord(value)) {
+    throw new Error(`Expected object at ${context}`);
+  }
+  const id = toNonEmptyString(value.id, `${context}.id`);
+  const name = toNonEmptyString(value.name, `${context}.name`);
+  const description = toOptionalString(value.description);
+  if (!Array.isArray(value.bundles) || value.bundles.length === 0) {
+    throw new Error(`Expected non-empty bundles array at ${context}.bundles`);
+  }
+  const bundles = value.bundles.map((entry, index) =>
+    parseBundleDefinition(entry, `${context}.bundles[${index}]`, `${id}-${index}`)
+  );
+  return Object.freeze({
+    id,
+    name,
+    description,
+    bundles: Object.freeze(bundles)
+  });
+}
+
+export const FACTION_IDS: readonly string[] = Object.freeze(Array.from(factionRegistry.keys()));
+
+export function getFactions(): readonly FactionDefinition[] {
+  return Object.freeze(Array.from(factionRegistry.values()));
+}
+
+export function getFaction(id: string): FactionDefinition | null {
+  return factionRegistry.get(id) ?? null;
+}
+
+export function getFactionBundles(id: string): readonly FactionBundleDefinition[] {
+  return getFaction(id)?.bundles ?? Object.freeze([]);
+}
+
+function normalizeRandom(random: RandomSource | undefined): RandomSource {
+  if (typeof random === 'function') {
+    return random;
+  }
+  return Math.random;
+}
+
+function normalizeRoll(random: RandomSource): number {
+  const value = random();
+  if (!Number.isFinite(value) || value < 0 || value >= 1) {
+    return Math.random();
+  }
+  return value;
+}
+
+export function pickFactionBundle(
+  id: string,
+  randomSource?: RandomSource
+): FactionBundleDefinition {
+  const bundles = getFactionBundles(id);
+  if (bundles.length === 0) {
+    throw new Error(`No bundles found for faction: ${id}`);
+  }
+  const random = normalizeRandom(randomSource);
+  const totalWeight = bundles.reduce((sum, bundle) => sum + bundle.weight, 0);
+  if (!Number.isFinite(totalWeight) || totalWeight <= 0) {
+    throw new Error(`Invalid bundle weights for faction: ${id}`);
+  }
+  const roll = normalizeRoll(random) * totalWeight;
+  let cursor = 0;
+  for (const bundle of bundles) {
+    cursor += bundle.weight;
+    if (roll < cursor) {
+      return bundle;
+    }
+  }
+  return bundles[bundles.length - 1];
+}

--- a/src/sim/EnemySpawner.test.ts
+++ b/src/sim/EnemySpawner.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { EnemySpawner } from './EnemySpawner.ts';
+import type { Unit } from '../units/Unit.ts';
+import { getAvantoMarauderStats } from '../units/AvantoMarauder.ts';
+
+function makeRandomSource(values: number[]): () => number {
+  const queue = [...values];
+  return () => queue.shift() ?? 0;
+}
+
+describe('EnemySpawner', () => {
+  it('spawns bundles according to cadence and faction identity', () => {
+    const spawner = new EnemySpawner({
+      factionId: 'enemy',
+      random: makeRandomSource([0.6, 0.95])
+    });
+    const units: Unit[] = [];
+    const edges = [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: 0 }
+    ];
+    const added: Unit[] = [];
+
+    const registerUnit = (unit: Unit) => {
+      units.push(unit);
+      added.push(unit);
+    };
+    const pickEdge = () => edges.shift();
+
+    spawner.update(29, units, registerUnit, pickEdge);
+    expect(units).toHaveLength(0);
+
+    spawner.update(1, units, registerUnit, pickEdge);
+    expect(units).toHaveLength(2);
+    expect(added.map((unit) => unit.coord)).toEqual([
+      { q: 0, r: 0 },
+      { q: 1, r: 0 }
+    ]);
+    expect(units.every((unit) => unit.faction === 'enemy')).toBe(true);
+
+    spawner.update(5, units, registerUnit, pickEdge);
+    expect(units).toHaveLength(2);
+
+    spawner.update(23.5, units, registerUnit, pickEdge);
+    expect(units).toHaveLength(3);
+    const lastUnit = units.at(-1);
+    expect(lastUnit?.coord).toEqual({ q: 2, r: 0 });
+    if (lastUnit) {
+      const levelTwoStats = getAvantoMarauderStats(2);
+      expect(lastUnit.stats.health).toBe(levelTwoStats.health);
+    }
+  });
+});

--- a/src/sim/EnemySpawner.ts
+++ b/src/sim/EnemySpawner.ts
@@ -1,11 +1,31 @@
 import type { Unit } from '../units/Unit.ts';
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import { MAX_ENEMIES } from '../battle/BattleManager.ts';
-import { createUnit } from '../units/UnitFactory.ts';
+import { pickFactionBundle } from '../factions/bundles.ts';
+import { spawnEnemyBundle } from '../world/spawn/enemy_spawns.ts';
+
+export interface EnemySpawnerOptions {
+  readonly factionId?: string;
+  readonly random?: () => number;
+  readonly idFactory?: () => string;
+}
 
 export class EnemySpawner {
   private timer = 30; // seconds
   private interval = 30; // cadence
+  private readonly factionId: string;
+  private readonly random: () => number;
+  private readonly makeId: () => string;
+
+  constructor(options: EnemySpawnerOptions = {}) {
+    this.factionId = options.factionId ?? 'enemy';
+    this.random = typeof options.random === 'function' ? options.random : Math.random;
+    const fallbackIdFactory = (() => {
+      let counter = 0;
+      return () => `e${Date.now()}-${(counter += 1)}`;
+    })();
+    this.makeId = typeof options.idFactory === 'function' ? options.idFactory : fallbackIdFactory;
+  }
 
   update(
     dt: number,
@@ -18,15 +38,18 @@ export class EnemySpawner {
       return;
     }
 
-    const enemyCount = units.filter((u) => u.faction === 'enemy' && !u.isDead()).length;
-    if (enemyCount < MAX_ENEMIES) {
-      const at = pickEdge();
-      if (at) {
-        const unit = createUnit('avanto-marauder', `e${Date.now()}`, at, 'enemy');
-        if (unit) {
-          addUnit(unit);
-        }
-      }
+    const enemyCount = units.filter((u) => u.faction === this.factionId && !u.isDead()).length;
+    const availableSlots = MAX_ENEMIES - enemyCount;
+    if (availableSlots > 0) {
+      const bundle = pickFactionBundle(this.factionId, this.random);
+      spawnEnemyBundle({
+        bundle,
+        factionId: this.factionId,
+        pickEdge,
+        addUnit,
+        makeId: this.makeId,
+        availableSlots
+      });
     }
 
     this.interval = Math.max(10, this.interval * 0.95); // escalate slowly

--- a/src/world/spawn/enemy_spawns.ts
+++ b/src/world/spawn/enemy_spawns.ts
@@ -1,0 +1,77 @@
+import type { AxialCoord } from '../../hex/HexUtils.ts';
+import type { Unit } from '../../units/Unit.ts';
+import { createUnit, type UnitSpawnOptions, type UnitType } from '../../units/UnitFactory.ts';
+import type { FactionBundleDefinition } from '../../factions/bundles.ts';
+
+export interface SpawnBundleOptions {
+  readonly bundle: FactionBundleDefinition;
+  readonly factionId: string;
+  readonly pickEdge: () => AxialCoord | undefined;
+  readonly addUnit: (unit: Unit) => void;
+  readonly makeId?: () => string;
+  readonly availableSlots: number;
+}
+
+export interface SpawnBundleResult {
+  readonly spawned: readonly Unit[];
+  readonly items: readonly string[];
+  readonly modifiers: readonly string[];
+}
+
+function defaultIdFactory(): string {
+  return `e${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
+}
+
+function buildSpawnOptions(level: number): UnitSpawnOptions {
+  return { level } satisfies UnitSpawnOptions;
+}
+
+export function spawnEnemyBundle(options: SpawnBundleOptions): SpawnBundleResult {
+  let slots = Math.max(0, Math.floor(options.availableSlots));
+  const spawned: Unit[] = [];
+  if (slots <= 0) {
+    return {
+      spawned: Object.freeze(spawned),
+      items: options.bundle.items,
+      modifiers: options.bundle.modifiers
+    };
+  }
+
+  const makeId = options.makeId ?? defaultIdFactory;
+
+  for (const spec of options.bundle.units) {
+    const iterations = Math.min(spec.quantity, slots);
+    const unitType = spec.unit as UnitType;
+    const spawnOptions = buildSpawnOptions(spec.level);
+    for (let index = 0; index < iterations; index += 1) {
+      const coord = options.pickEdge();
+      if (!coord) {
+        return {
+          spawned: Object.freeze(spawned),
+          items: options.bundle.items,
+          modifiers: options.bundle.modifiers
+        };
+      }
+      const unit = createUnit(unitType, makeId(), coord, options.factionId, spawnOptions);
+      if (!unit) {
+        continue;
+      }
+      options.addUnit(unit);
+      spawned.push(unit);
+      slots -= 1;
+      if (slots <= 0) {
+        return {
+          spawned: Object.freeze(spawned),
+          items: options.bundle.items,
+          modifiers: options.bundle.modifiers
+        };
+      }
+    }
+  }
+
+  return {
+    spawned: Object.freeze(spawned),
+    items: options.bundle.items,
+    modifiers: options.bundle.modifiers
+  };
+}


### PR DESCRIPTION
## Summary
- add JSON-defined faction spawn bundles and utilities to load and select them
- update the enemy spawner to instantiate bundles via a shared world spawn helper
- cover bundle loading and cadence-driven spawning with new unit tests and changelog entry

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cbddb4c8b88330ae32762e010d2035