### PR TITLE
Fix handheld command console collapse behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Restore the sauna command console roster on handheld layouts by keeping the
+  panel open until players collapse it manually so the roster is visible again
 - Catalog faction spawn bundles in JSON, expose weighted selection helpers, and
   drive enemy wave spawns through the bundle system with cadence and identity
   tests

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -93,11 +93,19 @@ export function setupRightPanel(
   };
   insertToggle();
 
-  let isCollapsed = smallViewportQuery.matches;
+  let isCollapsed = false;
+  let narrowLayoutCollapsed = false;
 
-  const applyCollapsedState = (collapsed: boolean, matches = smallViewportQuery.matches): void => {
-    isCollapsed = collapsed;
+  const applyCollapsedState = (
+    collapsed: boolean,
+    matches = smallViewportQuery.matches
+  ): void => {
+    const wasCollapsed = isCollapsed;
+    if (matches) {
+      narrowLayoutCollapsed = collapsed;
+    }
     const shouldCollapse = collapsed && matches;
+    isCollapsed = shouldCollapse;
     panel.classList.toggle('right-panel--collapsed', shouldCollapse);
     panel.setAttribute('aria-hidden', shouldCollapse ? 'true' : 'false');
     toggle.setAttribute('aria-expanded', shouldCollapse ? 'false' : 'true');
@@ -107,18 +115,19 @@ export function setupRightPanel(
     toggle.title = shouldCollapse
       ? 'Open the sauna command console overlay'
       : 'Close the sauna command console overlay';
-    if (!shouldCollapse && matches) {
+    if (wasCollapsed && !shouldCollapse && matches) {
       panel.focus({ preventScroll: true });
     }
   };
 
-  applyCollapsedState(isCollapsed, smallViewportQuery.matches);
+  applyCollapsedState(narrowLayoutCollapsed, smallViewportQuery.matches);
   toggle.hidden = !smallViewportQuery.matches;
 
   const handleViewportChange = (event: MediaQueryListEvent): void => {
     const matches = event.matches;
     toggle.hidden = !matches;
-    applyCollapsedState(matches ? true : false, matches);
+    const collapsed = matches ? narrowLayoutCollapsed : false;
+    applyCollapsedState(collapsed, matches);
   };
 
   if (typeof smallViewportQuery.addEventListener === 'function') {


### PR DESCRIPTION
## Summary
- keep the right panel open by default on narrow layouts and remember the user collapse preference for the command console toggle
- reuse the stored narrow-layout preference on viewport changes while keeping wide layouts forced open and labels accurate
- document the roster visibility regression fix in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe5dde31c8330b55c275e6686a0e9