### PR TITLE
Route unit attacks through combat resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   tracks shield absorption, fires keyword hooks for both sides, and routes
   modifier callbacks so Saunoja and battlefield units share consistent
   damage/kill events
+- Return combat resolutions from battlefield attacks so BattleManager can react
+  to lethal blows, and ensure zero-damage keyword kills still mark units dead
+  while emitting the polished death events
 - Add a modifier runtime that tracks timed effects, routes hook triggers, emits
   lifecycle events, and exposes helper APIs plus tests so timed buffs expire
   cleanly during the polished game loop

--- a/src/battle/BattleManager.ts
+++ b/src/battle/BattleManager.ts
@@ -160,8 +160,8 @@ export class BattleManager {
       }
 
       if (unit.distanceTo(target.coord) <= unit.stats.attackRange && !target.isDead()) {
-        unit.attack(target);
-        if (target.isDead()) {
+        const resolution = unit.attack(target);
+        if ((resolution?.lethal ?? false) || target.isDead()) {
           occupied.delete(currentTargetKey);
           unit.clearPathCache();
         }

--- a/src/units/Unit.test.ts
+++ b/src/units/Unit.test.ts
@@ -27,8 +27,10 @@ describe('Unit combat keywords', () => {
 
     const defender = makeUnit('defender', { health: 14 });
 
-    defender.takeDamage(undefined, attacker);
+    const resolution = defender.takeDamage(undefined, attacker);
 
+    expect(resolution).not.toBeNull();
+    expect(resolution?.attackerRemainingHealth).toBeCloseTo(8, 5);
     expect(attacker.stats.health).toBeCloseTo(8, 5);
     expect(defender.stats.health).toBe(10);
   });


### PR DESCRIPTION
## Summary
- return combat resolutions from `Unit.attack`/`takeDamage` so callers can respond to lethal blows
- let `BattleManager` consume the combat resolution while preserving existing event bus emissions
- document the change in the changelog and extend the lifesteal test to validate the returned data

## Testing
- npm run build
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cbee2fb5d08330aef78842363e6410