### PR TITLE
Add economy tick for heat and upkeep-driven spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Track sauna heat with a dedicated tracker, drive the economy tick to drain
+  upkeep and trigger heat-gated player spawns through a shared helper, and
+  cover the flow with upkeep and reinforcement tests
 - Catalog faction spawn bundles in JSON, expose weighted selection helpers, and
   drive enemy wave spawns through the bundle system with cadence and identity
   tests

--- a/src/economy/tick.test.ts
+++ b/src/economy/tick.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { GameState, Resource } from '../core/GameState.ts';
+import { createSauna } from '../sim/sauna.ts';
+import { runEconomyTick } from './tick.ts';
+import type { Unit } from '../units/Unit.ts';
+import { Unit as UnitClass } from '../units/Unit.ts';
+import { getSoldierStats } from '../units/Soldier.ts';
+
+function makeUnit(id: string, faction: string): Unit {
+  const stats = getSoldierStats();
+  return new UnitClass(id, 'soldier', { q: 0, r: 0 }, faction, stats);
+}
+
+describe('runEconomyTick', () => {
+  it('spawns a reinforcement when heat crosses the threshold and upkeep remains', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.SAUNA_BEER, 200);
+    const sauna = createSauna(
+      { q: 0, r: 0 },
+      {
+        baseThreshold: 5,
+        heatPerSecond: 4,
+        thresholdGrowth: 0.05,
+        initialHeat: 3
+      }
+    );
+    const units: Unit[] = [];
+    const spawned: Unit[] = [];
+
+    runEconomyTick({
+      dt: 0.5,
+      state,
+      sauna,
+      heat: sauna.heatTracker,
+      units,
+      getUnitUpkeep: () => 0,
+      pickSpawnTile: () => ({ q: 1, r: 0 }),
+      spawnBaseUnit: (coord) => {
+        const unit = new UnitClass(`test-${spawned.length + 1}`, 'soldier', coord, 'player', getSoldierStats());
+        units.push(unit);
+        spawned.push(unit);
+        return unit;
+      },
+      minUpkeepReserve: 1
+    });
+
+    expect(spawned).toHaveLength(1);
+    expect(sauna.heatTracker.getHeat()).toBeLessThan(sauna.playerSpawnThreshold);
+    expect(sauna.playerSpawnTimer).toBeGreaterThan(0);
+  });
+
+  it('drains upkeep from active player units', () => {
+    const state = new GameState(1000);
+    state.addResource(Resource.SAUNA_BEER, 100);
+    const sauna = createSauna(
+      { q: 0, r: 0 },
+      { baseThreshold: 20, heatPerSecond: 0, initialHeat: 0 }
+    );
+    const units: Unit[] = [makeUnit('u1', 'player'), makeUnit('u2', 'player'), makeUnit('e1', 'enemy')];
+    const upkeep = new Map(
+      units.map((unit, index) => {
+        if (unit.faction !== 'player') {
+          return [unit.id, 0];
+        }
+        return [unit.id, index + 2];
+      })
+    );
+
+    const result = runEconomyTick({
+      dt: 1,
+      state,
+      sauna,
+      heat: sauna.heatTracker,
+      units,
+      getUnitUpkeep: (unit) => upkeep.get(unit.id) ?? 0,
+      pickSpawnTile: () => null,
+      spawnBaseUnit: () => null,
+      minUpkeepReserve: 1
+    });
+
+    expect(result.upkeepDrain).toBe(5);
+    expect(state.getResource(Resource.SAUNA_BEER)).toBe(95);
+    expect(result.spawn.spawned).toBe(0);
+  });
+});

--- a/src/economy/tick.ts
+++ b/src/economy/tick.ts
@@ -1,0 +1,85 @@
+import { Resource, type GameState } from '../core/GameState.ts';
+import type { Unit } from '../units/Unit.ts';
+import type { Sauna } from '../sim/sauna.ts';
+import type { SaunaHeat } from '../sauna/heat.ts';
+import { processPlayerSpawns, type PlayerSpawnResult } from '../world/spawn/player_spawns.ts';
+import type { AxialCoord } from '../hex/HexUtils.ts';
+
+function sanitize(value: number, fallback = 0): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+export type UnitUpkeepResolver = (unit: Unit) => number;
+
+export interface EconomyTickOptions {
+  /** Elapsed simulation time in seconds since the previous economy tick. */
+  dt: number;
+  state: GameState;
+  sauna: Sauna;
+  heat: SaunaHeat;
+  units: readonly Unit[];
+  getUnitUpkeep: UnitUpkeepResolver;
+  pickSpawnTile: () => AxialCoord | null;
+  spawnBaseUnit: (coord: AxialCoord) => Unit | null;
+  minUpkeepReserve?: number;
+  maxSpawns?: number;
+}
+
+export interface EconomyTickResult {
+  addedHeat: number;
+  cooledHeat: number;
+  upkeepDrain: number;
+  spawn: PlayerSpawnResult;
+  beerRemaining: number;
+  availableUpkeep: number;
+}
+
+export function runEconomyTick(options: EconomyTickOptions): EconomyTickResult {
+  const dt = Math.max(0, sanitize(options.dt, 0));
+
+  const { addedHeat, cooledHeat } = options.heat.advance(dt);
+
+  let upkeepDrain = 0;
+  for (const unit of options.units) {
+    if (unit.isDead() || unit.faction !== 'player') {
+      continue;
+    }
+    const upkeep = Math.max(0, sanitize(options.getUnitUpkeep(unit), 0));
+    if (upkeep > 0) {
+      upkeepDrain += upkeep;
+    }
+  }
+
+  if (upkeepDrain > 0) {
+    options.state.addResource(Resource.SAUNA_BEER, -upkeepDrain);
+  }
+
+  const availableUpkeep = options.state.getResource(Resource.SAUNA_BEER);
+
+  const spawn = processPlayerSpawns({
+    heat: options.heat,
+    availableUpkeep,
+    pickSpawnTile: options.pickSpawnTile,
+    spawnUnit: options.spawnBaseUnit,
+    minUpkeepReserve: options.minUpkeepReserve,
+    maxSpawns: options.maxSpawns
+  });
+
+  const cooldown = options.heat.getCooldownSeconds();
+  const timer = options.heat.timeUntilNextTrigger();
+
+  options.sauna.heat = options.heat.getHeat();
+  options.sauna.playerSpawnThreshold = options.heat.getThreshold();
+  options.sauna.playerSpawnCooldown = Number.isFinite(cooldown) ? cooldown : 0;
+  options.sauna.playerSpawnTimer = Number.isFinite(timer) ? timer : 0;
+  options.sauna.heatPerTick = options.heat.getBuildRate();
+
+  return {
+    addedHeat,
+    cooledHeat,
+    upkeepDrain,
+    spawn,
+    beerRemaining: options.state.getResource(Resource.SAUNA_BEER),
+    availableUpkeep: spawn.remainingUpkeep
+  };
+}

--- a/src/sauna/heat.ts
+++ b/src/sauna/heat.ts
@@ -1,0 +1,216 @@
+export interface SaunaHeatConfig {
+  /** Base threshold of heat required to trigger a spawn. */
+  baseThreshold: number;
+  /** Heat gained per simulated second. */
+  heatPerSecond: number;
+  /**
+   * Growth applied to the threshold after each trigger. A value of 0.05
+   * increases the threshold by 5% whenever heat is spent on a spawn.
+   */
+  thresholdGrowth: number;
+  /** Passive cooling applied every simulated second. */
+  coolingPerSecond: number;
+  /** Optional cap on how much heat can be stored. */
+  maxStoredHeat?: number;
+}
+
+export interface SaunaHeatInit extends Partial<SaunaHeatConfig> {
+  /** Starting heat when the tracker is created. */
+  initialHeat?: number;
+  /** Optional override for the first threshold. */
+  initialThreshold?: number;
+}
+
+export interface SaunaHeatAdvanceResult {
+  /** Amount of heat successfully added during the advance call. */
+  addedHeat: number;
+  /** Amount of heat removed via passive cooling. */
+  cooledHeat: number;
+  /** Heat stored after the advance completes. */
+  heat: number;
+}
+
+export const DEFAULT_SAUNA_HEAT_CONFIG: SaunaHeatConfig = {
+  baseThreshold: 50,
+  heatPerSecond: 50 / 30,
+  thresholdGrowth: 0.05,
+  coolingPerSecond: 0
+};
+
+function sanitizeNumber(value: number, fallback = 0): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return value;
+}
+
+export class SaunaHeat {
+  private heat: number;
+  private threshold: number;
+  private readonly baseThreshold: number;
+  private readonly thresholdGrowthFactor: number;
+  private readonly heatPerSecond: number;
+  private readonly coolingPerSecond: number;
+  private readonly maxStoredHeat: number | null;
+
+  constructor(config: SaunaHeatInit = {}) {
+    const merged: SaunaHeatConfig = {
+      ...DEFAULT_SAUNA_HEAT_CONFIG,
+      ...config
+    };
+
+    const baseThreshold = Math.max(1, sanitizeNumber(merged.baseThreshold, 50));
+    const initialThreshold = Math.max(
+      1,
+      sanitizeNumber(config.initialThreshold ?? baseThreshold, baseThreshold)
+    );
+
+    this.baseThreshold = baseThreshold;
+    this.threshold = initialThreshold;
+    this.thresholdGrowthFactor = 1 + Math.max(0, sanitizeNumber(merged.thresholdGrowth, 0));
+    this.heatPerSecond = Math.max(0, sanitizeNumber(merged.heatPerSecond, 0));
+    this.coolingPerSecond = Math.max(0, sanitizeNumber(merged.coolingPerSecond, 0));
+
+    const maxStoredHeat = sanitizeNumber(merged.maxStoredHeat ?? Number.NaN, Number.NaN);
+    this.maxStoredHeat = Number.isFinite(maxStoredHeat) && maxStoredHeat >= 0 ? maxStoredHeat : null;
+
+    const initialHeat = Math.max(0, sanitizeNumber(config.initialHeat ?? 0, 0));
+    this.heat = this.setHeatInternal(initialHeat);
+  }
+
+  /** Current stored heat. */
+  getHeat(): number {
+    return this.heat;
+  }
+
+  /** Heat required to trigger the next spawn. */
+  getThreshold(): number {
+    return this.threshold;
+  }
+
+  /** Passive heat gain rate per simulated second. */
+  getBuildRate(): number {
+    return this.heatPerSecond;
+  }
+
+  /** Passive cooling applied each simulated second. */
+  getCoolingRate(): number {
+    return this.coolingPerSecond;
+  }
+
+  /** Reset heat and threshold to their initial values. */
+  reset(): void {
+    this.heat = 0;
+    this.threshold = this.baseThreshold;
+  }
+
+  /** Force the stored heat to a specific value, respecting any configured cap. */
+  setHeat(value: number): number {
+    const sanitized = Math.max(0, sanitizeNumber(value, 0));
+    this.heat = this.setHeatInternal(sanitized);
+    return this.heat;
+  }
+
+  private setHeatInternal(value: number): number {
+    const sanitized = Math.max(0, sanitizeNumber(value, 0));
+    if (this.maxStoredHeat === null) {
+      this.heat = sanitized;
+      return this.heat;
+    }
+    this.heat = Math.min(sanitized, this.maxStoredHeat);
+    return this.heat;
+  }
+
+  private addHeat(amount: number): number {
+    const sanitized = Math.max(0, sanitizeNumber(amount, 0));
+    if (sanitized <= 0) {
+      return 0;
+    }
+    const before = this.heat;
+    const next = before + sanitized;
+    this.heat = this.maxStoredHeat === null ? next : Math.min(next, this.maxStoredHeat);
+    return this.heat - before;
+  }
+
+  /** Remove heat by a direct amount. */
+  cool(amount: number): number {
+    const sanitized = Math.max(0, sanitizeNumber(amount, 0));
+    if (sanitized <= 0 || this.heat <= 0) {
+      return 0;
+    }
+    const before = this.heat;
+    this.heat = Math.max(0, this.heat - sanitized);
+    return before - this.heat;
+  }
+
+  /** Reduce heat by a fraction of the current threshold. */
+  vent(fraction = 1): number {
+    const clamped = Math.max(0, Math.min(1, sanitizeNumber(fraction, 1)));
+    if (clamped <= 0) {
+      return 0;
+    }
+    return this.cool(this.threshold * clamped);
+  }
+
+  /**
+   * Advance the simulation by a number of seconds, applying heat gain and
+   * passive cooling. Returns how much heat changed during the advance.
+   */
+  advance(seconds: number, options?: { bonusHeat?: number; coolingMultiplier?: number }): SaunaHeatAdvanceResult {
+    const dt = Math.max(0, sanitizeNumber(seconds, 0));
+    const heatRate = this.heatPerSecond;
+    const addedFromRate = dt > 0 ? heatRate * dt : 0;
+    const bonusHeat = Math.max(0, sanitizeNumber(options?.bonusHeat ?? 0, 0));
+    const totalAdded = addedFromRate + bonusHeat;
+    const addedHeat = this.addHeat(totalAdded);
+
+    const coolingMultiplier = Math.max(0, sanitizeNumber(options?.coolingMultiplier ?? 1, 1));
+    const coolingTarget = dt > 0 ? this.coolingPerSecond * dt * coolingMultiplier : 0;
+    const cooled = this.cool(coolingTarget);
+
+    return {
+      addedHeat,
+      cooledHeat: cooled,
+      heat: this.heat
+    };
+  }
+
+  /** Check whether the stored heat meets or exceeds the current threshold. */
+  hasTriggerReady(): boolean {
+    return this.heat >= this.threshold - 1e-6;
+  }
+
+  /** Spend heat on a trigger, advancing the next threshold. */
+  consumeTrigger(): boolean {
+    if (!this.hasTriggerReady()) {
+      return false;
+    }
+    this.cool(this.threshold);
+    this.threshold = Math.max(this.baseThreshold, this.threshold * this.thresholdGrowthFactor);
+    return true;
+  }
+
+  /** Seconds until the next trigger fires if heat gain continues unabated. */
+  timeUntilNextTrigger(): number {
+    if (this.hasTriggerReady()) {
+      return 0;
+    }
+    if (this.heatPerSecond <= 0) {
+      return Number.POSITIVE_INFINITY;
+    }
+    const remaining = Math.max(0, this.threshold - this.heat);
+    return remaining / this.heatPerSecond;
+  }
+
+  /** Duration of a full heat cycle at the current threshold. */
+  getCooldownSeconds(): number {
+    if (this.heatPerSecond <= 0) {
+      return Number.POSITIVE_INFINITY;
+    }
+    return this.threshold / this.heatPerSecond;
+  }
+}
+
+export function createSaunaHeat(config?: SaunaHeatInit): SaunaHeat {
+  return new SaunaHeat(config);
+}

--- a/src/world/spawn/player_spawns.ts
+++ b/src/world/spawn/player_spawns.ts
@@ -1,0 +1,104 @@
+import type { AxialCoord } from '../../hex/HexUtils.ts';
+import type { SaunaHeat } from '../../sauna/heat.ts';
+import type { Unit } from '../../units/Unit.ts';
+import { SAUNOJA_UPKEEP_MIN } from '../../units/saunoja.ts';
+
+const FALLBACK_UPKEEP_RESERVE = 1;
+
+export interface PlayerSpawnOptions {
+  /** Sauna heat tracker controlling spawn readiness. */
+  heat: SaunaHeat;
+  /** Beer remaining after upkeep drains this tick. */
+  availableUpkeep: number;
+  /** Callback to find a free coordinate for the next spawn. */
+  pickSpawnTile: () => AxialCoord | null;
+  /** Factory invoked once a coordinate has been chosen. */
+  spawnUnit: (coord: AxialCoord) => Unit | null;
+  /** Minimum upkeep buffer required before attempting another spawn. */
+  minUpkeepReserve?: number;
+  /** Hard cap on spawns processed in a single tick. */
+  maxSpawns?: number;
+}
+
+export interface PlayerSpawnResult {
+  /** Number of units successfully spawned. */
+  spawned: number;
+  /** Spawn opportunities skipped because upkeep was exhausted. */
+  blockedByUpkeep: number;
+  /** Spawn attempts skipped because no valid tile was available. */
+  blockedByPosition: number;
+  /** Spawn attempts that failed after acquiring a tile. */
+  failedSpawns: number;
+  /** Total heat vented because spawns were blocked. */
+  ventedHeat: number;
+  /** Remaining upkeep buffer after processing spawns. */
+  remainingUpkeep: number;
+}
+
+function sanitize(value: number, fallback = 0): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+export function processPlayerSpawns(options: PlayerSpawnOptions): PlayerSpawnResult {
+  const {
+    heat,
+    pickSpawnTile,
+    spawnUnit,
+    maxSpawns
+  } = options;
+
+  const reserveFallback = Math.max(FALLBACK_UPKEEP_RESERVE, SAUNOJA_UPKEEP_MIN);
+  const minReserve = Math.max(0, sanitize(options.minUpkeepReserve ?? reserveFallback, reserveFallback));
+  let available = Math.max(0, sanitize(options.availableUpkeep, 0));
+  const spawnLimit = Math.max(1, Math.floor(sanitize(maxSpawns ?? Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY)));
+
+  let processed = 0;
+  let ventedHeat = 0;
+  let spawned = 0;
+  let blockedByUpkeep = 0;
+  let blockedByPosition = 0;
+  let failedSpawns = 0;
+
+  while (heat.hasTriggerReady() && processed < spawnLimit) {
+    processed += 1;
+
+    if (available < minReserve) {
+      blockedByUpkeep += 1;
+      ventedHeat += heat.vent(0.5);
+      break;
+    }
+
+    const coord = pickSpawnTile();
+    if (!coord) {
+      blockedByPosition += 1;
+      ventedHeat += heat.vent(0.25);
+      break;
+    }
+
+    const unit = spawnUnit(coord);
+    if (!unit) {
+      failedSpawns += 1;
+      ventedHeat += heat.vent(0.25);
+      break;
+    }
+
+    const consumed = heat.consumeTrigger();
+    if (!consumed) {
+      // Safety break to avoid infinite loops if the tracker rejects the trigger.
+      failedSpawns += 1;
+      break;
+    }
+
+    spawned += 1;
+    available = Math.max(0, available - minReserve);
+  }
+
+  return {
+    spawned,
+    blockedByUpkeep,
+    blockedByPosition,
+    failedSpawns,
+    ventedHeat,
+    remainingUpkeep: available
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable sauna heat tracker and player spawn helper modules
- drive economy ticks to update heat, drain upkeep, and trigger player reinforcements
- expand tests to cover heat-driven spawns and upkeep drain logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbf23c8b848330861c490bbb9288fc