### PR TITLE
Add roster loadout UI with modifier pills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Upgrade the command console roster to render shared Saunoja stats, live loadout
+  icons, and modifier timers with polished styling, refresh the panel on
+  inventory and modifier events, and cover the new HUD with Vitest DOM tests
 - Track sauna heat with a dedicated tracker, drive the economy tick to drain
   upkeep and trigger heat-gated player spawns through a shared helper, and
   cover the flow with upkeep and reinforcement tests

--- a/src/style.css
+++ b/src/style.css
@@ -910,6 +910,133 @@ body > #game-container {
   background: linear-gradient(90deg, rgba(248, 113, 113, 0.85), rgba(239, 68, 68, 0.85));
 }
 
+.panel-roster__loadout {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 12px;
+  margin-top: 4px;
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.panel-roster__items,
+.panel-roster__mods {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.panel-roster__mods {
+  gap: 8px;
+}
+
+.item-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: linear-gradient(140deg, rgba(148, 163, 184, 0.16), rgba(226, 232, 240, 0.04));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.28), 0 10px 20px rgba(15, 23, 42, 0.28);
+  color: var(--color-foreground);
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.item-icon:is(:hover, :focus-visible) {
+  transform: translateY(-2px);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 55%, transparent),
+    0 16px 28px rgba(56, 189, 248, 0.35);
+}
+
+.item-icon__image {
+  width: 70%;
+  height: 70%;
+  object-fit: contain;
+  filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.4));
+}
+
+.item-icon__fallback {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.item-icon__quantity {
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+  padding: 3px 6px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--color-accent) 70%, rgba(15, 23, 42, 0.95));
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.35);
+  color: white;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.item-icon[data-rarity='uncommon'] {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, rgb(34 197 94) 55%, transparent),
+    0 16px 28px rgba(34, 197, 94, 0.28);
+}
+
+.item-icon[data-rarity='rare'] {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, rgb(59 130 246) 55%, transparent),
+    0 16px 28px rgba(59, 130, 246, 0.32);
+}
+
+.item-icon[data-rarity='epic'],
+.item-icon[data-rarity='legendary'],
+.item-icon[data-rarity='mythic'] {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, rgb(168 85 247) 55%, transparent),
+    0 18px 32px rgba(168, 85, 247, 0.38);
+}
+
+.mod-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.22), rgba(59, 130, 246, 0.16));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 48%, transparent);
+  color: var(--color-foreground);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mod-pill[data-urgent='true'] {
+  background: linear-gradient(120deg, rgba(248, 113, 113, 0.26), rgba(239, 68, 68, 0.18));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-danger) 42%, transparent);
+  color: color-mix(in srgb, var(--color-danger) 80%, white 20%);
+}
+
+.mod-pill__name {
+  font-weight: 600;
+  letter-spacing: inherit;
+}
+
+.mod-pill__stacks {
+  padding: 2px 6px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, rgba(148, 163, 184, 0.32) 70%, transparent);
+  font-size: 10px;
+}
+
+.mod-pill__timer {
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, rgba(15, 23, 42, 0.75) 80%, transparent);
+  font-size: 10px;
+  font-weight: 600;
+}
+
 .panel-roster__empty {
   margin: 0;
   padding: 16px 18px;

--- a/src/ui/components/ItemIcon.tsx
+++ b/src/ui/components/ItemIcon.tsx
@@ -1,0 +1,67 @@
+import type { SaunojaItem } from '../../units/saunoja.ts';
+
+export interface ItemIconProps extends SaunojaItem {}
+
+function buildTooltip(props: ItemIconProps): string {
+  const segments: string[] = [props.name];
+  if (props.description) {
+    segments.push(props.description);
+  }
+  if (props.rarity) {
+    segments.push(`Rarity: ${props.rarity}`);
+  }
+  if (props.quantity > 1) {
+    segments.push(`Quantity: ${props.quantity}`);
+  }
+  return segments.join(' — ');
+}
+
+function renderFallbackGlyph(name: string): HTMLSpanElement {
+  const glyph = document.createElement('span');
+  glyph.classList.add('item-icon__fallback');
+  const trimmed = name.trim();
+  glyph.textContent = trimmed ? trimmed[0]?.toUpperCase() ?? '?' : '?';
+  glyph.setAttribute('aria-hidden', 'true');
+  return glyph;
+}
+
+function renderImage(src: string, name: string): HTMLImageElement {
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = '';
+  img.decoding = 'async';
+  img.loading = 'lazy';
+  img.classList.add('item-icon__image');
+  img.setAttribute('aria-hidden', 'true');
+  img.title = name;
+  return img;
+}
+
+export function renderItemIcon(props: ItemIconProps): HTMLLIElement {
+  const root = document.createElement('li');
+  root.classList.add('item-icon');
+  root.dataset.itemId = props.id;
+  const tooltip = buildTooltip(props);
+  root.title = tooltip;
+  root.setAttribute('aria-label', tooltip);
+  root.setAttribute('role', 'listitem');
+  if (props.rarity) {
+    root.dataset.rarity = props.rarity.toLowerCase();
+  }
+
+  if (props.icon && props.icon.trim().length > 0) {
+    root.appendChild(renderImage(props.icon, props.name));
+  } else {
+    root.appendChild(renderFallbackGlyph(props.name));
+  }
+
+  if (props.quantity > 1) {
+    const badge = document.createElement('span');
+    badge.classList.add('item-icon__quantity');
+    badge.textContent = `×${props.quantity}`;
+    badge.setAttribute('aria-hidden', 'true');
+    root.appendChild(badge);
+  }
+
+  return root;
+}

--- a/src/ui/components/ModPill.tsx
+++ b/src/ui/components/ModPill.tsx
@@ -1,0 +1,78 @@
+import type { SaunojaModifier } from '../../units/saunoja.ts';
+
+export interface ModPillProps extends SaunojaModifier {}
+
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0
+});
+
+function formatTimer(value: number | typeof Infinity): string {
+  if (value === Infinity) {
+    return '∞';
+  }
+  if (!Number.isFinite(value) || value <= 0) {
+    return '0s';
+  }
+  return `${numberFormatter.format(Math.ceil(value))}s`;
+}
+
+function buildTooltip(props: ModPillProps): string {
+  const segments: string[] = [props.name];
+  if (props.description) {
+    segments.push(props.description);
+  }
+  if (props.source) {
+    segments.push(`Source: ${props.source}`);
+  }
+  if (props.duration !== Infinity) {
+    segments.push(`Duration: ${formatTimer(props.duration)}`);
+  }
+  segments.push(`Remaining: ${formatTimer(props.remaining)}`);
+  if (props.stacks && props.stacks > 1) {
+    segments.push(`Stacks: ${props.stacks}`);
+  }
+  return segments.join(' — ');
+}
+
+export function renderModPill(props: ModPillProps): HTMLLIElement {
+  const root = document.createElement('li');
+  root.classList.add('mod-pill');
+  root.dataset.modifierId = props.id;
+  root.title = buildTooltip(props);
+  root.setAttribute('aria-label', root.title);
+  root.setAttribute('role', 'listitem');
+  root.dataset.duration = props.duration === Infinity ? 'infinite' : String(props.duration);
+  root.dataset.remaining = props.remaining === Infinity ? 'infinite' : String(props.remaining);
+  if (props.appliedAt !== undefined) {
+    root.dataset.appliedAt = String(props.appliedAt);
+  }
+  if (props.stacks && props.stacks > 1) {
+    root.dataset.stacks = String(props.stacks);
+  }
+
+  const name = document.createElement('span');
+  name.classList.add('mod-pill__name');
+  name.textContent = props.name;
+  name.setAttribute('aria-hidden', 'true');
+  root.appendChild(name);
+
+  if (props.stacks && props.stacks > 1) {
+    const stacks = document.createElement('span');
+    stacks.classList.add('mod-pill__stacks');
+    stacks.textContent = `×${props.stacks}`;
+    stacks.setAttribute('aria-hidden', 'true');
+    root.appendChild(stacks);
+  }
+
+  const timer = document.createElement('span');
+  timer.classList.add('mod-pill__timer');
+  timer.textContent = formatTimer(props.remaining);
+  timer.setAttribute('aria-hidden', 'true');
+  root.appendChild(timer);
+
+  if (props.remaining !== Infinity && props.remaining <= 5) {
+    root.dataset.urgent = 'true';
+  }
+
+  return root;
+}

--- a/src/ui/panels/RosterPanel.test.ts
+++ b/src/ui/panels/RosterPanel.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { createRosterPanel, type RosterEntry } from './RosterPanel.tsx';
+
+function buildEntry(
+  overrides: Partial<Omit<RosterEntry, 'stats' | 'items' | 'modifiers' | 'traits'>> & {
+    stats?: Partial<RosterEntry['stats']>;
+    items?: RosterEntry['items'];
+    modifiers?: RosterEntry['modifiers'];
+    traits?: readonly string[];
+  } = {}
+): RosterEntry {
+  const baseStats: RosterEntry['stats'] = {
+    health: 18,
+    maxHealth: 30,
+    attackDamage: 4,
+    attackRange: 2,
+    movementRange: 3,
+    defense: 1,
+    shield: undefined
+  };
+
+  const stats = { ...baseStats, ...overrides.stats } as RosterEntry['stats'];
+  const items = overrides.items ? [...overrides.items] : ([] as RosterEntry['items']);
+  const modifiers = overrides.modifiers
+    ? [...overrides.modifiers]
+    : ([] as RosterEntry['modifiers']);
+  const traits = overrides.traits ? [...overrides.traits] : ['Resolute', 'Trailblazer'];
+
+  return {
+    id: 'roster-entry',
+    name: 'Aava "Emberguard" Aalto',
+    upkeep: 3,
+    status: 'reserve',
+    selected: false,
+    traits,
+    stats,
+    items,
+    modifiers,
+    ...overrides
+  } satisfies RosterEntry;
+}
+
+describe('createRosterPanel', () => {
+  it('renders roster stats, items, and modifiers and updates when they change', () => {
+    const container = document.createElement('div');
+    const panel = createRosterPanel(container);
+
+    const baseEntry = buildEntry();
+    panel.render([baseEntry]);
+
+    expect(container.dataset.count).toBe('1');
+    const metaInitial = container.querySelector('.panel-roster__meta');
+    expect(metaInitial?.textContent).toContain('HP 18/30');
+    expect(metaInitial?.textContent).toContain('ATK 4');
+    expect(metaInitial?.textContent).toContain('RNG 2');
+    expect(metaInitial?.textContent).toContain('MOV 3');
+    expect(metaInitial?.textContent).toContain('Upkeep 3 beer');
+    expect(container.querySelector('.panel-roster__items')).toBeNull();
+    expect(container.querySelector('.panel-roster__mods')).toBeNull();
+
+    const updatedEntry = buildEntry({
+      upkeep: 5,
+      status: 'engaged',
+      selected: true,
+      stats: {
+        health: 12,
+        maxHealth: 30,
+        attackDamage: 7,
+        attackRange: 4,
+        movementRange: 5,
+        defense: 3,
+        shield: 6
+      },
+      items: [
+        {
+          id: 'emberglass-arrow',
+          name: 'Emberglass Arrow',
+          description: 'Ignites targets on impact',
+          icon: '/assets/items/emberglass.svg',
+          rarity: 'rare',
+          quantity: 2
+        },
+        {
+          id: 'sauna-towel',
+          name: 'Sauna Towel',
+          description: 'Always ready for the steam room',
+          quantity: 1
+        }
+      ],
+      modifiers: [
+        {
+          id: 'barkskin-ritual',
+          name: 'Barkskin Ritual',
+          description: 'Gain +3 defense for a short time',
+          duration: 18,
+          remaining: 12,
+          stacks: 2,
+          source: 'Shamanic Rite'
+        }
+      ],
+      traits: ['Resolute', 'Trailblazer', 'Vanguard']
+    });
+
+    panel.render([updatedEntry]);
+
+    const button = container.querySelector<HTMLButtonElement>('.panel-roster__item');
+    expect(button).not.toBeNull();
+    expect(button?.classList.contains('is-selected')).toBe(true);
+    expect(button?.dataset.status).toBe('engaged');
+
+    const metaUpdated = container.querySelector('.panel-roster__meta');
+    expect(metaUpdated?.textContent).toContain('HP 12/30');
+    expect(metaUpdated?.textContent).toContain('Shield 6');
+    expect(metaUpdated?.textContent).toContain('ATK 7');
+    expect(metaUpdated?.textContent).toContain('RNG 4');
+    expect(metaUpdated?.textContent).toContain('DEF 3');
+    expect(metaUpdated?.textContent).toContain('MOV 5');
+    expect(metaUpdated?.textContent).toContain('Upkeep 5 beer');
+
+    const loadout = container.querySelector('.panel-roster__loadout');
+    expect(loadout).not.toBeNull();
+
+    const items = container.querySelectorAll<HTMLElement>('.item-icon');
+    expect(items).toHaveLength(2);
+    expect(items[0].dataset.itemId).toBe('emberglass-arrow');
+    expect(items[0].dataset.rarity).toBe('rare');
+    expect(items[0].querySelector('.item-icon__quantity')?.textContent).toBe('×2');
+    expect(items[1].dataset.itemId).toBe('sauna-towel');
+    expect(items[1].querySelector('.item-icon__quantity')).toBeNull();
+
+    const modifiers = container.querySelectorAll<HTMLElement>('.mod-pill');
+    expect(modifiers).toHaveLength(1);
+    const modifier = modifiers[0];
+    expect(modifier.dataset.modifierId).toBe('barkskin-ritual');
+    expect(modifier.querySelector('.mod-pill__stacks')?.textContent).toBe('×2');
+    expect(modifier.querySelector('.mod-pill__timer')?.textContent).toBe('12s');
+
+    const ariaLabel = button?.getAttribute('aria-label') ?? '';
+    expect(ariaLabel).toContain('attack range 4');
+    expect(ariaLabel).toContain('upkeep 5 beer');
+    expect(ariaLabel).toContain('2 equipped items');
+    expect(ariaLabel).toContain('1 active modifier');
+  });
+});

--- a/src/ui/panels/RosterPanel.tsx
+++ b/src/ui/panels/RosterPanel.tsx
@@ -1,0 +1,275 @@
+import { renderItemIcon } from '../components/ItemIcon.tsx';
+import { renderModPill } from '../components/ModPill.tsx';
+import type { SaunojaItem, SaunojaModifier } from '../../units/saunoja.ts';
+
+export type RosterStatus = 'engaged' | 'reserve' | 'downed';
+
+export type RosterItem = SaunojaItem;
+export type RosterModifier = SaunojaModifier;
+
+export interface RosterStats {
+  readonly health: number;
+  readonly maxHealth: number;
+  readonly attackDamage: number;
+  readonly attackRange: number;
+  readonly movementRange: number;
+  readonly defense?: number;
+  readonly shield?: number;
+}
+
+export interface RosterEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly upkeep: number;
+  readonly status: RosterStatus;
+  readonly selected: boolean;
+  readonly traits: readonly string[];
+  readonly stats: RosterStats;
+  readonly items: readonly RosterItem[];
+  readonly modifiers: readonly RosterModifier[];
+}
+
+export interface RosterPanelOptions {
+  readonly onSelect?: (unitId: string) => void;
+}
+
+const rosterStatusLabels: Record<RosterStatus, string> = {
+  engaged: 'Engaged on the field',
+  reserve: 'On reserve duty',
+  downed: 'Recovering from battle'
+};
+
+const integerFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0
+});
+
+const rosterTitleId = 'panel-roster-title';
+
+function formatTraits(traits: readonly string[]): string {
+  if (traits.length === 0) {
+    return 'No defining traits yet';
+  }
+  return traits.join(' • ');
+}
+
+function buildMetaLine(entry: RosterEntry): string {
+  const { stats } = entry;
+  const segments: string[] = [
+    `HP ${integerFormatter.format(stats.health)}/${integerFormatter.format(stats.maxHealth)}`
+  ];
+  if (stats.shield && stats.shield > 0) {
+    segments.push(`Shield ${integerFormatter.format(stats.shield)}`);
+  }
+  segments.push(`ATK ${integerFormatter.format(stats.attackDamage)}`);
+  segments.push(`RNG ${integerFormatter.format(stats.attackRange)}`);
+  if (stats.defense && stats.defense > 0) {
+    segments.push(`DEF ${integerFormatter.format(stats.defense)}`);
+  }
+  segments.push(`MOV ${integerFormatter.format(stats.movementRange)}`);
+  segments.push(`Upkeep ${integerFormatter.format(entry.upkeep)} beer`);
+  return segments.join(' • ');
+}
+
+function buildAriaLabel(entry: RosterEntry): string {
+  const { stats } = entry;
+  const segments: string[] = [entry.name, rosterStatusLabels[entry.status]];
+  segments.push(`health ${integerFormatter.format(stats.health)} of ${integerFormatter.format(stats.maxHealth)}`);
+  if (stats.shield && stats.shield > 0) {
+    segments.push(`shield ${integerFormatter.format(stats.shield)}`);
+  }
+  segments.push(`attack ${integerFormatter.format(stats.attackDamage)}`);
+  if (stats.defense && stats.defense > 0) {
+    segments.push(`defense ${integerFormatter.format(stats.defense)}`);
+  }
+  if (stats.attackRange > 0) {
+    segments.push(`attack range ${integerFormatter.format(stats.attackRange)}`);
+  }
+  segments.push(`movement ${integerFormatter.format(stats.movementRange)}`);
+  segments.push(`upkeep ${integerFormatter.format(entry.upkeep)} beer`);
+  if (entry.items.length > 0) {
+    segments.push(`${entry.items.length} equipped item${entry.items.length === 1 ? '' : 's'}`);
+  }
+  if (entry.modifiers.length > 0) {
+    segments.push(`${entry.modifiers.length} active modifier${entry.modifiers.length === 1 ? '' : 's'}`);
+  }
+  return segments.join(', ');
+}
+
+function renderMetrics(container: HTMLElement, entries: readonly RosterEntry[]): void {
+  const engaged = entries.filter((entry) => entry.status === 'engaged').length;
+  const reserve = entries.filter((entry) => entry.status === 'reserve').length;
+  const downed = entries.filter((entry) => entry.status === 'downed').length;
+
+  const buildMetric = (label: string, value: number, status: RosterStatus): HTMLSpanElement => {
+    const metric = document.createElement('span');
+    metric.classList.add('panel-roster__metric');
+    metric.dataset.status = status;
+    metric.textContent = `${integerFormatter.format(value)} ${label}`;
+    metric.setAttribute('aria-label', metric.textContent);
+    return metric;
+  };
+
+  const metrics = document.createElement('div');
+  metrics.classList.add('panel-roster__metrics');
+  metrics.append(
+    buildMetric('engaged', engaged, 'engaged'),
+    buildMetric('reserve', reserve, 'reserve'),
+    buildMetric('downed', downed, 'downed')
+  );
+  container.appendChild(metrics);
+}
+
+function renderLoadout(root: HTMLButtonElement, entry: RosterEntry): void {
+  if (entry.items.length === 0 && entry.modifiers.length === 0) {
+    return;
+  }
+
+  const loadout = document.createElement('div');
+  loadout.classList.add('panel-roster__loadout');
+
+  if (entry.items.length > 0) {
+    const list = document.createElement('ul');
+    list.classList.add('panel-roster__items');
+    list.setAttribute('role', 'list');
+    list.setAttribute('aria-label', `${entry.name} equipped items`);
+    list.title = entry.items.map((item) => item.name).join(', ');
+    for (const item of entry.items) {
+      list.appendChild(renderItemIcon(item));
+    }
+    loadout.appendChild(list);
+  }
+
+  if (entry.modifiers.length > 0) {
+    const list = document.createElement('ul');
+    list.classList.add('panel-roster__mods');
+    list.setAttribute('role', 'list');
+    list.setAttribute('aria-label', `${entry.name} active modifiers`);
+    list.title = entry.modifiers.map((modifier) => modifier.name).join(', ');
+    for (const modifier of entry.modifiers) {
+      list.appendChild(renderModPill(modifier));
+    }
+    loadout.appendChild(list);
+  }
+
+  root.appendChild(loadout);
+}
+
+export function createRosterPanel(
+  container: HTMLElement,
+  options: RosterPanelOptions = {}
+): { render: (entries: readonly RosterEntry[]) => void } {
+  const render = (entries: readonly RosterEntry[]): void => {
+    container.innerHTML = '';
+    container.dataset.count = String(entries.length);
+    container.classList.add('panel-roster');
+
+    const header = document.createElement('div');
+    header.classList.add('panel-roster__header');
+
+    const heading = document.createElement('h4');
+    heading.classList.add('panel-roster__title');
+    heading.textContent = 'Battalion Roster';
+    heading.id = rosterTitleId;
+    header.appendChild(heading);
+
+    container.setAttribute('aria-labelledby', rosterTitleId);
+
+    const totalLabel =
+      entries.length === 0
+        ? 'No attendants mustered yet'
+        : `${integerFormatter.format(entries.length)} attendant${entries.length === 1 ? '' : 's'} enlisted`;
+    const count = document.createElement('span');
+    count.classList.add('panel-roster__count');
+    count.textContent = totalLabel;
+    header.appendChild(count);
+
+    container.appendChild(header);
+
+    if (entries.length === 0) {
+      const empty = document.createElement('p');
+      empty.classList.add('panel-roster__empty');
+      empty.textContent = 'No attendants have rallied to the sauna yet.';
+      container.appendChild(empty);
+      return;
+    }
+
+    renderMetrics(container, entries);
+
+    const list = document.createElement('ul');
+    list.classList.add('panel-roster__list');
+    list.setAttribute('role', 'list');
+
+    for (const entry of entries) {
+      const item = document.createElement('li');
+      item.classList.add('panel-roster__row');
+
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.classList.add('panel-roster__item');
+      button.dataset.unitId = entry.id;
+      button.dataset.status = entry.status;
+      button.setAttribute('aria-pressed', entry.selected ? 'true' : 'false');
+      button.setAttribute('aria-label', buildAriaLabel(entry));
+      button.title = `${entry.name} • ${rosterStatusLabels[entry.status]}`;
+      if (entry.selected) {
+        button.classList.add('is-selected');
+      }
+      if (entry.status === 'downed') {
+        button.classList.add('is-downed');
+      }
+
+      const nameRow = document.createElement('div');
+      nameRow.classList.add('panel-roster__name-row');
+
+      const name = document.createElement('span');
+      name.classList.add('panel-roster__name');
+      name.textContent = entry.name;
+      name.title = entry.name;
+      nameRow.appendChild(name);
+
+      const badge = document.createElement('span');
+      badge.classList.add('panel-roster__status');
+      badge.dataset.status = entry.status;
+      badge.textContent = rosterStatusLabels[entry.status];
+      nameRow.appendChild(badge);
+
+      const meta = document.createElement('div');
+      meta.classList.add('panel-roster__meta');
+      const metaLabel = buildMetaLine(entry);
+      meta.textContent = metaLabel;
+      meta.title = metaLabel;
+
+      const healthBar = document.createElement('div');
+      healthBar.classList.add('panel-roster__health');
+      const fill = document.createElement('div');
+      fill.classList.add('panel-roster__health-fill');
+      const percent =
+        entry.stats.maxHealth > 0
+          ? Math.max(0, Math.min(100, Math.round((entry.stats.health / entry.stats.maxHealth) * 100)))
+          : 0;
+      fill.style.width = `${percent}%`;
+      fill.dataset.percent = `${percent}`;
+      healthBar.appendChild(fill);
+
+      const traits = document.createElement('div');
+      traits.classList.add('panel-roster__traits');
+      const traitLabel = formatTraits(entry.traits);
+      traits.textContent = traitLabel;
+      traits.title = traitLabel;
+
+      button.append(nameRow, meta, healthBar, traits);
+      renderLoadout(button, entry);
+
+      if (typeof options.onSelect === 'function') {
+        button.addEventListener('click', () => options.onSelect?.(entry.id));
+      }
+
+      item.appendChild(button);
+      list.appendChild(item);
+    }
+
+    container.appendChild(list);
+  };
+
+  return { render };
+}

--- a/src/units/saunoja.test.ts
+++ b/src/units/saunoja.test.ts
@@ -81,6 +81,79 @@ describe('makeSaunoja', () => {
     expect(saunoja.name).toBe('Noora "Steamcaller" Tuomi');
     randomSpy.mockRestore();
   });
+
+  it('sanitises loadout items and active modifiers', () => {
+    const loadout = [
+      {
+        id: ' emberglass-arrow ',
+        name: '  Emberglass Arrow ',
+        description: 'Ignites targets on hit',
+        icon: '/assets/items/emberglass.svg',
+        rarity: 'rare',
+        quantity: 2.6
+      },
+      {
+        id: '',
+        name: 'Missing id'
+      },
+      42 as unknown as { id: string; name: string }
+    ];
+
+    const modifiers = [
+      {
+        id: 'barkskin-ritual',
+        name: 'Barkskin Ritual',
+        description: 'Gain +3 defense for a short time',
+        duration: 19.9,
+        remaining: 7.3,
+        stacks: 0,
+        appliedAt: -50
+      },
+      {
+        id: 'eternal-steam',
+        name: 'Eternal Steam',
+        duration: Infinity,
+        remaining: Infinity,
+        source: 'Sauna Core'
+      },
+      {
+        id: '',
+        name: 'Unnamed'
+      }
+    ];
+
+    const saunoja = makeSaunoja({ id: 'loadout-test', items: loadout, modifiers });
+
+    expect(saunoja.items).toEqual([
+      {
+        id: 'emberglass-arrow',
+        name: 'Emberglass Arrow',
+        description: 'Ignites targets on hit',
+        icon: '/assets/items/emberglass.svg',
+        rarity: 'rare',
+        quantity: 3
+      }
+    ]);
+    expect(saunoja.modifiers).toEqual([
+      {
+        id: 'barkskin-ritual',
+        name: 'Barkskin Ritual',
+        description: 'Gain +3 defense for a short time',
+        duration: 19.9,
+        remaining: 7.3,
+        stacks: 1,
+        appliedAt: 0
+      },
+      {
+        id: 'eternal-steam',
+        name: 'Eternal Steam',
+        description: undefined,
+        duration: Infinity,
+        remaining: Infinity,
+        source: 'Sauna Core'
+      }
+    ]);
+  });
 });
 
 describe('applyDamage', () => {


### PR DESCRIPTION
## Summary
- finalize roster entry generation to expose effective stats, equipped items, and active modifiers while refreshing the right panel when roster, inventory, or modifier events fire
- add reusable item icon and modifier pill components, wire them into the roster panel renderer, and polish HUD styling for the new loadout section
- document the upgrade in the changelog and cover the roster panel with Vitest DOM assertions

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbf75e7f1483308cf755fbe6db9ec9