### PR TITLE
Enhance SISU burst modifiers and add coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Amplify SISU Burst with +50% attack, a one-charge shield, and temporary
+  immortality tracked through the modifier runtime, emit polished HUD status
+  messaging, and cover the surge with regression tests to ensure buffs expire
+  on schedule
 - Upgrade the command console roster to render shared Saunoja stats, live loadout
   icons, and modifier timers with polished styling, refresh the panel on
   inventory and modifier events, and cover the new HUD with Vitest DOM tests

--- a/src/sim/sisu.test.ts
+++ b/src/sim/sisu.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { GameState, Resource } from '../core/GameState.ts';
+import { useSisuBurst, endSisuBurst, isSisuBurstActive } from './sisu.ts';
+import { modifierRuntime } from '../mods/runtime.ts';
+import { Unit } from '../units/Unit.ts';
+import type { UnitStats } from '../unit/types.ts';
+
+const BASE_COORD = { q: 0, r: 0 } as const;
+
+function createStats(overrides: Partial<UnitStats> = {}): UnitStats {
+  return {
+    health: 20,
+    attackDamage: 4,
+    attackRange: 1,
+    movementRange: 2,
+    defense: 0,
+    ...overrides
+  };
+}
+
+function createUnit(id: string, faction: string, stats?: Partial<UnitStats>): Unit {
+  return new Unit(id, 'soldier', { ...BASE_COORD }, faction, createStats(stats));
+}
+
+describe('useSisuBurst', () => {
+  let state: GameState;
+  let now = 0;
+  const durationMs = 10_000;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+    state = new GameState(1000);
+    state.addResource(Resource.SISU, 20);
+  });
+
+  afterEach(() => {
+    endSisuBurst();
+    modifierRuntime.clear();
+    vi.runAllTimers();
+    vi.clearAllTimers();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('applies attack, shield, and immortality buffs via modifiers', () => {
+    const ally = createUnit('ally', 'player');
+    const result = useSisuBurst(state, [ally]);
+
+    expect(result).toBe(true);
+    expect(isSisuBurstActive()).toBe(true);
+    expect(ally.stats.attackDamage).toBe(Math.round(4 * 1.5));
+    expect(ally.stats.movementRange).toBe(Math.max(1, Math.round(2 * 1.5)));
+    expect(ally.getShield()).toBe(1);
+    expect(ally.isImmortal()).toBe(true);
+    expect(state.getResource(Resource.SISU)).toBe(15);
+  });
+
+  it('prevents lethal damage while the burst is active', () => {
+    const ally = createUnit('immortal-ally', 'player');
+    const foe = createUnit('attacker', 'enemy', { attackDamage: 12 });
+
+    useSisuBurst(state, [ally]);
+    const result = ally.takeDamage(ally.getMaxHealth() + 5, foe);
+
+    expect(result).not.toBeNull();
+    expect(result?.lethal).toBe(false);
+    expect(ally.isDead()).toBe(false);
+    expect(ally.stats.health).toBe(1);
+    expect(ally.isImmortal()).toBe(true);
+  });
+
+  it('expires on schedule and removes temporary buffs', () => {
+    const ally = createUnit('timed-ally', 'player');
+    const baseAttack = ally.stats.attackDamage;
+    const baseMovement = ally.stats.movementRange;
+
+    useSisuBurst(state, [ally]);
+    now += durationMs;
+    vi.advanceTimersByTime(durationMs);
+
+    expect(isSisuBurstActive()).toBe(false);
+    expect(ally.stats.attackDamage).toBe(baseAttack);
+    expect(ally.stats.movementRange).toBe(baseMovement);
+    expect(ally.isImmortal()).toBe(false);
+    expect(ally.getShield()).toBe(0);
+  });
+});

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -227,28 +227,45 @@ export function setupTopbar(
   renderMute();
   bar.appendChild(muteBtn);
 
-  eventBus.on('sisuBurstStart', ({ remaining }: { remaining: number }) => {
+  function renderBurstStatus(remaining: number, status?: string): void {
     const seconds = Math.max(0, Math.ceil(remaining));
     burstTimer.container.style.display = 'block';
     burstTimer.value.textContent = String(seconds);
-    burstTimer.delta.textContent = '';
-    burstTimer.container.setAttribute(
-      'aria-label',
-      `Sisu burst active — ${seconds} seconds remaining`
-    );
-    refreshAbilityButtons();
-  });
-  eventBus.on('sisuBurstTick', ({ remaining }: { remaining: number }) => {
-    const seconds = Math.max(0, Math.ceil(remaining));
-    burstTimer.value.textContent = String(seconds);
-    burstTimer.container.setAttribute(
-      'aria-label',
-      `Sisu burst active — ${seconds} seconds remaining`
-    );
-  });
+    if (status) {
+      burstTimer.delta.style.display = 'block';
+      burstTimer.delta.textContent = status;
+      burstTimer.container.title = `Sisu burst active: ${status}`;
+    } else {
+      burstTimer.delta.style.display = 'none';
+      burstTimer.delta.textContent = '';
+      burstTimer.container.removeAttribute('title');
+    }
+    const ariaParts = [`Sisu burst active — ${seconds} seconds remaining`];
+    if (status) {
+      ariaParts.push(status);
+    }
+    burstTimer.container.setAttribute('aria-label', ariaParts.join(' — '));
+  }
+
+  eventBus.on(
+    'sisuBurstStart',
+    ({ remaining, status }: { remaining: number; status?: string }) => {
+      renderBurstStatus(remaining, status);
+      refreshAbilityButtons();
+    }
+  );
+  eventBus.on(
+    'sisuBurstTick',
+    ({ remaining, status }: { remaining: number; status?: string }) => {
+      renderBurstStatus(remaining, status);
+    }
+  );
   eventBus.on('sisuBurstEnd', () => {
     burstTimer.container.style.display = 'none';
     burstTimer.value.textContent = '0';
+    burstTimer.delta.textContent = '';
+    burstTimer.delta.style.display = 'none';
+    burstTimer.container.removeAttribute('title');
     refreshAbilityButtons();
   });
 


### PR DESCRIPTION
## Summary
- boost the SISU burst to use the modifier runtime for a +50% attack surge, one-charge shield, immortality, and countdown status messaging
- teach units to honor temporary immortality and surface the burst status in the HUD
- add regression tests for the burst modifiers and document the changes in the changelog

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc00c435c08330a04deba26bc6be79