### PR TITLE
Add loot tables, inventory persistence, and stash HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Introduce faction loot tables with rarity-weighted rolls, stash new drops in a
+  persistent inventory that auto-equips selected attendants when possible,
+  surface polished HUD toasts and a quartermaster panel for stash management,
+  and cover loot generation plus inventory persistence with Vitest suites
 - Amplify SISU Burst with +50% attack, a one-charge shield, and temporary
   immortality tracked through the modifier runtime, emit polished HUD status
   messaging, and cover the surge with regression tests to ensure buffs expire

--- a/src/inventory/state.test.ts
+++ b/src/inventory/state.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { InventoryState } from './state.ts';
+
+const SAMPLE_ITEM = {
+  id: 'emberglass-arrow',
+  name: 'Emberglass Arrow',
+  quantity: 2,
+  rarity: 'rare' as const
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('InventoryState', () => {
+  it('persists stash items across sessions', () => {
+    const inventory = new InventoryState({ now: () => 1000 });
+    inventory.addItem(SAMPLE_ITEM, { autoEquip: false });
+    const snapshot = inventory.getStash();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].quantity).toBe(2);
+
+    const reload = new InventoryState({ now: () => 2000 });
+    expect(reload.getStash()).toHaveLength(1);
+    expect(reload.getStash()[0].id).toBe('emberglass-arrow');
+    expect(reload.isAutoEquipEnabled()).toBe(true);
+  });
+
+  it('auto-equips items when a handler succeeds', () => {
+    const equip = vi.fn().mockReturnValue(true);
+    const inventory = new InventoryState({ now: () => 500 });
+    const receipt = inventory.addItem(SAMPLE_ITEM, { unitId: 's1', equip });
+    expect(receipt.equipped).toBe(true);
+    expect(equip).toHaveBeenCalledTimes(1);
+    expect(inventory.getStashSize()).toBe(0);
+  });
+
+  it('adds items to stash when auto-equip is disabled', () => {
+    const equip = vi.fn().mockReturnValue(true);
+    const inventory = new InventoryState({ now: () => 600, autoEquip: false });
+    const receipt = inventory.addItem(SAMPLE_ITEM, { unitId: 's1', equip });
+    expect(receipt.equipped).toBe(false);
+    expect(inventory.getStashSize()).toBe(1);
+  });
+
+  it('equips items from the stash and emits events', () => {
+    const equip = vi.fn().mockReturnValue(true);
+    const inventory = new InventoryState({ now: () => 700 });
+    inventory.addItem(SAMPLE_ITEM, { autoEquip: false });
+
+    const events: string[] = [];
+    const stop = inventory.on((event) => {
+      events.push(event.type);
+    });
+
+    const equipped = inventory.equipFromStash(0, 's1', equip);
+    expect(equipped).toBe(true);
+    expect(equip).toHaveBeenCalledWith('s1', expect.objectContaining({ id: 'emberglass-arrow' }));
+    expect(inventory.getStashSize()).toBe(0);
+    expect(events).toContain('item-equipped');
+    expect(events).toContain('stash-updated');
+    stop();
+  });
+
+  it('discards items from the stash', () => {
+    const inventory = new InventoryState({ now: () => 900 });
+    inventory.addItem(SAMPLE_ITEM, { autoEquip: false });
+    const removed = inventory.discardFromStash(0);
+    expect(removed?.id).toBe('emberglass-arrow');
+    expect(inventory.getStashSize()).toBe(0);
+  });
+});

--- a/src/inventory/state.ts
+++ b/src/inventory/state.ts
@@ -1,0 +1,316 @@
+import type { RolledLootItem } from '../loot/roll.ts';
+import type { SaunojaItem } from '../units/saunoja.ts';
+
+export interface InventoryItem extends SaunojaItem {
+  readonly acquiredAt: number;
+  readonly sourceTableId?: string;
+  readonly sourceEntryId?: string;
+}
+
+export type InventoryEvent =
+  | {
+      readonly type: 'item-acquired';
+      readonly item: InventoryItem;
+      readonly equipped: boolean;
+      readonly unitId?: string;
+      readonly stashSize: number;
+    }
+  | {
+      readonly type: 'item-equipped';
+      readonly item: InventoryItem;
+      readonly unitId: string;
+      readonly fromStash: boolean;
+      readonly stashSize: number;
+    }
+  | {
+      readonly type: 'item-discarded';
+      readonly item: InventoryItem;
+      readonly stashSize: number;
+    }
+  | {
+      readonly type: 'stash-updated';
+      readonly stash: readonly InventoryItem[];
+    }
+  | {
+      readonly type: 'settings-updated';
+      readonly autoEquip: boolean;
+    };
+
+export type InventoryListener = (event: InventoryEvent) => void;
+
+export interface InventoryStateOptions {
+  readonly storageKey?: string;
+  readonly now?: () => number;
+  readonly maxStashSize?: number;
+  readonly autoEquip?: boolean;
+}
+
+export interface AcquisitionOptions {
+  readonly unitId?: string;
+  readonly autoEquip?: boolean;
+  readonly sourceTableId?: string;
+  readonly sourceEntryId?: string;
+  readonly equip?: (unitId: string, item: SaunojaItem) => boolean;
+}
+
+export interface InventoryReceipt {
+  readonly item: InventoryItem;
+  readonly equipped: boolean;
+  readonly stashIndex?: number;
+}
+
+type SerializedInventory = {
+  readonly autoEquip?: boolean;
+  readonly stash?: readonly (InventoryItem & { readonly acquiredAt: number })[];
+};
+
+function getStorage(): Storage | null {
+  try {
+    const globalWithStorage = globalThis as typeof globalThis & { localStorage?: Storage };
+    return globalWithStorage.localStorage ?? null;
+  } catch (error) {
+    console.warn('Unable to access localStorage for inventory persistence', error);
+    return null;
+  }
+}
+
+function safeLoad<T>(storage: Storage, key: string): T | undefined {
+  const raw = storage.getItem(key);
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    console.warn(`Failed to parse persisted inventory for "${key}", clearing.`, error);
+    storage.removeItem(key);
+    return undefined;
+  }
+}
+
+function sanitizeItem(
+  source: SaunojaItem,
+  acquiredAt: number,
+  context?: { tableId?: string; entryId?: string }
+): InventoryItem {
+  const baseQuantity = Number.isFinite(source.quantity) ? (source.quantity as number) : 1;
+  const quantity = Math.max(1, Math.round(baseQuantity));
+  const rarity = typeof source.rarity === 'string' ? source.rarity.trim() : undefined;
+  const icon = typeof source.icon === 'string' ? source.icon : undefined;
+  const description = typeof source.description === 'string' ? source.description : undefined;
+  return {
+    id: source.id,
+    name: source.name,
+    description,
+    icon,
+    rarity,
+    quantity,
+    acquiredAt,
+    sourceTableId: context?.tableId,
+    sourceEntryId: context?.entryId
+  } satisfies InventoryItem;
+}
+
+export class InventoryState {
+  private readonly listeners = new Set<InventoryListener>();
+  private readonly storageKey: string;
+  private readonly now: () => number;
+  private readonly maxStashSize: number;
+  private readonly storage: Storage | null;
+
+  private autoEquip: boolean;
+  private stash: InventoryItem[] = [];
+
+  constructor(options: InventoryStateOptions = {}) {
+    this.storageKey = options.storageKey ?? 'autobattles:inventory';
+    this.now = typeof options.now === 'function' ? options.now : () => Date.now();
+    this.maxStashSize = Math.max(1, Math.floor(options.maxStashSize ?? 24));
+    this.storage = getStorage();
+    this.autoEquip = options.autoEquip ?? true;
+    this.load();
+  }
+
+  private load(): void {
+    if (!this.storage) {
+      return;
+    }
+    const data = safeLoad<SerializedInventory>(this.storage, this.storageKey);
+    if (!data) {
+      return;
+    }
+    if (typeof data.autoEquip === 'boolean') {
+      this.autoEquip = data.autoEquip;
+    }
+    if (Array.isArray(data.stash)) {
+      const restored: InventoryItem[] = [];
+      for (const entry of data.stash) {
+        if (!entry || typeof entry !== 'object') {
+          continue;
+        }
+        const { id, name, quantity } = entry as InventoryItem;
+        if (typeof id !== 'string' || typeof name !== 'string') {
+          continue;
+        }
+        const timestamp = Number.isFinite(entry.acquiredAt) ? (entry.acquiredAt as number) : this.now();
+        restored.push(
+          sanitizeItem(
+            {
+              id,
+              name,
+              description: entry.description,
+              icon: entry.icon,
+              rarity: entry.rarity,
+              quantity
+            },
+            timestamp,
+            { tableId: entry.sourceTableId, entryId: entry.sourceEntryId }
+          )
+        );
+      }
+      this.stash = restored.slice(0, this.maxStashSize);
+    }
+  }
+
+  private persist(): void {
+    if (!this.storage) {
+      return;
+    }
+    const payload: SerializedInventory = {
+      autoEquip: this.autoEquip,
+      stash: this.stash.map((item) => ({ ...item }))
+    };
+    try {
+      this.storage.setItem(this.storageKey, JSON.stringify(payload));
+    } catch (error) {
+      console.warn('Failed to persist inventory state', error);
+    }
+  }
+
+  private emit(event: InventoryEvent): void {
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+
+  on(listener: InventoryListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  isAutoEquipEnabled(): boolean {
+    return this.autoEquip;
+  }
+
+  setAutoEquip(enabled: boolean): void {
+    if (this.autoEquip === enabled) {
+      return;
+    }
+    this.autoEquip = enabled;
+    this.persist();
+    this.emit({ type: 'settings-updated', autoEquip: this.autoEquip });
+  }
+
+  getStash(): readonly InventoryItem[] {
+    return this.stash.map((item) => ({ ...item }));
+  }
+
+  getStashSize(): number {
+    return this.stash.length;
+  }
+
+  addLoot(drop: RolledLootItem, options: AcquisitionOptions = {}): InventoryReceipt {
+    return this.addItem({ ...drop.item }, {
+      ...options,
+      sourceTableId: options.sourceTableId,
+      sourceEntryId: options.sourceEntryId ?? drop.entryId
+    });
+  }
+
+  addItem(item: SaunojaItem, options: AcquisitionOptions = {}): InventoryReceipt {
+    const timestamp = Math.max(0, Math.round(this.now()));
+    const entry = sanitizeItem(item, timestamp, {
+      tableId: options.sourceTableId,
+      entryId: options.sourceEntryId
+    });
+    const preferEquip = options.autoEquip ?? this.autoEquip;
+    let equipped = false;
+
+    if (preferEquip && options.unitId && typeof options.equip === 'function') {
+      try {
+        equipped = options.equip(options.unitId, entry);
+      } catch (error) {
+        console.warn('Failed to auto-equip inventory item', { item: entry, error });
+      }
+      if (equipped) {
+        this.emit({
+          type: 'item-acquired',
+          item: entry,
+          equipped: true,
+          unitId: options.unitId,
+          stashSize: this.stash.length
+        });
+        this.persist();
+        return { item: entry, equipped: true } satisfies InventoryReceipt;
+      }
+    }
+
+    this.stash.push(entry);
+    if (this.stash.length > this.maxStashSize) {
+      const overflow = this.stash.splice(0, this.stash.length - this.maxStashSize);
+      if (overflow.length > 0) {
+        console.warn('Inventory stash full, trimming oldest items', overflow);
+      }
+    }
+    this.persist();
+    this.emit({ type: 'stash-updated', stash: this.getStash() });
+    this.emit({
+      type: 'item-acquired',
+      item: entry,
+      equipped: false,
+      unitId: options.unitId,
+      stashSize: this.stash.length
+    });
+    return { item: entry, equipped: false, stashIndex: this.stash.length - 1 } satisfies InventoryReceipt;
+  }
+
+  equipFromStash(index: number, unitId: string, equip: (unitId: string, item: SaunojaItem) => boolean): boolean {
+    if (index < 0 || index >= this.stash.length) {
+      return false;
+    }
+    const target = this.stash[index];
+    let equipped = false;
+    try {
+      equipped = equip(unitId, target);
+    } catch (error) {
+      console.warn('Failed to equip stash item', { item: target, error });
+      equipped = false;
+    }
+    if (!equipped) {
+      return false;
+    }
+    const [removed] = this.stash.splice(index, 1);
+    this.persist();
+    this.emit({ type: 'stash-updated', stash: this.getStash() });
+    this.emit({
+      type: 'item-equipped',
+      item: removed,
+      unitId,
+      fromStash: true,
+      stashSize: this.stash.length
+    });
+    return true;
+  }
+
+  discardFromStash(index: number): InventoryItem | null {
+    if (index < 0 || index >= this.stash.length) {
+      return null;
+    }
+    const [removed] = this.stash.splice(index, 1);
+    this.persist();
+    this.emit({ type: 'stash-updated', stash: this.getStash() });
+    this.emit({ type: 'item-discarded', item: removed, stashSize: this.stash.length });
+    return removed;
+  }
+}

--- a/src/loot/roll.test.ts
+++ b/src/loot/roll.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { rollLoot } from './roll.ts';
+import type { LootTable } from './tables.ts';
+
+function sequenceRandom(values: number[]): () => number {
+  let index = 0;
+  return () => {
+    const value = values[index] ?? values[values.length - 1] ?? 0;
+    index += 1;
+    return value;
+  };
+}
+
+describe('rollLoot', () => {
+  it('falls back to base loot table when faction is unknown', () => {
+    const result = rollLoot({ factionId: 'unknown-faction', rolls: 1, random: () => 0.01 });
+    expect(result.tableId).toBe('general-salvage');
+    expect(result.rolls.length).toBe(1);
+    expect(result.rolls[0].item.name).toBeDefined();
+  });
+
+  it('weights entries by rarity before rolling', () => {
+    const table: LootTable = {
+      id: 'test-table',
+      label: 'Test Table',
+      entries: [
+        { id: 'common', name: 'Common Trinket', rarity: 'common', quantity: 1, weight: 1 },
+        { id: 'legendary', name: 'Legendary Relic', rarity: 'legendary', quantity: 1, weight: 1 }
+      ]
+    };
+
+    const weightedRare = rollLoot({
+      factionId: 'enemy',
+      table,
+      // A high roll that would select the second entry if rarity weighting did
+      // not reduce the legendary odds.
+      random: sequenceRandom([0.9]),
+      rolls: 1
+    });
+
+    expect(weightedRare.rolls[0].entryId).toBe('common');
+
+    const guaranteedLegendary = rollLoot({
+      factionId: 'enemy',
+      table,
+      random: sequenceRandom([0.99]),
+      rolls: 1
+    });
+    expect(guaranteedLegendary.rolls[0].entryId).toBe('legendary');
+  });
+
+  it('respects quantity ranges when producing loot', () => {
+    const table: LootTable = {
+      id: 'quantity-table',
+      label: 'Quantity Table',
+      entries: [
+        { id: 'bundle', name: 'Bundle', rarity: 'uncommon', quantity: { min: 2, max: 4 }, weight: 1 }
+      ]
+    };
+
+    const roll = rollLoot({
+      factionId: 'enemy',
+      table,
+      random: sequenceRandom([0.4, 0.8]),
+      rolls: 2
+    });
+
+    expect(roll.rolls).toHaveLength(2);
+    expect(roll.rolls[0].quantity).toBeGreaterThanOrEqual(2);
+    expect(roll.rolls[0].quantity).toBeLessThanOrEqual(4);
+  });
+});

--- a/src/loot/roll.ts
+++ b/src/loot/roll.ts
@@ -1,0 +1,148 @@
+import type { SaunojaItem, SaunojaItemRarity } from '../units/saunoja.ts';
+import {
+  getLootTableForFaction,
+  RARITY_WEIGHT_MULTIPLIER,
+  type LootBlueprint,
+  type LootQuantityRange,
+  type LootTable
+} from './tables.ts';
+
+export type RandomSource = () => number;
+
+export interface RolledLootItem {
+  readonly entryId: string;
+  readonly rarity: SaunojaItemRarity;
+  readonly quantity: number;
+  readonly item: SaunojaItem;
+}
+
+export interface LootRollOptions {
+  readonly factionId: string;
+  readonly elite?: boolean;
+  readonly rolls?: number;
+  readonly random?: RandomSource;
+  /**
+   * Optional explicit table override. When provided the {@link factionId}
+   * remains part of the result metadata while the supplied table is used for
+   * every roll.
+   */
+  readonly table?: LootTable;
+}
+
+export interface LootRollResult {
+  readonly factionId: string;
+  readonly elite: boolean;
+  readonly tableId: string;
+  readonly tableLabel: string;
+  readonly rolls: readonly RolledLootItem[];
+}
+
+function clampRollCount(requested: number | undefined): number {
+  if (!Number.isFinite(requested)) {
+    return 1;
+  }
+  const rounded = Math.floor(requested as number);
+  if (rounded <= 0) {
+    return 0;
+  }
+  return Math.min(10, rounded);
+}
+
+function resolveQuantity(
+  quantity: LootBlueprint['quantity'],
+  random: RandomSource
+): number {
+  if (typeof quantity === 'number' && Number.isFinite(quantity)) {
+    return Math.max(1, Math.round(quantity));
+  }
+  if (!quantity) {
+    return 1;
+  }
+  const range = quantity as LootQuantityRange;
+  const min = Math.max(1, Math.round(range.min));
+  const max = Math.max(min, Math.round(range.max));
+  const span = max - min + 1;
+  const roll = Math.floor(Math.max(0, Math.min(0.999999, random())) * span);
+  return min + roll;
+}
+
+function resolveWeight(entry: LootBlueprint): number {
+  const rarityWeight = RARITY_WEIGHT_MULTIPLIER[entry.rarity] ?? 1;
+  const baseWeight = typeof entry.weight === 'number' ? entry.weight : 1;
+  return Math.max(0, baseWeight) * Math.max(0, rarityWeight);
+}
+
+function selectEntry(
+  entries: readonly LootBlueprint[],
+  random: RandomSource
+): LootBlueprint | null {
+  const weighted = entries
+    .map((entry) => ({ entry, weight: resolveWeight(entry) }))
+    .filter((candidate) => candidate.weight > 0);
+
+  if (weighted.length === 0) {
+    return null;
+  }
+
+  const total = weighted.reduce((sum, candidate) => sum + candidate.weight, 0);
+  const roll = Math.max(0, Math.min(0.999999, random())) * total;
+  let accum = 0;
+  for (const candidate of weighted) {
+    accum += candidate.weight;
+    if (roll < accum) {
+      return candidate.entry;
+    }
+  }
+  return weighted[weighted.length - 1]?.entry ?? null;
+}
+
+function buildItem(entry: LootBlueprint, quantity: number): SaunojaItem {
+  return {
+    id: entry.id,
+    name: entry.name,
+    description: entry.description,
+    icon: entry.icon,
+    rarity: entry.rarity,
+    quantity
+  } satisfies SaunojaItem;
+}
+
+export function rollLoot(options: LootRollOptions): LootRollResult {
+  const random = typeof options.random === 'function' ? options.random : Math.random;
+  const elite = Boolean(options.elite);
+  const table = options.table ?? getLootTableForFaction(options.factionId, elite);
+  const rollCount = clampRollCount(options.rolls);
+  const rolls: RolledLootItem[] = [];
+
+  if (rollCount <= 0 || table.entries.length === 0) {
+    return {
+      factionId: options.factionId,
+      elite,
+      tableId: table.id,
+      tableLabel: table.label,
+      rolls
+    } satisfies LootRollResult;
+  }
+
+  for (let index = 0; index < rollCount; index += 1) {
+    const entry = selectEntry(table.entries, random);
+    if (!entry) {
+      break;
+    }
+    const quantity = resolveQuantity(entry.quantity, random);
+    rolls.push({
+      entryId: entry.id,
+      rarity: entry.rarity,
+      quantity,
+      item: buildItem(entry, quantity)
+    });
+  }
+
+  return {
+    factionId: options.factionId,
+    elite,
+    tableId: table.id,
+    tableLabel: table.label,
+    rolls
+  } satisfies LootRollResult;
+}

--- a/src/loot/tables.ts
+++ b/src/loot/tables.ts
@@ -1,0 +1,230 @@
+import type { SaunojaItem, SaunojaItemRarity } from '../units/saunoja.ts';
+
+export type LootQuantityRange = {
+  readonly min: number;
+  readonly max: number;
+};
+
+export interface LootBlueprint {
+  readonly id: SaunojaItem['id'];
+  readonly name: SaunojaItem['name'];
+  readonly description?: SaunojaItem['description'];
+  readonly icon?: SaunojaItem['icon'];
+  readonly rarity: SaunojaItemRarity;
+  readonly quantity?: number | LootQuantityRange;
+  readonly weight?: number;
+}
+
+export interface LootTable {
+  readonly id: string;
+  readonly label: string;
+  readonly entries: readonly LootBlueprint[];
+}
+
+export interface FactionLootTables {
+  readonly base: LootTable;
+  readonly elite?: LootTable;
+}
+
+export const RARITY_WEIGHT_MULTIPLIER: Record<SaunojaItemRarity, number> = Object.freeze({
+  common: 1,
+  uncommon: 0.6,
+  rare: 0.35,
+  epic: 0.18,
+  legendary: 0.08,
+  mythic: 0.03
+});
+
+const DEFAULT_LOOT_TABLE: LootTable = Object.freeze({
+  id: 'general-salvage',
+  label: 'General Salvage',
+  entries: Object.freeze([
+    {
+      id: 'birch-sap-satchel',
+      name: 'Birch Sap Satchel',
+      description: 'Soothing birch sap that doubles as a brisk field tonic.',
+      rarity: 'common',
+      quantity: { min: 1, max: 3 },
+      weight: 6
+    },
+    {
+      id: 'steamed-bandages',
+      name: 'Steamed Linen Bandages',
+      description: 'Freshly steamed bandages infused with pine oils.',
+      rarity: 'common',
+      quantity: 1,
+      weight: 5
+    },
+    {
+      id: 'emberglass-shard',
+      name: 'Emberglass Shard',
+      description: 'A radiant shard used to kindle sauna braziers.',
+      rarity: 'uncommon',
+      quantity: 1,
+      weight: 3
+    },
+    {
+      id: 'aurora-distillate',
+      name: 'Aurora Distillate',
+      description: 'Vials of shimmering condensation that empower sauna rituals.',
+      rarity: 'rare',
+      quantity: 1,
+      weight: 1.5
+    },
+    {
+      id: 'myrsky-charm',
+      name: 'Myrsky Charm',
+      description: 'Storm-forged charm rumored to call down aurora flares.',
+      rarity: 'epic',
+      quantity: 1,
+      weight: 0.7
+    }
+  ])
+});
+
+const ENEMY_LOOT: FactionLootTables = Object.freeze({
+  base: Object.freeze({
+    id: 'enemy-raiders',
+    label: 'Avanto Marauder Spoils',
+    entries: Object.freeze([
+      {
+        id: 'cracked-ice-amulet',
+        name: 'Cracked Ice Amulet',
+        description: 'Necklace of frostbitten charms that hum when danger nears.',
+        rarity: 'common',
+        quantity: 1,
+        weight: 5
+      },
+      {
+        id: 'stolen-sauna-tokens',
+        name: 'Stolen Sauna Tokens',
+        description: 'Pilfered entrance tokens, gladly accepted back at any sauna hall.',
+        rarity: 'uncommon',
+        quantity: { min: 2, max: 5 },
+        weight: 3
+      },
+      {
+        id: 'glacier-brand',
+        name: 'Glacier Brand',
+        description: 'A cleaver chilled in glacial meltwater that never dulls.',
+        rarity: 'rare',
+        quantity: 1,
+        weight: 1.25
+      }
+    ])
+  }),
+  elite: Object.freeze({
+    id: 'enemy-champions',
+    label: 'Avanto Champion Cache',
+    entries: Object.freeze([
+      {
+        id: 'frostwyrm-signet',
+        name: 'Frostwyrm Signet',
+        description: 'An icy signet ring that wreathes its bearer in frozen vapour.',
+        rarity: 'epic',
+        quantity: 1,
+        weight: 1.1
+      },
+      {
+        id: 'aurora-lattice',
+        name: 'Aurora Lattice',
+        description: 'Filigree latticework that channels auroral light into focused beams.',
+        rarity: 'legendary',
+        quantity: 1,
+        weight: 0.4
+      },
+      {
+        id: 'midnight-bloodwine',
+        name: 'Midnight Bloodwine',
+        description: 'A mythical draught said to rekindle a warrior\'s lost resolve.',
+        rarity: 'mythic',
+        quantity: 1,
+        weight: 0.12
+      }
+    ])
+  })
+});
+
+const DEEPWOOD_LOOT: FactionLootTables = Object.freeze({
+  base: Object.freeze({
+    id: 'deepwood-offerings',
+    label: 'Deepwood Offerings',
+    entries: Object.freeze([
+      {
+        id: 'spirit-oak-charm',
+        name: 'Spirit Oak Charm',
+        description: 'Carved from living oak, it whispers guidance between sauna rounds.',
+        rarity: 'uncommon',
+        quantity: 1,
+        weight: 4
+      },
+      {
+        id: 'sauna-incense',
+        name: 'Sauna Incense Pouches',
+        description: 'Fragrant blends that steady breathing before the next engagement.',
+        rarity: 'common',
+        quantity: { min: 1, max: 4 },
+        weight: 5
+      },
+      {
+        id: 'emberglass-arrow',
+        name: 'Emberglass Arrow Bundle',
+        description: 'Arrowheads that glow amber when a perfect shot reveals itself.',
+        rarity: 'rare',
+        quantity: { min: 1, max: 2 },
+        weight: 1.75
+      }
+    ])
+  }),
+  elite: Object.freeze({
+    id: 'deepwood-ritual-cache',
+    label: 'Deepwood Ritual Cache',
+    entries: Object.freeze([
+      {
+        id: 'windstep-totem',
+        name: 'Windstep Totem',
+        description: 'Totem etched with gale sigils that lighten every cautious stride.',
+        rarity: 'epic',
+        quantity: 1,
+        weight: 0.9
+      },
+      {
+        id: 'searing-chant-censer',
+        name: 'Searing Chant Censer',
+        description: 'An ornate censer that empowers allies with smouldering hymns.',
+        rarity: 'legendary',
+        quantity: 1,
+        weight: 0.35
+      }
+    ])
+  })
+});
+
+const FACTION_TABLES: Record<string, FactionLootTables> = Object.freeze({
+  enemy: ENEMY_LOOT,
+  deepwood: DEEPWOOD_LOOT
+});
+
+export function listFactionLootTables(): ReadonlyMap<string, FactionLootTables> {
+  return new Map(Object.entries(FACTION_TABLES));
+}
+
+export function getFactionLootTables(factionId: string): FactionLootTables {
+  return FACTION_TABLES[factionId] ?? { base: DEFAULT_LOOT_TABLE };
+}
+
+export function getLootTableForFaction(factionId: string, elite = false): LootTable {
+  const tables = getFactionLootTables(factionId);
+  if (elite && tables.elite) {
+    return tables.elite;
+  }
+  return tables.base;
+}
+
+export function getLootEntries(factionId: string, elite = false): readonly LootBlueprint[] {
+  return getLootTableForFaction(factionId, elite).entries;
+}
+
+export function isEliteTableAvailable(factionId: string): boolean {
+  return Boolean(getFactionLootTables(factionId).elite);
+}

--- a/src/ui/inventoryHud.ts
+++ b/src/ui/inventoryHud.ts
@@ -1,0 +1,254 @@
+import type { InventoryEvent, InventoryItem, InventoryState } from '../inventory/state.ts';
+import { ensureHudLayout } from './layout.ts';
+
+export interface InventoryHudOptions {
+  readonly getSelectedUnitId?: () => string | null;
+  readonly onEquip?: (unitId: string, item: InventoryItem) => boolean;
+}
+
+const TOAST_LIFETIME_MS = 4500;
+
+function formatTimestamp(value: number): string {
+  const date = new Date(value);
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+export function setupInventoryHud(
+  inventory: InventoryState,
+  options: InventoryHudOptions = {}
+): { destroy: () => void } {
+  const overlay = document.getElementById('ui-overlay');
+  if (!overlay) {
+    return { destroy: () => {} };
+  }
+
+  const { actions } = ensureHudLayout(overlay);
+
+  const existingStack = overlay.querySelector<HTMLDivElement>('.loot-toast-stack');
+  const toastStack = existingStack ?? document.createElement('div');
+  if (!existingStack) {
+    toastStack.classList.add('loot-toast-stack');
+    toastStack.setAttribute('aria-live', 'polite');
+    toastStack.setAttribute('role', 'status');
+    overlay.appendChild(toastStack);
+  }
+
+  overlay.querySelectorAll('.inventory-badge').forEach((el) => el.remove());
+  const badgeButton = document.createElement('button');
+  badgeButton.type = 'button';
+  badgeButton.classList.add('inventory-badge');
+  badgeButton.setAttribute('aria-expanded', 'false');
+  badgeButton.setAttribute('aria-controls', 'inventory-stash-panel');
+  badgeButton.setAttribute('aria-label', 'Open quartermaster stash');
+
+  const badgeIcon = document.createElement('span');
+  badgeIcon.classList.add('inventory-badge__icon');
+  badgeIcon.setAttribute('aria-hidden', 'true');
+
+  const badgeText = document.createElement('span');
+  badgeText.classList.add('inventory-badge__text');
+  badgeText.textContent = 'Stash';
+
+  const badgeCount = document.createElement('span');
+  badgeCount.classList.add('inventory-badge__count');
+  badgeCount.textContent = '0';
+  badgeCount.setAttribute('aria-hidden', 'true');
+
+  badgeButton.append(badgeIcon, badgeText, badgeCount);
+
+  overlay.querySelector('#inventory-stash-panel')?.remove();
+  const panel = document.createElement('section');
+  panel.id = 'inventory-stash-panel';
+  panel.classList.add('inventory-stash');
+  panel.hidden = true;
+  panel.tabIndex = -1;
+  panel.setAttribute('aria-label', 'Quartermaster stash');
+
+  const panelHeader = document.createElement('header');
+  panelHeader.classList.add('inventory-stash__header');
+
+  const panelTitle = document.createElement('h3');
+  panelTitle.classList.add('inventory-stash__title');
+  panelTitle.textContent = 'Quartermaster Stash';
+  panelHeader.appendChild(panelTitle);
+
+  const panelMeta = document.createElement('span');
+  panelMeta.classList.add('inventory-stash__meta');
+  panelHeader.appendChild(panelMeta);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.classList.add('inventory-stash__close');
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => {
+    panel.hidden = true;
+    badgeButton.setAttribute('aria-expanded', 'false');
+    badgeButton.focus({ preventScroll: true });
+  });
+  panelHeader.appendChild(closeBtn);
+
+  const list = document.createElement('ul');
+  list.classList.add('inventory-stash__list');
+  list.setAttribute('role', 'list');
+
+  panel.append(panelHeader, list);
+  actions.appendChild(badgeButton);
+  overlay.appendChild(panel);
+
+  function togglePanel(): void {
+    const willOpen = panel.hidden;
+    panel.hidden = !willOpen;
+    badgeButton.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+    badgeButton.setAttribute(
+      'aria-label',
+      willOpen ? 'Close quartermaster stash' : 'Open quartermaster stash'
+    );
+    if (willOpen) {
+      panel.focus({ preventScroll: true });
+    }
+  }
+
+  badgeButton.addEventListener('click', () => {
+    togglePanel();
+  });
+
+  function renderEmptyState(): void {
+    list.innerHTML = '';
+    const empty = document.createElement('li');
+    empty.classList.add('inventory-stash__empty');
+    empty.textContent = 'No items are waiting in the stash.';
+    list.appendChild(empty);
+  }
+
+  function showToast(message: string, emphasis: 'loot' | 'info' | 'warn' = 'loot'): void {
+    const toast = document.createElement('div');
+    toast.classList.add('loot-toast');
+    toast.dataset.variant = emphasis;
+    toast.textContent = message;
+    toastStack.appendChild(toast);
+    const timeout = window.setTimeout(() => {
+      toast.classList.add('loot-toast--exit');
+      window.setTimeout(() => toast.remove(), 400);
+    }, TOAST_LIFETIME_MS);
+    toast.addEventListener('click', () => {
+      window.clearTimeout(timeout);
+      toast.remove();
+    });
+  }
+
+  function renderStash(stash: readonly InventoryItem[]): void {
+    badgeCount.textContent = String(stash.length);
+    badgeButton.dataset.count = String(stash.length);
+    panelMeta.textContent = stash.length === 0 ? 'Empty' : `${stash.length} item(s)`;
+    if (stash.length === 0) {
+      renderEmptyState();
+      return;
+    }
+    list.innerHTML = '';
+    stash.forEach((item, index) => {
+      const entry = document.createElement('li');
+      entry.classList.add('inventory-stash__item');
+      entry.dataset.rarity = item.rarity ?? 'common';
+
+      const title = document.createElement('div');
+      title.classList.add('inventory-stash__item-title');
+      title.textContent = item.name;
+      entry.appendChild(title);
+
+      if (item.rarity) {
+        const rarity = document.createElement('span');
+        rarity.classList.add('inventory-stash__item-rarity');
+        rarity.textContent = item.rarity;
+        entry.appendChild(rarity);
+      }
+
+      const quantity = document.createElement('span');
+      quantity.classList.add('inventory-stash__item-quantity');
+      quantity.textContent = `×${item.quantity}`;
+      entry.appendChild(quantity);
+
+      const acquired = document.createElement('span');
+      acquired.classList.add('inventory-stash__item-time');
+      acquired.textContent = formatTimestamp(item.acquiredAt);
+      entry.appendChild(acquired);
+
+      const actionRow = document.createElement('div');
+      actionRow.classList.add('inventory-stash__actions');
+
+      const equipBtn = document.createElement('button');
+      equipBtn.type = 'button';
+      equipBtn.classList.add('inventory-stash__action');
+      equipBtn.textContent = 'Equip to selected';
+      equipBtn.addEventListener('click', () => {
+        const selectedId = options.getSelectedUnitId?.() ?? null;
+        if (!selectedId) {
+          showToast('Select an attendant before equipping an item.', 'warn');
+          return;
+        }
+        const handler = options.onEquip ?? (() => false);
+        const equipped = inventory.equipFromStash(index, selectedId, handler);
+        if (!equipped) {
+          showToast('Unable to equip that item right now.', 'warn');
+          return;
+        }
+        showToast(`Equipped ${item.name} to the selected attendant.`, 'info');
+      });
+      actionRow.appendChild(equipBtn);
+
+      const discardBtn = document.createElement('button');
+      discardBtn.type = 'button';
+      discardBtn.classList.add('inventory-stash__action', 'inventory-stash__action--danger');
+      discardBtn.textContent = 'Discard';
+      discardBtn.addEventListener('click', () => {
+        const removed = inventory.discardFromStash(index);
+        if (removed) {
+          showToast(`${removed.name} was discarded from the stash.`, 'warn');
+        }
+      });
+      actionRow.appendChild(discardBtn);
+
+      entry.appendChild(actionRow);
+      list.appendChild(entry);
+    });
+  }
+
+  badgeButton.dataset.autoequip = inventory.isAutoEquipEnabled() ? 'on' : 'off';
+  renderStash(inventory.getStash());
+
+  const unsubscribe = inventory.on((event: InventoryEvent) => {
+    switch (event.type) {
+      case 'item-acquired':
+        if (event.equipped) {
+          showToast(`${event.item.name} auto-equipped successfully.`, 'info');
+        } else {
+          showToast(`New item secured: ${event.item.name}`);
+        }
+        break;
+      case 'item-equipped':
+        showToast(`${event.item.name} equipped to the selected attendant.`, 'info');
+        break;
+      case 'item-discarded':
+        showToast(`${event.item.name} discarded from the stash.`, 'warn');
+        break;
+      case 'stash-updated':
+        renderStash(event.stash);
+        break;
+      case 'settings-updated':
+        badgeButton.dataset.autoequip = event.autoEquip ? 'on' : 'off';
+        break;
+      default:
+        break;
+    }
+  });
+
+  const destroy = (): void => {
+    unsubscribe();
+    badgeButton.remove();
+    panel.remove();
+    if (!toastStack.hasChildNodes()) {
+      toastStack.remove();
+    }
+  };
+
+  return { destroy };
+}

--- a/src/ui/style/atoms.css
+++ b/src/ui/style/atoms.css
@@ -91,3 +91,215 @@
   flex-direction: column;
   gap: var(--gap-md);
 }
+
+.loot-toast-stack {
+  position: absolute;
+  top: var(--gap-lg);
+  right: var(--gap-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--gap-sm);
+  pointer-events: none;
+  z-index: 900;
+}
+
+.loot-toast {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(215, 229, 255, 0.95));
+  color: #152035;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  pointer-events: auto;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+  max-width: 18rem;
+}
+
+.loot-toast[data-variant='info'] {
+  background: linear-gradient(135deg, rgba(219, 245, 255, 0.95), rgba(197, 228, 255, 0.95));
+}
+
+.loot-toast[data-variant='warn'] {
+  background: linear-gradient(135deg, rgba(255, 231, 217, 0.95), rgba(255, 214, 196, 0.95));
+  color: #4a1f0e;
+}
+
+.loot-toast--exit {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+.inventory-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, rgba(27, 36, 56, 0.9), rgba(39, 74, 110, 0.9));
+  color: #f7fbff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.inventory-badge:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.inventory-badge__icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 0.75rem;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(225, 235, 255, 0.2));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+}
+
+.inventory-badge__text {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+}
+
+.inventory-badge__count {
+  min-width: 1.5rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.inventory-badge[data-autoequip='off'] {
+  background: linear-gradient(135deg, rgba(56, 44, 25, 0.9), rgba(92, 72, 40, 0.9));
+}
+
+.inventory-stash {
+  position: absolute;
+  top: 4.5rem;
+  right: var(--gap-lg);
+  width: min(22rem, 90vw);
+  background: linear-gradient(145deg, rgba(9, 15, 24, 0.96), rgba(23, 36, 54, 0.94));
+  color: #f7fbff;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--gap-lg);
+  backdrop-filter: blur(6px);
+  z-index: 850;
+}
+
+.inventory-stash__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap-md);
+  margin-bottom: var(--gap-md);
+}
+
+.inventory-stash__title {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.inventory-stash__meta {
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+.inventory-stash__close {
+  border: none;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+}
+
+.inventory-stash__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-md);
+  max-height: 22rem;
+  overflow-y: auto;
+}
+
+.inventory-stash__empty {
+  text-align: center;
+  padding: var(--gap-md);
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+}
+
+.inventory-stash__item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--gap-sm);
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  padding: var(--gap-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.inventory-stash__item-title {
+  grid-column: 1 / -1;
+  font-weight: 700;
+}
+
+.inventory-stash__item-rarity {
+  justify-self: start;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.8;
+}
+
+.inventory-stash__item-quantity {
+  justify-self: end;
+  font-weight: 600;
+}
+
+.inventory-stash__item-time {
+  grid-column: 1 / -1;
+  font-size: 0.7rem;
+  opacity: 0.6;
+}
+
+.inventory-stash__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: var(--gap-sm);
+}
+
+.inventory-stash__action {
+  flex: 1;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.18);
+  color: inherit;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.inventory-stash__action:hover {
+  background: rgba(255, 255, 255, 0.28);
+  transform: translateY(-1px);
+}
+
+.inventory-stash__action--danger {
+  background: rgba(255, 120, 120, 0.18);
+}
+
+.inventory-stash__action--danger:hover {
+  background: rgba(255, 120, 120, 0.28);
+}


### PR DESCRIPTION
## Summary
- define reusable faction loot tables with rarity multipliers and lookup helpers
- add weighted loot rolling plus persistent inventory state with auto-equip/stash flows and tests
- integrate loot drops into the game loop, surface a polished stash HUD, and log the update in the changelog

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc0595cefc83309df16c501bb2ef51