### PR TITLE
Expand TypeScript and Vitest globs for tests directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Expand TypeScript and Vitest globs to cover a dedicated `tests/` tree so future
+  issue tasks can land spec files outside `src/` without compiler friction
 - Introduce faction loot tables with rarity-weighted rolls, stash new drops in a
   persistent inventory that auto-equips selected attendants when possible,
   surface polished HUD toasts and a quartermaster panel for stash management,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,6 @@
+# Tests
+
+Issue work items such as #245, #246, and #250 can stage upcoming specs under this
+`tests/` tree. The repository TypeScript and Vitest configurations already include
+this directory, so new files will participate in type-checking and the test run
+without additional setup.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,5 +10,9 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    include: [
+      'src/**/*.{test,spec}.{js,ts,jsx,tsx}',
+      'tests/**/*.{test,spec}.{js,ts,jsx,tsx}',
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- expand the TypeScript include list so a dedicated `tests/` tree is type-checked
- teach Vitest to search both `src/` and `tests/` for spec files
- document the new test location for issues #245, #246, and #250 in the changelog and a README stub

## Testing
- `npm test` *(passes with the existing network warning from check-demo-link)*

------
https://chatgpt.com/codex/tasks/task_e_68cc12350d5883309b5a09619ecb3106