### PR TITLE
Add topbar dispose hook to remove HUD event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Expose a disposable controller from the HUD topbar so cleanup routines remove
+  SISU burst and resource listeners before rebuilding the UI, preventing
+  duplicated overlays during restarts
 - Note in issue #245 that the `src/unit.ts` barrel must migrate to `src/unit/index.ts`
   (or be removed) and its consumers updated before adding the new `src/unit/`
   directory so the refactor avoids path collisions

--- a/src/game.ts
+++ b/src/game.ts
@@ -625,7 +625,7 @@ if (import.meta.env.DEV) {
   });
 }
 const updateSaunaUI = setupSaunaUI(sauna);
-const updateTopbar = setupTopbar(
+const { update: updateTopbar, dispose: disposeTopbar } = setupTopbar(
   state,
   {
     saunakunnia: uiIcons.resource,
@@ -930,6 +930,7 @@ export function cleanup(): void {
   eventBus.off('buildingPlaced', invalidateTerrainCache);
   eventBus.off('buildingRemoved', invalidateTerrainCache);
   inventoryHud.destroy();
+  disposeTopbar();
 }
 
 export async function start(): Promise<void> {


### PR DESCRIPTION
## Summary
- wrap the HUD topbar wiring in a TopbarControls interface that exposes update and dispose helpers
- unregister burst/resource event listeners and clear timers when the topbar is torn down
- update game cleanup to call the topbar disposer and note the regression fix in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc19f077048330baad4b3191387247