### PR TITLE
Ensure right panel disposes registered listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a disposable sauna command console setup that unregisters media-query and
+  event bus listeners while removing the HUD panel during cleanup so repeated
+  game initializations no longer leak toggles or listeners
 - Expose a disposable controller from the HUD topbar so cleanup routines remove
   SISU burst and resource listeners before rebuilding the UI, preventing
   duplicated overlays during restarts

--- a/src/game.ts
+++ b/src/game.ts
@@ -74,6 +74,7 @@ let log: (msg: string) => void = () => {};
 let addEvent: (event: GameEvent) => void = () => {};
 let renderRosterView: ((entries: RosterEntry[]) => void) | null = null;
 let rosterSignature: string | null = null;
+let disposeRightPanel: (() => void) | null = null;
 
 function installRosterRenderer(renderer: (entries: RosterEntry[]) => void): void {
   rosterSignature = null;
@@ -662,6 +663,10 @@ const inventoryHud = setupInventoryHud(inventory, {
   onEquip: (unitId, item) => equipItemToSaunoja(unitId, item)
 });
 function initializeRightPanel(): void {
+  if (disposeRightPanel) {
+    disposeRightPanel();
+    disposeRightPanel = null;
+  }
   const rightPanel = setupRightPanel(state, {
     onRosterSelect: focusSaunojaById,
     onRosterRendererReady: installRosterRenderer
@@ -669,6 +674,7 @@ function initializeRightPanel(): void {
   log = rightPanel.log;
   addEvent = rightPanel.addEvent;
   installRosterRenderer(rightPanel.renderRoster);
+  disposeRightPanel = rightPanel.dispose;
 }
 
 initializeRightPanel();
@@ -929,6 +935,10 @@ export function cleanup(): void {
   eventBus.off('modifierExpired', onModifierChanged);
   eventBus.off('buildingPlaced', invalidateTerrainCache);
   eventBus.off('buildingRemoved', invalidateTerrainCache);
+  if (disposeRightPanel) {
+    disposeRightPanel();
+    disposeRightPanel = null;
+  }
   inventoryHud.destroy();
   disposeTopbar();
 }


### PR DESCRIPTION
## Summary
- extend the sauna command console setup to retain DOM, media query, and event bus listener cleanup functions
- expose a dispose callback from setupRightPanel and call it during initialization and cleanup to avoid leaking toggles
- document the new disposable HUD behavior in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc1d0052ec8330b77005b00b4b3b2d