### PR TITLE
Refactor bootstrap orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Refactor bootstrap wiring into dedicated input, HUD, and loader modules so the main entrypoint stays a light orchestrator with reusable UI hooks
 - Extract polished roster storage and HUD modules, relocate asset configuration,
   and add smoke tests so serialization and summary UI updates remain stable
 - Guard `safeLoadJSON` against missing `localStorage` implementations and cover
@@ -299,4 +300,3 @@
 - Defer game initialization until DOMContentLoaded via exported `init()`
 - Add workflow to deploy docs from `dist/` on pushes to `main`
 - Switch deployment workflow to Node.js 18
-

--- a/src/bootstrap/loader.ts
+++ b/src/bootstrap/loader.ts
@@ -1,0 +1,131 @@
+import type { AssetPaths, AssetLoadResult, LoadedAssets } from '../loader.ts';
+import { loadResources } from '../lib/loadResources.ts';
+
+export type LoaderStatusEvent =
+  | { type: 'status'; phase: 'start' | 'progress'; message: string }
+  | { type: 'ready'; assets: LoadedAssets; warnings: string[]; errors: string[] }
+  | { type: 'warnings'; warnings: string[] }
+  | { type: 'errors'; errors: string[] }
+  | { type: 'fatal'; messages: string[] }
+  | { type: 'failure'; error: unknown; message: string }
+  | { type: 'cancelled' };
+
+export interface BootstrapLoaderOptions {
+  assetPaths: AssetPaths;
+  loadAssets(paths: AssetPaths): Promise<AssetLoadResult>;
+  preloadSaunojaIcon(): Promise<unknown>;
+  setAssets(assets: LoadedAssets): void;
+  startGame(): void;
+  formatError?(reason: unknown): string;
+  shouldAbort?(runToken: number): boolean;
+}
+
+type Listener = (event: LoaderStatusEvent) => void;
+
+const DEFAULT_START_MESSAGE = 'Heating the sauna stones…';
+const DEFAULT_PROGRESS_MESSAGE = 'Polishing sauna ambience…';
+
+function defaultFormatError(reason: unknown): string {
+  if (reason instanceof Error && reason.message) {
+    return reason.message;
+  }
+  if (typeof reason === 'string' && reason.trim().length > 0) {
+    return reason;
+  }
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
+}
+
+export function createBootstrapLoader(options: BootstrapLoaderOptions) {
+  const listeners = new Set<Listener>();
+
+  const emit = (event: LoaderStatusEvent) => {
+    listeners.forEach((listener) => listener(event));
+  };
+
+  const formatError = options.formatError ?? defaultFormatError;
+
+  const run = async (runToken: number): Promise<void> => {
+    emit({ type: 'status', phase: 'start', message: DEFAULT_START_MESSAGE });
+
+    try {
+      const { resources, warnings, errors } = await loadResources({
+        assets: {
+          label: 'Core assets',
+          load: async () => {
+            const result = await options.loadAssets(options.assetPaths);
+            return { value: result.assets, errors: result.failures };
+          },
+        },
+        saunojaIcon: {
+          label: 'Saunoja icon',
+          load: async () => {
+            try {
+              await options.preloadSaunojaIcon();
+              return { value: true };
+            } catch (error) {
+              return {
+                value: false,
+                warnings: [`Unable to preload Saunoja icon (${formatError(error)})`],
+              };
+            }
+          },
+        },
+      });
+
+      if (options.shouldAbort?.(runToken)) {
+        emit({ type: 'cancelled' });
+        return;
+      }
+
+      emit({ type: 'status', phase: 'progress', message: DEFAULT_PROGRESS_MESSAGE });
+
+      const loadedAssets = resources.assets;
+      if (!loadedAssets) {
+        const fatalMessages = errors.length
+          ? [...errors]
+          : ['Critical assets were unavailable. Please refresh to try again.'];
+        emit({ type: 'fatal', messages: fatalMessages });
+        return;
+      }
+
+      if (errors.length) {
+        emit({ type: 'errors', errors });
+      }
+
+      if (warnings.length) {
+        emit({ type: 'warnings', warnings });
+      }
+
+      options.setAssets(loadedAssets);
+      if (options.shouldAbort?.(runToken)) {
+        emit({ type: 'cancelled' });
+        return;
+      }
+
+      options.startGame();
+      emit({ type: 'ready', assets: loadedAssets, warnings, errors });
+    } catch (error) {
+      if (options.shouldAbort?.(runToken)) {
+        emit({ type: 'cancelled' });
+        return;
+      }
+      emit({ type: 'failure', error, message: formatError(error) });
+    }
+  };
+
+  const subscribe = (listener: Listener): (() => void) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  return {
+    run,
+    subscribe,
+  };
+}

--- a/src/camera/controls.ts
+++ b/src/camera/controls.ts
@@ -1,0 +1,83 @@
+import { camera } from './autoFrame.ts';
+import type { PixelCoord } from '../hex/HexUtils.ts';
+import { draw } from '../game.ts';
+
+export const MIN_ZOOM = 0.5;
+export const MAX_ZOOM = 3.5;
+
+function screenToWorldWith(
+  canvas: HTMLCanvasElement,
+  screenX: number,
+  screenY: number,
+  zoom: number,
+  center: PixelCoord
+): PixelCoord {
+  const rect = canvas.getBoundingClientRect();
+  const offsetX = screenX - rect.left;
+  const offsetY = screenY - rect.top;
+  const halfWidth = rect.width / 2;
+  const halfHeight = rect.height / 2;
+  return {
+    x: center.x + (offsetX - halfWidth) / zoom,
+    y: center.y + (offsetY - halfHeight) / zoom,
+  };
+}
+
+export function clampZoom(zoom: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom));
+}
+
+export function screenToWorld(
+  canvas: HTMLCanvasElement,
+  screenX: number,
+  screenY: number,
+  zoom = camera.zoom,
+  center: PixelCoord = camera
+): PixelCoord {
+  return screenToWorldWith(canvas, screenX, screenY, zoom, center);
+}
+
+export function applyZoomAtPoint(
+  canvas: HTMLCanvasElement,
+  screenX: number,
+  screenY: number,
+  targetZoom: number
+): void {
+  const clamped = clampZoom(targetZoom);
+  if (clamped === camera.zoom) return;
+
+  const currentCenter = { x: camera.x, y: camera.y };
+  const before = screenToWorldWith(canvas, screenX, screenY, camera.zoom, currentCenter);
+  const after = screenToWorldWith(canvas, screenX, screenY, clamped, currentCenter);
+
+  camera.x += before.x - after.x;
+  camera.y += before.y - after.y;
+  camera.zoom = clamped;
+  draw();
+}
+
+export function panCameraByScreenDelta(dx: number, dy: number): void {
+  if (dx === 0 && dy === 0) return;
+  camera.x -= dx / camera.zoom;
+  camera.y -= dy / camera.zoom;
+  draw();
+}
+
+export function resizeCanvasToDisplaySize(canvas: HTMLCanvasElement): void {
+  const dpr = window.devicePixelRatio || 1;
+  const width = Math.max(window.innerWidth, 1);
+  const height = Math.max(window.innerHeight, 1);
+
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  canvas.width = Math.round(width * dpr);
+  canvas.height = Math.round(height * dpr);
+
+  const ctx = canvas.getContext('2d');
+  if (ctx) {
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+  }
+  draw();
+}
+
+export { camera };

--- a/src/input/pointerPan.ts
+++ b/src/input/pointerPan.ts
@@ -1,0 +1,94 @@
+export interface PointerPanHandlers {
+  onPan: (dx: number, dy: number, event: PointerEvent) => void;
+  onPanStart?: (event: PointerEvent) => void;
+  onPanEnd?: (event: PointerEvent) => void;
+}
+
+export interface PointerPanOptions extends PointerPanHandlers {
+  dragCursor?: string;
+}
+
+const DEFAULT_CURSOR = 'grabbing';
+
+type PointerEventHandler = (event: PointerEvent) => void;
+
+export function attachPointerPan(
+  canvas: HTMLElement,
+  handlers: PointerPanOptions
+): () => void {
+  const dragCursor = handlers.dragCursor ?? DEFAULT_CURSOR;
+  let active = false;
+  let pointerId: number | null = null;
+  let lastX = 0;
+  let lastY = 0;
+  let previousCursor: string | null = null;
+
+  const handlePointerDown: PointerEventHandler = (event) => {
+    if (event.pointerType !== 'mouse' || event.button !== 0) {
+      return;
+    }
+
+    active = true;
+    pointerId = event.pointerId;
+    lastX = event.clientX;
+    lastY = event.clientY;
+    previousCursor = canvas.style.cursor ?? '';
+
+    canvas.setPointerCapture?.(event.pointerId);
+    canvas.style.cursor = dragCursor;
+
+    handlers.onPanStart?.(event);
+  };
+
+  const handlePointerMove: PointerEventHandler = (event) => {
+    if (!active || pointerId !== event.pointerId) {
+      return;
+    }
+
+    const dx = event.clientX - lastX;
+    const dy = event.clientY - lastY;
+    lastX = event.clientX;
+    lastY = event.clientY;
+    handlers.onPan(dx, dy, event);
+  };
+
+  const endPan = (event: PointerEvent) => {
+    if (!active || pointerId !== event.pointerId) {
+      return;
+    }
+
+    active = false;
+    pointerId = null;
+
+    canvas.releasePointerCapture?.(event.pointerId);
+    canvas.style.cursor = previousCursor ?? '';
+
+    handlers.onPanEnd?.(event);
+  };
+
+  const handlePointerUp: PointerEventHandler = (event) => {
+    endPan(event);
+  };
+
+  const handlePointerCancel: PointerEventHandler = (event) => {
+    endPan(event);
+  };
+
+  canvas.addEventListener('pointerdown', handlePointerDown);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('pointerup', handlePointerUp);
+  canvas.addEventListener('pointercancel', handlePointerCancel);
+  canvas.addEventListener('pointerleave', handlePointerCancel);
+
+  return () => {
+    canvas.removeEventListener('pointerdown', handlePointerDown);
+    canvas.removeEventListener('pointermove', handlePointerMove);
+    canvas.removeEventListener('pointerup', handlePointerUp);
+    canvas.removeEventListener('pointercancel', handlePointerCancel);
+    canvas.removeEventListener('pointerleave', handlePointerCancel);
+    if (active && pointerId !== null) {
+      canvas.releasePointerCapture?.(pointerId);
+    }
+    canvas.style.cursor = previousCursor ?? '';
+  };
+}

--- a/src/input/touchGestures.ts
+++ b/src/input/touchGestures.ts
@@ -1,0 +1,245 @@
+export interface TouchPanHandler {
+  (dx: number, dy: number, event: TouchEvent): void;
+}
+
+export interface TouchPinchDetails {
+  centerX: number;
+  centerY: number;
+  scale: number;
+  deltaCenterX: number;
+  deltaCenterY: number;
+}
+
+export interface TouchPinchHandler {
+  (details: TouchPinchDetails, event: TouchEvent): void;
+}
+
+export interface TouchTapHandler {
+  (position: { x: number; y: number }, event: TouchEvent): void;
+}
+
+export interface TouchGestureHandlers {
+  onPan: TouchPanHandler;
+  onPinch: TouchPinchHandler;
+  onTap?: TouchTapHandler;
+}
+
+export interface TouchGestureOptions extends TouchGestureHandlers {
+  tapMaxMovement?: number;
+  tapMaxDuration?: number;
+}
+
+type TouchGestureState =
+  | {
+      mode: 'pan';
+      lastX: number;
+      lastY: number;
+      startX: number;
+      startY: number;
+      startTime: number;
+      moved: boolean;
+    }
+  | {
+      mode: 'pinch';
+      lastCenterX: number;
+      lastCenterY: number;
+      lastDistance: number;
+      startTime: number;
+      moved: boolean;
+    };
+
+const DEFAULT_TAP_MAX_MOVEMENT = 10;
+const DEFAULT_TAP_MAX_DURATION = 250;
+
+type TouchEventHandler = (event: TouchEvent) => void;
+
+function now(): number {
+  return typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+}
+
+export function attachTouchGestures(
+  canvas: HTMLElement,
+  handlers: TouchGestureOptions
+): () => void {
+  const tapMaxMovement = handlers.tapMaxMovement ?? DEFAULT_TAP_MAX_MOVEMENT;
+  const tapMaxDuration = handlers.tapMaxDuration ?? DEFAULT_TAP_MAX_DURATION;
+  let state: TouchGestureState | null = null;
+
+  const handleTouchStart: TouchEventHandler = (event) => {
+    if (event.touches.length === 1) {
+      const touch = event.touches[0];
+      state = {
+        mode: 'pan',
+        lastX: touch.clientX,
+        lastY: touch.clientY,
+        startX: touch.clientX,
+        startY: touch.clientY,
+        startTime: now(),
+        moved: false,
+      };
+      return;
+    }
+
+    if (event.touches.length >= 2) {
+      const [t0, t1] = [event.touches[0], event.touches[1]];
+      state = {
+        mode: 'pinch',
+        lastCenterX: (t0.clientX + t1.clientX) / 2,
+        lastCenterY: (t0.clientY + t1.clientY) / 2,
+        lastDistance: Math.hypot(t0.clientX - t1.clientX, t0.clientY - t1.clientY),
+        startTime: now(),
+        moved: false,
+      };
+    }
+  };
+
+  const handlePan = (touch: Touch, event: TouchEvent) => {
+    if (!state || state.mode !== 'pan') {
+      return;
+    }
+
+    const dx = touch.clientX - state.lastX;
+    const dy = touch.clientY - state.lastY;
+    if (!state.moved && Math.hypot(dx, dy) > 1) {
+      state.moved = true;
+    }
+    state.lastX = touch.clientX;
+    state.lastY = touch.clientY;
+    handlers.onPan(dx, dy, event);
+  };
+
+  const handlePinch = (t0: Touch, t1: Touch, event: TouchEvent) => {
+    const centerX = (t0.clientX + t1.clientX) / 2;
+    const centerY = (t0.clientY + t1.clientY) / 2;
+    const distance = Math.hypot(t0.clientX - t1.clientX, t0.clientY - t1.clientY);
+
+    let scale = 1;
+    let deltaCenterX = 0;
+    let deltaCenterY = 0;
+
+    if (state && state.mode === 'pinch') {
+      scale = distance / state.lastDistance;
+      deltaCenterX = centerX - state.lastCenterX;
+      deltaCenterY = centerY - state.lastCenterY;
+    } else {
+      state = {
+        mode: 'pinch',
+        lastCenterX: centerX,
+        lastCenterY: centerY,
+        lastDistance: distance,
+        startTime: now(),
+        moved: false,
+      };
+    }
+
+    if (!state || state.mode !== 'pinch') {
+      return;
+    }
+
+    state.lastCenterX = centerX;
+    state.lastCenterY = centerY;
+    state.lastDistance = distance;
+    state.moved = true;
+
+    handlers.onPinch({ centerX, centerY, scale, deltaCenterX, deltaCenterY }, event);
+  };
+
+  const handleTouchMove: TouchEventHandler = (event) => {
+    if (!state) {
+      return;
+    }
+    if (event.touches.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    if (event.touches.length === 1) {
+      const touch = event.touches[0];
+      if (state.mode !== 'pan') {
+        state = {
+          mode: 'pan',
+          lastX: touch.clientX,
+          lastY: touch.clientY,
+          startX: touch.clientX,
+          startY: touch.clientY,
+          startTime: now(),
+          moved: true,
+        };
+      }
+      handlePan(touch, event);
+      return;
+    }
+
+    const [t0, t1] = [event.touches[0], event.touches[1]];
+    handlePinch(t0, t1, event);
+  };
+
+  const isTap = (): boolean => {
+    if (!state || state.mode !== 'pan') {
+      return false;
+    }
+
+    const movement = Math.hypot(state.lastX - state.startX, state.lastY - state.startY);
+    if (movement > tapMaxMovement) {
+      return false;
+    }
+    const duration = now() - state.startTime;
+    return duration <= tapMaxDuration;
+  };
+
+  const handleTouchEnd: TouchEventHandler = (event) => {
+    if (!state) {
+      return;
+    }
+
+    if (event.touches.length === 0) {
+      if (state.mode === 'pan' && handlers.onTap && isTap()) {
+        handlers.onTap({ x: state.startX, y: state.startY }, event);
+      }
+      state = null;
+      return;
+    }
+
+    if (event.touches.length === 1) {
+      const touch = event.touches[0];
+      state = {
+        mode: 'pan',
+        lastX: touch.clientX,
+        lastY: touch.clientY,
+        startX: touch.clientX,
+        startY: touch.clientY,
+        startTime: now(),
+        moved: true,
+      };
+      return;
+    }
+
+    if (event.touches.length >= 2) {
+      const [t0, t1] = [event.touches[0], event.touches[1]];
+      state = {
+        mode: 'pinch',
+        lastCenterX: (t0.clientX + t1.clientX) / 2,
+        lastCenterY: (t0.clientY + t1.clientY) / 2,
+        lastDistance: Math.hypot(t0.clientX - t1.clientX, t0.clientY - t1.clientY),
+        startTime: now(),
+        moved: true,
+      };
+    }
+  };
+
+  canvas.addEventListener('touchstart', handleTouchStart, { passive: false });
+  canvas.addEventListener('touchmove', handleTouchMove, { passive: false });
+  canvas.addEventListener('touchend', handleTouchEnd);
+  canvas.addEventListener('touchcancel', handleTouchEnd);
+
+  return () => {
+    canvas.removeEventListener('touchstart', handleTouchStart);
+    canvas.removeEventListener('touchmove', handleTouchMove);
+    canvas.removeEventListener('touchend', handleTouchEnd);
+    canvas.removeEventListener('touchcancel', handleTouchEnd);
+    state = null;
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,29 +1,30 @@
 import './style.css';
-import { setupGame, start, handleCanvasClick, draw, cleanup } from './game.ts';
+import { setupGame, start, handleCanvasClick, cleanup } from './game.ts';
 import { assetPaths, setAssets } from './game/assets.ts';
-import { camera } from './camera/autoFrame.ts';
-import type { PixelCoord } from './hex/HexUtils.ts';
-import { loadResources } from './lib/loadResources.ts';
 import { loadAssets } from './loader.ts';
 import { preloadSaunojaIcon } from './units/renderSaunoja.ts';
+import { createHud, type HudController, type LoadingHandle, type BannerOptions } from './ui/hud.ts';
+import { createBootstrapLoader, type LoaderStatusEvent } from './bootstrap/loader.ts';
+import { attachPointerPan } from './input/pointerPan.ts';
+import { attachTouchGestures } from './input/touchGestures.ts';
+import {
+  camera,
+  MIN_ZOOM,
+  MAX_ZOOM,
+  clampZoom,
+  screenToWorld,
+  applyZoomAtPoint,
+  panCameraByScreenDelta,
+  resizeCanvasToDisplaySize,
+} from './camera/controls.ts';
 
-const MIN_CAMERA_ZOOM = 0.5;
-const MAX_CAMERA_ZOOM = 3.5;
 const WHEEL_ZOOM_SENSITIVITY = 0.0015;
-const TOUCH_TAP_MAX_MOVEMENT = 10;
-const TOUCH_TAP_MAX_DURATION = 250;
 
-interface TouchGestureState {
-  mode: 'pan' | 'pinch';
-  lastX?: number;
-  lastY?: number;
-  lastCenter?: { x: number; y: number };
-  lastDistance?: number;
-  startX?: number;
-  startY?: number;
-  startTime: number;
-  moved: boolean;
-}
+const cleanupHandlers: Array<() => void> = [];
+let initToken = 0;
+let canvasRef: HTMLCanvasElement | null = null;
+let hud: HudController = createHud(null);
+let loaderHandle: LoadingHandle | null = null;
 
 function applyBuildIdentity(): void {
   if (typeof document === 'undefined') {
@@ -57,329 +58,8 @@ function applyBuildIdentity(): void {
 
 applyBuildIdentity();
 
-const cleanupHandlers: Array<() => void> = [];
-
-let initToken = 0;
-
-let canvasRef: HTMLCanvasElement | null = null;
-let isInitialized = false;
-let touchState: TouchGestureState | null = null;
-
-const pointerPanState: {
-  active: boolean;
-  pointerId: number | null;
-  lastX: number;
-  lastY: number;
-} = {
-  active: false,
-  pointerId: null,
-  lastX: 0,
-  lastY: 0,
-};
-
-export { camera };
-export const MIN_ZOOM = MIN_CAMERA_ZOOM;
-export const MAX_ZOOM = MAX_CAMERA_ZOOM;
-
-export function clampZoom(zoom: number): number {
-  return Math.min(MAX_CAMERA_ZOOM, Math.max(MIN_CAMERA_ZOOM, zoom));
-}
-
 function addCleanup(fn: () => void): void {
   cleanupHandlers.push(fn);
-}
-
-function now(): number {
-  return typeof performance !== 'undefined' && typeof performance.now === 'function'
-    ? performance.now()
-    : Date.now();
-}
-
-export function resizeCanvasToDisplaySize(canvas: HTMLCanvasElement): void {
-  const dpr = window.devicePixelRatio || 1;
-  const width = Math.max(window.innerWidth, 1);
-  const height = Math.max(window.innerHeight, 1);
-
-  canvas.style.width = `${width}px`;
-  canvas.style.height = `${height}px`;
-  canvas.width = Math.round(width * dpr);
-  canvas.height = Math.round(height * dpr);
-
-  const ctx = canvas.getContext('2d');
-  if (ctx) {
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-  }
-  draw();
-}
-
-function screenToWorldWith(
-  canvas: HTMLCanvasElement,
-  screenX: number,
-  screenY: number,
-  zoom: number,
-  center: PixelCoord
-): PixelCoord {
-  const rect = canvas.getBoundingClientRect();
-  const offsetX = screenX - rect.left;
-  const offsetY = screenY - rect.top;
-  const halfWidth = rect.width / 2;
-  const halfHeight = rect.height / 2;
-  return {
-    x: center.x + (offsetX - halfWidth) / zoom,
-    y: center.y + (offsetY - halfHeight) / zoom,
-  };
-}
-
-export function screenToWorld(
-  canvas: HTMLCanvasElement,
-  screenX: number,
-  screenY: number,
-  zoom = camera.zoom,
-  center: PixelCoord = camera
-): PixelCoord {
-  return screenToWorldWith(canvas, screenX, screenY, zoom, center);
-}
-
-export function applyZoomAtPoint(canvas: HTMLCanvasElement, screenX: number, screenY: number, targetZoom: number): void {
-  const clamped = clampZoom(targetZoom);
-  if (clamped === camera.zoom) return;
-
-  const currentCenter = { x: camera.x, y: camera.y };
-  const before = screenToWorldWith(canvas, screenX, screenY, camera.zoom, currentCenter);
-  const after = screenToWorldWith(canvas, screenX, screenY, clamped, currentCenter);
-
-  camera.x += before.x - after.x;
-  camera.y += before.y - after.y;
-  camera.zoom = clamped;
-  draw();
-}
-
-export function panCameraByScreenDelta(dx: number, dy: number): void {
-  if (dx === 0 && dy === 0) return;
-  camera.x -= dx / camera.zoom;
-  camera.y -= dy / camera.zoom;
-  draw();
-}
-
-function onWheel(event: WheelEvent): void {
-  if (!canvasRef) return;
-  event.preventDefault();
-  const scaleFactor = Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY);
-  const targetZoom = camera.zoom * scaleFactor;
-  applyZoomAtPoint(canvasRef, event.clientX, event.clientY, targetZoom);
-}
-
-function onPointerDown(event: PointerEvent): void {
-  if (!canvasRef) return;
-  if (event.pointerType !== 'mouse' || event.button !== 0) return;
-  pointerPanState.active = true;
-  pointerPanState.pointerId = event.pointerId;
-  pointerPanState.lastX = event.clientX;
-  pointerPanState.lastY = event.clientY;
-  canvasRef.setPointerCapture?.(event.pointerId);
-  canvasRef.style.cursor = 'grabbing';
-}
-
-function onPointerMove(event: PointerEvent): void {
-  if (!canvasRef) return;
-  if (!pointerPanState.active || pointerPanState.pointerId !== event.pointerId) return;
-  const dx = event.clientX - pointerPanState.lastX;
-  const dy = event.clientY - pointerPanState.lastY;
-  pointerPanState.lastX = event.clientX;
-  pointerPanState.lastY = event.clientY;
-  panCameraByScreenDelta(dx, dy);
-}
-
-function onPointerUp(event: PointerEvent): void {
-  if (!canvasRef) return;
-  if (!pointerPanState.active || pointerPanState.pointerId !== event.pointerId) return;
-  pointerPanState.active = false;
-  pointerPanState.pointerId = null;
-  canvasRef.releasePointerCapture?.(event.pointerId);
-  canvasRef.style.cursor = '';
-}
-
-function isTapGesture(state: TouchGestureState): boolean {
-  if (!canvasRef) return false;
-  if (state.mode !== 'pan' || state.startX == null || state.startY == null) return false;
-  const movedTooFar = state.moved && Math.hypot((state.lastX ?? state.startX) - state.startX, (state.lastY ?? state.startY) - state.startY) > TOUCH_TAP_MAX_MOVEMENT;
-  if (movedTooFar) return false;
-  const duration = now() - state.startTime;
-  return duration <= TOUCH_TAP_MAX_DURATION;
-}
-
-function fireTap(state: TouchGestureState): void {
-  if (!canvasRef || state.startX == null || state.startY == null) return;
-  const world = screenToWorld(canvasRef, state.startX, state.startY);
-  handleCanvasClick(world);
-}
-
-function handlePanTouch(touch: Touch): void {
-  if (!touchState) return;
-  const dx = touch.clientX - (touchState.lastX ?? touch.clientX);
-  const dy = touch.clientY - (touchState.lastY ?? touch.clientY);
-  if (Math.hypot(dx, dy) > 1) {
-    touchState.moved = true;
-  }
-  touchState.lastX = touch.clientX;
-  touchState.lastY = touch.clientY;
-  panCameraByScreenDelta(dx, dy);
-}
-
-function handlePinchTouches(t0: Touch, t1: Touch): void {
-  if (!canvasRef) return;
-  const centerX = (t0.clientX + t1.clientX) / 2;
-  const centerY = (t0.clientY + t1.clientY) / 2;
-  const distance = Math.hypot(t0.clientX - t1.clientX, t0.clientY - t1.clientY);
-
-  if (touchState?.lastDistance) {
-    const zoomFactor = distance / touchState.lastDistance;
-    const targetZoom = camera.zoom * zoomFactor;
-    applyZoomAtPoint(canvasRef, centerX, centerY, targetZoom);
-  }
-
-  if (touchState?.lastCenter) {
-    const dx = centerX - touchState.lastCenter.x;
-    const dy = centerY - touchState.lastCenter.y;
-    panCameraByScreenDelta(dx, dy);
-  }
-
-  if (!touchState) {
-    touchState = {
-      mode: 'pinch',
-      lastCenter: { x: centerX, y: centerY },
-      lastDistance: distance,
-      startTime: now(),
-      moved: true,
-    };
-  } else {
-    touchState.mode = 'pinch';
-    touchState.lastCenter = { x: centerX, y: centerY };
-    touchState.lastDistance = distance;
-    touchState.moved = true;
-  }
-}
-
-function onTouchStart(event: TouchEvent): void {
-  if (!canvasRef) return;
-  if (event.touches.length === 1) {
-    const touch = event.touches[0];
-    touchState = {
-      mode: 'pan',
-      lastX: touch.clientX,
-      lastY: touch.clientY,
-      startX: touch.clientX,
-      startY: touch.clientY,
-      startTime: now(),
-      moved: false,
-    };
-  } else if (event.touches.length >= 2) {
-    const [t0, t1] = [event.touches[0], event.touches[1]];
-    touchState = {
-      mode: 'pinch',
-      lastCenter: { x: (t0.clientX + t1.clientX) / 2, y: (t0.clientY + t1.clientY) / 2 },
-      lastDistance: Math.hypot(t0.clientX - t1.clientX, t0.clientY - t1.clientY),
-      startTime: now(),
-      moved: false,
-    };
-  }
-}
-
-function onTouchMove(event: TouchEvent): void {
-  if (!canvasRef || !touchState) return;
-  if (event.touches.length === 0) return;
-  event.preventDefault();
-  if (event.touches.length === 1) {
-    const touch = event.touches[0];
-    if (touchState.mode !== 'pan') {
-      const transitionedFromPinch = touchState.mode === 'pinch';
-      touchState = {
-        mode: 'pan',
-        lastX: touch.clientX,
-        lastY: touch.clientY,
-        startX: touch.clientX,
-        startY: touch.clientY,
-        startTime: now(),
-        moved: transitionedFromPinch,
-      };
-    }
-    handlePanTouch(touch);
-  } else {
-    const [t0, t1] = [event.touches[0], event.touches[1]];
-    handlePinchTouches(t0, t1);
-  }
-}
-
-function onTouchEnd(event: TouchEvent): void {
-  if (!canvasRef || !touchState) return;
-  if (event.touches.length === 0) {
-    if (isTapGesture(touchState)) {
-      fireTap(touchState);
-    }
-    touchState = null;
-    return;
-  }
-
-  if (event.touches.length === 1) {
-    const touch = event.touches[0];
-    const transitionedFromPinch = touchState.mode === 'pinch';
-    touchState = {
-      mode: 'pan',
-      lastX: touch.clientX,
-      lastY: touch.clientY,
-      startX: touch.clientX,
-      startY: touch.clientY,
-      startTime: now(),
-      moved: transitionedFromPinch,
-    };
-  } else if (event.touches.length >= 2) {
-    const [t0, t1] = [event.touches[0], event.touches[1]];
-    touchState = {
-      mode: 'pinch',
-      lastCenter: { x: (t0.clientX + t1.clientX) / 2, y: (t0.clientY + t1.clientY) / 2 },
-      lastDistance: Math.hypot(t0.clientX - t1.clientX, t0.clientY - t1.clientY),
-      startTime: now(),
-      moved: true,
-    };
-  }
-}
-
-function onCanvasClick(event: MouseEvent): void {
-  if (!canvasRef) return;
-  const world = screenToWorld(canvasRef, event.clientX, event.clientY);
-  handleCanvasClick(world);
-}
-
-function attachCanvasListeners(canvas: HTMLCanvasElement): void {
-  canvas.addEventListener('click', onCanvasClick);
-  addCleanup(() => canvas.removeEventListener('click', onCanvasClick));
-
-  canvas.addEventListener('wheel', onWheel, { passive: false });
-  addCleanup(() => canvas.removeEventListener('wheel', onWheel));
-
-  canvas.addEventListener('pointerdown', onPointerDown);
-  canvas.addEventListener('pointermove', onPointerMove);
-  canvas.addEventListener('pointerup', onPointerUp);
-  canvas.addEventListener('pointercancel', onPointerUp);
-  canvas.addEventListener('pointerleave', onPointerUp);
-  addCleanup(() => {
-    canvas.removeEventListener('pointerdown', onPointerDown);
-    canvas.removeEventListener('pointermove', onPointerMove);
-    canvas.removeEventListener('pointerup', onPointerUp);
-    canvas.removeEventListener('pointercancel', onPointerUp);
-    canvas.removeEventListener('pointerleave', onPointerUp);
-  });
-
-  canvas.addEventListener('touchstart', onTouchStart, { passive: false });
-  canvas.addEventListener('touchmove', onTouchMove, { passive: false });
-  canvas.addEventListener('touchend', onTouchEnd);
-  canvas.addEventListener('touchcancel', onTouchEnd);
-  addCleanup(() => {
-    canvas.removeEventListener('touchstart', onTouchStart);
-    canvas.removeEventListener('touchmove', onTouchMove);
-    canvas.removeEventListener('touchend', onTouchEnd);
-    canvas.removeEventListener('touchcancel', onTouchEnd);
-  });
 }
 
 function clearCleanupHandlers(): void {
@@ -393,302 +73,68 @@ function clearCleanupHandlers(): void {
   }
 }
 
-export function destroy(): void {
-  initToken += 1;
-  clearCleanupHandlers();
-  pointerPanState.active = false;
-  pointerPanState.pointerId = null;
-  if (canvasRef) {
-    canvasRef.style.cursor = '';
+function registerLoaderCleanup(handle: LoadingHandle): void {
+  addCleanup(() => handle.dispose());
+}
+
+function showBanner(type: 'info' | 'warning' | 'error', options: BannerOptions): void {
+  const banner = hud.showBanner(type, options);
+  if (banner) {
+    addCleanup(() => banner.dismiss());
   }
-  touchState = null;
-  canvasRef = null;
-  isInitialized = false;
-  removeTransientUI();
-  cleanup();
 }
 
-function removeTransientUI(): void {
-  document.querySelectorAll('.hud-loader').forEach((element) => {
-    element.remove();
-  });
-  document.querySelectorAll('.hud-banner-stack').forEach((element) => {
-    element.remove();
-  });
-}
-
-interface LoadingHandle {
-  update(message: string): void;
-  clear(): void;
-  dispose(): void;
-}
-
-function showLoadingUI(message = 'Heating the sauna stones…'): LoadingHandle {
-  const overlay = document.getElementById('ui-overlay');
-  if (!overlay) {
-    return {
-      update: () => undefined,
-      clear: () => undefined,
-      dispose: () => undefined,
-    };
-  }
-
-  const loader = document.createElement('div');
-  loader.className = 'hud-loader';
-  loader.setAttribute('role', 'status');
-  loader.setAttribute('aria-live', 'polite');
-
-  const card = document.createElement('div');
-  card.className = 'hud-loader__card';
-
-  const spinner = document.createElement('div');
-  spinner.className = 'hud-loader__spinner';
-  spinner.setAttribute('aria-hidden', 'true');
-
-  const messageElement = document.createElement('p');
-  messageElement.className = 'hud-loader__message';
-  messageElement.textContent = message;
-
-  card.append(spinner, messageElement);
-  loader.append(card);
-  overlay.append(loader);
-
-  let dismissed = false;
-
-  return {
-    update(text: string) {
-      messageElement.textContent = text;
-    },
-    clear() {
-      if (dismissed) {
-        return;
+function handleLoaderEvent(event: LoaderStatusEvent): void {
+  switch (event.type) {
+    case 'status':
+      if (event.phase === 'start') {
+        loaderHandle?.dispose();
+        const handle = hud.showLoader(event.message);
+        loaderHandle = handle;
+        registerLoaderCleanup(handle);
+      } else if (loaderHandle) {
+        loaderHandle.update(event.message);
+        loaderHandle.clear();
+        loaderHandle = null;
       }
-      animateRemoval(loader, 'hud-loader--hidden', () => {
-        dismissed = true;
-        loader.remove();
-      });
-    },
-    dispose() {
-      if (dismissed) {
-        return;
+      break;
+    case 'ready':
+      loaderHandle?.clear();
+      loaderHandle = null;
+      break;
+    case 'warnings':
+      if (event.warnings.length) {
+        console.warn('Resource loader warnings', event.warnings);
+        showBanner('warning', {
+          title: 'Heads up',
+          messages: event.warnings,
+          autoCloseMs: 12000,
+        });
       }
-      dismissed = true;
-      loader.remove();
-    },
-  };
-}
-
-type BannerType = 'info' | 'warning' | 'error';
-
-interface BannerAction {
-  label: string;
-  onClick: () => void;
-  variant?: 'primary' | 'secondary';
-}
-
-interface BannerOptions {
-  title?: string;
-  messages: string[];
-  actions?: BannerAction[];
-  dismissible?: boolean;
-  autoCloseMs?: number;
-}
-
-interface BannerHandle {
-  element: HTMLElement;
-  dismiss: () => void;
-}
-
-function showBanner(type: BannerType, options: BannerOptions): BannerHandle | null {
-  const stack = ensureBannerStack();
-  if (!stack) {
-    return null;
-  }
-
-  const banner = document.createElement('section');
-  banner.className = `hud-banner hud-banner--${type}`;
-  banner.setAttribute('role', type === 'error' ? 'alert' : 'status');
-  banner.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
-
-  const header = document.createElement('header');
-  header.className = 'hud-banner__header';
-
-  const title = document.createElement('p');
-  title.className = 'hud-banner__title';
-  title.textContent =
-    options.title ??
-    (type === 'error' ? 'Attention required' : type === 'warning' ? 'Heads up' : 'Status update');
-  header.append(title);
-
-  const list = document.createElement('ul');
-  list.className = 'hud-banner__list';
-  for (const message of options.messages) {
-    const item = document.createElement('li');
-    item.textContent = message;
-    list.append(item);
-  }
-
-  banner.append(header);
-  if (options.messages.length) {
-    banner.append(list);
-  }
-
-  if (options.actions?.length) {
-    const actions = document.createElement('div');
-    actions.className = 'hud-banner__actions';
-    for (const action of options.actions) {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className =
-        action.variant === 'secondary'
-          ? 'hud-banner__button hud-banner__button--secondary'
-          : 'hud-banner__button';
-      button.textContent = action.label;
-      button.addEventListener('click', () => {
-        action.onClick();
-      });
-      actions.append(button);
-    }
-    banner.append(actions);
-  }
-
-  let autoDismissId: number | undefined;
-  let dismissed = false;
-
-  const dismiss = () => {
-    if (dismissed) {
-      return;
-    }
-    dismissed = true;
-    if (autoDismissId) {
-      window.clearTimeout(autoDismissId);
-    }
-    animateRemoval(banner, 'hud-banner--hide', () => {
-      banner.remove();
-      if (!stack.hasChildNodes()) {
-        stack.remove();
+      break;
+    case 'errors':
+      if (event.errors.length) {
+        console.error('Resource loader errors', event.errors);
+        showBanner('error', {
+          title: 'Some resources failed to load',
+          messages: event.errors,
+          actions: [
+            {
+              label: 'Reload',
+              onClick: () => window.location.reload(),
+              variant: 'primary',
+            },
+          ],
+        });
       }
-    });
-  };
-
-  if (options.dismissible !== false) {
-    const closeButton = document.createElement('button');
-    closeButton.type = 'button';
-    closeButton.className = 'hud-banner__close';
-    closeButton.setAttribute('aria-label', 'Dismiss notification');
-    closeButton.textContent = '×';
-    closeButton.addEventListener('click', () => {
-      dismiss();
-    });
-    header.append(closeButton);
-  }
-
-  stack.append(banner);
-
-  if (options.autoCloseMs && options.autoCloseMs > 0) {
-    autoDismissId = window.setTimeout(() => dismiss(), options.autoCloseMs);
-  }
-
-  return {
-    element: banner,
-    dismiss,
-  };
-}
-
-function ensureBannerStack(): HTMLElement | null {
-  const overlay = document.getElementById('ui-overlay');
-  if (!overlay) {
-    return null;
-  }
-
-  let stack = overlay.querySelector<HTMLElement>('.hud-banner-stack');
-  if (!stack) {
-    stack = document.createElement('div');
-    stack.className = 'hud-banner-stack';
-    overlay.append(stack);
-  }
-  return stack;
-}
-
-function animateRemoval(element: HTMLElement, hiddenClass: string, onComplete: () => void): void {
-  let finished = false;
-  const finalize = () => {
-    if (finished) {
-      return;
-    }
-    finished = true;
-    element.removeEventListener('transitionend', finalize);
-    onComplete();
-  };
-
-  element.addEventListener('transitionend', finalize);
-  requestAnimationFrame(() => {
-    element.classList.add(hiddenClass);
-  });
-  window.setTimeout(finalize, 400);
-}
-
-function formatError(reason: unknown): string {
-  if (reason instanceof Error && reason.message) {
-    return reason.message;
-  }
-  if (typeof reason === 'string' && reason.trim().length > 0) {
-    return reason;
-  }
-  try {
-    return JSON.stringify(reason);
-  } catch {
-    return String(reason);
-  }
-}
-
-async function prepareAndStart(runToken: number): Promise<void> {
-  const loader = showLoadingUI('Heating the sauna stones…');
-  addCleanup(() => loader.dispose());
-
-  try {
-    const { resources, warnings, errors } = await loadResources({
-      assets: {
-        label: 'Core assets',
-        load: async () => {
-          const result = await loadAssets(assetPaths);
-          return { value: result.assets, errors: result.failures };
-        },
-      },
-      saunojaIcon: {
-        label: 'Saunoja icon',
-        load: async () => {
-          try {
-            const icon = await preloadSaunojaIcon();
-            return { value: icon };
-          } catch (error) {
-            return {
-              value: null,
-              warnings: [`Unable to preload Saunoja icon (${formatError(error)})`],
-            };
-          }
-        },
-      },
-    });
-
-    if (runToken !== initToken) {
-      loader.dispose();
-      return;
-    }
-
-    loader.update('Polishing sauna ambience…');
-    loader.clear();
-
-    const loadedAssets = resources.assets;
-
-    if (!loadedAssets) {
-      const fatalMessages = errors.length
-        ? [...errors]
-        : ['Critical assets were unavailable. Please refresh to try again.'];
-      console.error('Critical assets failed to load', fatalMessages);
-      const fatalBanner = showBanner('error', {
+      break;
+    case 'fatal':
+      console.error('Critical assets failed to load', event.messages);
+      loaderHandle?.clear();
+      loaderHandle = null;
+      showBanner('error', {
         title: 'Unable to start the sauna battle',
-        messages: fatalMessages,
+        messages: event.messages,
         actions: [
           {
             label: 'Reload',
@@ -698,17 +144,14 @@ async function prepareAndStart(runToken: number): Promise<void> {
         ],
         dismissible: false,
       });
-      if (fatalBanner) {
-        addCleanup(() => fatalBanner.dismiss());
-      }
-      return;
-    }
-
-    if (errors.length) {
-      console.error('Resource loader errors', errors);
-      const errorBanner = showBanner('error', {
-        title: 'Some resources failed to load',
-        messages: errors,
+      break;
+    case 'failure':
+      console.error('Failed to initialize resources', event.error);
+      loaderHandle?.clear();
+      loaderHandle = null;
+      showBanner('error', {
+        title: 'Failed to initialize',
+        messages: [event.message],
         actions: [
           {
             label: 'Reload',
@@ -717,74 +160,111 @@ async function prepareAndStart(runToken: number): Promise<void> {
           },
         ],
       });
-      if (errorBanner) {
-        addCleanup(() => errorBanner.dismiss());
-      }
-    }
-
-    if (warnings.length) {
-      console.warn('Resource loader warnings', warnings);
-      const warningBanner = showBanner('warning', {
-        title: 'Heads up',
-        messages: warnings,
-        autoCloseMs: 12000,
-      });
-      if (warningBanner) {
-        addCleanup(() => warningBanner.dismiss());
-      }
-    }
-
-    setAssets(loadedAssets);
-    start();
-  } catch (error) {
-    if (runToken !== initToken) {
-      loader.dispose();
-      return;
-    }
-    console.error('Failed to initialize resources', error);
-    loader.clear();
-    const banner = showBanner('error', {
-      title: 'Failed to initialize',
-      messages: [formatError(error)],
-      actions: [
-        {
-          label: 'Reload',
-          onClick: () => window.location.reload(),
-          variant: 'primary',
-        },
-      ],
-    });
-    if (banner) {
-      addCleanup(() => banner.dismiss());
-    }
+      break;
+    case 'cancelled':
+      loaderHandle?.dispose();
+      loaderHandle = null;
+      break;
   }
+}
+
+const bootstrapLoader = createBootstrapLoader({
+  assetPaths,
+  loadAssets,
+  preloadSaunojaIcon,
+  setAssets,
+  startGame: start,
+  shouldAbort: (token) => token !== initToken,
+});
+
+bootstrapLoader.subscribe(handleLoaderEvent);
+
+function onWheel(event: WheelEvent): void {
+  if (!canvasRef) return;
+  event.preventDefault();
+  const scaleFactor = Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY);
+  const targetZoom = camera.zoom * scaleFactor;
+  applyZoomAtPoint(canvasRef, event.clientX, event.clientY, targetZoom);
+}
+
+function onCanvasClick(event: MouseEvent): void {
+  if (!canvasRef) return;
+  const world = screenToWorld(canvasRef, event.clientX, event.clientY);
+  handleCanvasClick(world);
+}
+
+function attachCanvasInputs(canvas: HTMLCanvasElement): void {
+  canvas.addEventListener('click', onCanvasClick);
+  addCleanup(() => canvas.removeEventListener('click', onCanvasClick));
+
+  canvas.addEventListener('wheel', onWheel, { passive: false });
+  addCleanup(() => canvas.removeEventListener('wheel', onWheel));
+
+  const detachPointer = attachPointerPan(canvas, {
+    onPan: (dx, dy) => {
+      panCameraByScreenDelta(dx, dy);
+    },
+    dragCursor: 'grabbing',
+  });
+  addCleanup(detachPointer);
+
+  const detachGestures = attachTouchGestures(canvas, {
+    onPan: (dx, dy) => {
+      panCameraByScreenDelta(dx, dy);
+    },
+    onPinch: ({ centerX, centerY, scale, deltaCenterX, deltaCenterY }) => {
+      applyZoomAtPoint(canvas, centerX, centerY, camera.zoom * scale);
+      panCameraByScreenDelta(deltaCenterX, deltaCenterY);
+    },
+    onTap: (position) => {
+      const world = screenToWorld(canvas, position.x, position.y);
+      handleCanvasClick(world);
+    },
+  });
+  addCleanup(detachGestures);
+}
+
+export function destroy(): void {
+  initToken += 1;
+  clearCleanupHandlers();
+  loaderHandle?.dispose();
+  loaderHandle = null;
+  if (canvasRef) {
+    canvasRef.style.cursor = '';
+  }
+  canvasRef = null;
+  hud.removeTransientUI();
+  cleanup();
 }
 
 export function init(): void {
   const canvas = document.getElementById('game-canvas') as HTMLCanvasElement | null;
   const resourceBar = document.getElementById('resource-bar');
-  if (!canvas || !resourceBar) {
+  const overlay = document.getElementById('ui-overlay');
+
+  if (!canvas || !resourceBar || !overlay) {
     console.error(
-      'Autobattles4xFinsauna shell is missing the required canvas or resource bar elements.',
+      'Autobattles4xFinsauna shell is missing the required canvas, overlay, or resource bar elements.',
       {
         hasCanvas: Boolean(canvas),
         hasResourceBar: Boolean(resourceBar),
+        hasOverlay: Boolean(overlay),
       }
     );
     return;
   }
 
-  if (isInitialized) {
+  if (canvasRef) {
     destroy();
   }
 
   const runToken = ++initToken;
 
   canvasRef = canvas;
-  isInitialized = true;
+  hud = createHud(overlay);
 
   setupGame(canvas, resourceBar);
-  attachCanvasListeners(canvas);
+  attachCanvasInputs(canvas);
 
   const resize = () => resizeCanvasToDisplaySize(canvas);
   window.addEventListener('resize', resize);
@@ -796,7 +276,7 @@ export function init(): void {
   resize();
 
   if (!import.meta.vitest) {
-    void prepareAndStart(runToken);
+    void bootstrapLoader.run(runToken);
   }
 }
 
@@ -805,20 +285,30 @@ function initWhenDomReady(): void {
     return;
   }
 
-  const start = () => {
-    document.removeEventListener('DOMContentLoaded', start);
+  const startInit = () => {
+    document.removeEventListener('DOMContentLoaded', startInit);
     init();
   };
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', start);
+    document.addEventListener('DOMContentLoaded', startInit);
     return;
   }
 
-  start();
+  startInit();
 }
 
 if (!import.meta.vitest) {
   initWhenDomReady();
 }
 
+export {
+  camera,
+  MIN_ZOOM,
+  MAX_ZOOM,
+  clampZoom,
+  screenToWorld,
+  applyZoomAtPoint,
+  panCameraByScreenDelta,
+  resizeCanvasToDisplaySize,
+};

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,0 +1,228 @@
+export type BannerType = 'info' | 'warning' | 'error';
+
+export interface BannerAction {
+  label: string;
+  onClick: () => void;
+  variant?: 'primary' | 'secondary';
+}
+
+export interface BannerOptions {
+  title?: string;
+  messages: string[];
+  actions?: BannerAction[];
+  dismissible?: boolean;
+  autoCloseMs?: number;
+}
+
+export interface BannerHandle {
+  element: HTMLElement;
+  dismiss: () => void;
+}
+
+export interface LoadingHandle {
+  update(message: string): void;
+  clear(): void;
+  dispose(): void;
+}
+
+export interface HudController {
+  showLoader(message?: string): LoadingHandle;
+  showBanner(type: BannerType, options: BannerOptions): BannerHandle | null;
+  removeTransientUI(): void;
+}
+
+export function createHud(root: HTMLElement | null): HudController {
+  if (!root) {
+    return {
+      showLoader: () => ({
+        update: () => undefined,
+        clear: () => undefined,
+        dispose: () => undefined,
+      }),
+      showBanner: () => null,
+      removeTransientUI: () => undefined,
+    };
+  }
+
+  const ensureBannerStack = (): HTMLElement => {
+    let stack = root.querySelector<HTMLElement>('.hud-banner-stack');
+    if (!stack) {
+      stack = document.createElement('div');
+      stack.className = 'hud-banner-stack';
+      root.append(stack);
+    }
+    return stack;
+  };
+
+  const animateRemoval = (element: HTMLElement, hiddenClass: string, onComplete: () => void) => {
+    let finished = false;
+    const finalize = () => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      element.removeEventListener('transitionend', finalize);
+      onComplete();
+    };
+
+    element.addEventListener('transitionend', finalize);
+    requestAnimationFrame(() => {
+      element.classList.add(hiddenClass);
+    });
+    window.setTimeout(finalize, 400);
+  };
+
+  const showLoader = (message = 'Heating the sauna stones…'): LoadingHandle => {
+    const loader = document.createElement('div');
+    loader.className = 'hud-loader';
+    loader.setAttribute('role', 'status');
+    loader.setAttribute('aria-live', 'polite');
+
+    const card = document.createElement('div');
+    card.className = 'hud-loader__card';
+
+    const spinner = document.createElement('div');
+    spinner.className = 'hud-loader__spinner';
+    spinner.setAttribute('aria-hidden', 'true');
+
+    const messageElement = document.createElement('p');
+    messageElement.className = 'hud-loader__message';
+    messageElement.textContent = message;
+
+    card.append(spinner, messageElement);
+    loader.append(card);
+    root.append(loader);
+
+    let dismissed = false;
+
+    return {
+      update(text: string) {
+        messageElement.textContent = text;
+      },
+      clear() {
+        if (dismissed) {
+          return;
+        }
+        animateRemoval(loader, 'hud-loader--hidden', () => {
+          dismissed = true;
+          loader.remove();
+        });
+      },
+      dispose() {
+        if (dismissed) {
+          return;
+        }
+        dismissed = true;
+        loader.remove();
+      },
+    };
+  };
+
+  const showBanner = (type: BannerType, options: BannerOptions): BannerHandle | null => {
+    const stack = ensureBannerStack();
+
+    const banner = document.createElement('section');
+    banner.className = `hud-banner hud-banner--${type}`;
+    banner.setAttribute('role', type === 'error' ? 'alert' : 'status');
+    banner.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
+
+    const header = document.createElement('header');
+    header.className = 'hud-banner__header';
+
+    const title = document.createElement('p');
+    title.className = 'hud-banner__title';
+    title.textContent =
+      options.title ??
+      (type === 'error' ? 'Attention required' : type === 'warning' ? 'Heads up' : 'Status update');
+    header.append(title);
+
+    const list = document.createElement('ul');
+    list.className = 'hud-banner__list';
+    for (const message of options.messages) {
+      const item = document.createElement('li');
+      item.textContent = message;
+      list.append(item);
+    }
+
+    banner.append(header);
+    if (options.messages.length) {
+      banner.append(list);
+    }
+
+    if (options.actions?.length) {
+      const actions = document.createElement('div');
+      actions.className = 'hud-banner__actions';
+      for (const action of options.actions) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className =
+          action.variant === 'secondary'
+            ? 'hud-banner__button hud-banner__button--secondary'
+            : 'hud-banner__button';
+        button.textContent = action.label;
+        button.addEventListener('click', () => {
+          action.onClick();
+        });
+        actions.append(button);
+      }
+      banner.append(actions);
+    }
+
+    let autoDismissId: number | undefined;
+    let dismissed = false;
+
+    const dismiss = () => {
+      if (dismissed) {
+        return;
+      }
+      dismissed = true;
+      if (autoDismissId) {
+        window.clearTimeout(autoDismissId);
+      }
+      animateRemoval(banner, 'hud-banner--hide', () => {
+        banner.remove();
+        if (!stack.hasChildNodes()) {
+          stack.remove();
+        }
+      });
+    };
+
+    if (options.dismissible !== false) {
+      const closeButton = document.createElement('button');
+      closeButton.type = 'button';
+      closeButton.className = 'hud-banner__close';
+      closeButton.setAttribute('aria-label', 'Dismiss notification');
+      closeButton.textContent = '×';
+      closeButton.addEventListener('click', () => {
+        dismiss();
+      });
+      header.append(closeButton);
+    }
+
+    stack.append(banner);
+
+    if (options.autoCloseMs && options.autoCloseMs > 0) {
+      autoDismissId = window.setTimeout(() => dismiss(), options.autoCloseMs);
+    }
+
+    return {
+      element: banner,
+      dismiss,
+    };
+  };
+
+  const removeTransientUI = () => {
+    root.querySelectorAll('.hud-loader').forEach((element) => {
+      element.remove();
+    });
+    root.querySelectorAll('.hud-banner-stack').forEach((element) => {
+      element.remove();
+    });
+  };
+
+  return {
+    showLoader,
+    showBanner,
+    removeTransientUI,
+  };
+}


### PR DESCRIPTION
## Summary
- extract reusable pointer and touch input hooks and centralize camera controls
- factor HUD loader/banner factories into a dedicated module and emit loader events from a bootstrap coordinator
- slim down main.ts to wire the new modules and add a changelog entry for the restructure

## Testing
- npm run build
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cc2939d8888330b77bd65a21e12017