### PR TITLE
Run demo link check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         with: { node-version: 20, cache: 'npm' }
       - run: npm ci
       - run: npm run build
+      - name: Verify live demo link
+        run: npm run check:demo
 
       # Sanity checks: dist exists and has required files
       - name: Sanity checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a post-build CI gate that runs the `check:demo` script so pull requests
+  surface broken live demo links or titles while preserving offline-friendly
+  warnings
 - Refactor bootstrap wiring into dedicated input, HUD, and loader modules so the main entrypoint stays a light orchestrator with reusable UI hooks
 - Extract polished roster storage and HUD modules, relocate asset configuration,
   and add smoke tests so serialization and summary UI updates remain stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ important for keeping the live experience in sync with the repository.
 - Keep the README in parity with the current build. In particular, the "Live
   Build" section must include the canonical link to
   `https://artobest.com/?utm_source=chatgpt.com` so the automated `check:demo`
-  script can verify the deployment.
+  script can verify the deployment. The CI pipeline now runs this guard after
+  the production build, so broken URLs or titles will fail pull requests.
 - Preserve the custom domain configuration. `public/CNAME` (and the mirrored
   `docs/CNAME` for historic deployments) should continue to reference
   `artobest.com` unless the production URL officially changes.
@@ -22,9 +23,12 @@ Run the full workflow locally before pushing:
 
 1. `npm test`
 2. `npm run build`
+3. `npm run check:demo`
 
-The test script already runs the live demo availability check; no additional
-steps are required if it succeeds.
+The test script already runs the live demo availability check; the dedicated
+`check:demo` command is listed separately so you can mirror the post-build CI
+gate when triaging demo link issues or re-running the check after network
+failures.
 
 ## Opening a pull request
 


### PR DESCRIPTION
## Summary
- run the `check:demo` script after the build in CI so failing demo URLs or titles stop pull requests
- document the new gate in CONTRIBUTING and note it in the changelog

## Testing
- npm run build
- npm run check:demo

------
https://chatgpt.com/codex/tasks/task_e_68cc2c2ac0a48330b15cdf64d29c7d3f