### PR TITLE
Refine hex chunk rendering and caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Compute camera-visible chunk ranges to populate tiles on reveal, move terrain
+  drawing into an event-driven chunk cache that reuses offscreen canvases, wire
+  the renderer through the new utilities so terrain, fog, and building updates
+  invalidate the right chunks, and cover the flow with chunk invalidation tests
 - Smooth battlefield workload spikes by rotating unit updates through a
   round-robin scheduler, reuse cached paths with TTL-aware invalidation when
   obstacles remain unchanged, and document the optimization with fresh tests

--- a/src/hex/HexTile.ts
+++ b/src/hex/HexTile.ts
@@ -3,13 +3,61 @@ import { TerrainId } from '../map/terrain.ts';
 export type TerrainType = TerrainId;
 export type BuildingType = 'city' | 'farm' | 'barracks' | 'mine' | null;
 
+export type TileMutation = 'terrain' | 'building' | 'fog';
+export type TileMutationListener = (mutation: TileMutation) => void;
+
 /** Represents a single hex tile on the map. */
 export class HexTile {
+  private _terrain: TerrainType;
+  private _building: BuildingType;
+  private _isFogged: boolean;
+  private readonly listeners = new Set<TileMutationListener>();
+
   constructor(
-    public terrain: TerrainType = TerrainId.Plains,
-    public building: BuildingType = null,
-    public isFogged: boolean = true
-  ) {}
+    terrain: TerrainType = TerrainId.Plains,
+    building: BuildingType = null,
+    isFogged: boolean = true
+  ) {
+    this._terrain = terrain;
+    this._building = building;
+    this._isFogged = isFogged;
+  }
+
+  get terrain(): TerrainType {
+    return this._terrain;
+  }
+
+  set terrain(value: TerrainType) {
+    if (this._terrain === value) {
+      return;
+    }
+    this._terrain = value;
+    this.notify('terrain');
+  }
+
+  get building(): BuildingType {
+    return this._building;
+  }
+
+  set building(value: BuildingType) {
+    if (this._building === value) {
+      return;
+    }
+    this._building = value;
+    this.notify('building');
+  }
+
+  get isFogged(): boolean {
+    return this._isFogged;
+  }
+
+  set isFogged(value: boolean) {
+    if (this._isFogged === value) {
+      return;
+    }
+    this._isFogged = value;
+    this.notify('fog');
+  }
 
   /** Reveal the tile by removing fog. */
   reveal(): void {
@@ -24,5 +72,16 @@ export class HexTile {
   /** Toggle fog of war state. */
   setFogged(value: boolean): void {
     this.isFogged = value;
+  }
+
+  addMutationListener(listener: TileMutationListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private notify(mutation: TileMutation): void {
+    for (const listener of this.listeners) {
+      listener(mutation);
+    }
   }
 }

--- a/src/hexmap.test.ts
+++ b/src/hexmap.test.ts
@@ -34,10 +34,59 @@ describe('HexMap', () => {
   it('draws a barracks image when tile has a barracks building', () => {
     const map = new HexMap(1, 1);
     const tile = map.ensureTile(0, 0);
+    tile.reveal();
     tile.placeBuilding('barracks');
-    // stub canvas context
+
+    const offscreenGradient = { addColorStop: vi.fn() };
+    const offscreenDrawImage = vi.fn();
+    const offscreenCtx = {
+      setTransform: vi.fn(),
+      clearRect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      createRadialGradient: vi.fn(() => offscreenGradient),
+      fillRect: vi.fn(),
+      drawImage: offscreenDrawImage,
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      clip: vi.fn(),
+      fill: vi.fn(),
+      stroke: vi.fn(),
+      globalAlpha: 1,
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 1,
+      lineJoin: 'round' as CanvasLineJoin,
+      lineCap: 'round' as CanvasLineCap,
+      shadowColor: '',
+      shadowBlur: 0,
+      shadowOffsetX: 0,
+      shadowOffsetY: 0,
+      globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
+    } as unknown as CanvasRenderingContext2D;
+
+    const originalCreateElement = document.createElement;
+    const offscreenCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => offscreenCtx),
+    } as unknown as HTMLCanvasElement;
+    const createElementSpy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation((tagName: string) => {
+        if (tagName === 'canvas') {
+          offscreenCanvas.width = 0;
+          offscreenCanvas.height = 0;
+          return offscreenCanvas;
+        }
+        return originalCreateElement.call(document, tagName);
+      });
+
     const gradient = { addColorStop: vi.fn() };
     const ctx = {
+      canvas: { width: 800, height: 600 } as HTMLCanvasElement,
       drawImage: vi.fn(),
       beginPath: vi.fn(),
       moveTo: vi.fn(),
@@ -48,7 +97,6 @@ describe('HexMap', () => {
       clip: vi.fn(),
       save: vi.fn(),
       restore: vi.fn(),
-      arc: vi.fn(),
       fillRect: vi.fn(),
       createRadialGradient: vi.fn(() => gradient),
       globalAlpha: 1,
@@ -63,20 +111,27 @@ describe('HexMap', () => {
       shadowOffsetY: 0,
       globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
     } as unknown as CanvasRenderingContext2D;
-    const createImg = () => document.createElement('img') as HTMLImageElement;
+
+    const createImg = () => originalCreateElement.call(document, 'img') as HTMLImageElement;
     const images = {
       'building-barracks': createImg(),
       placeholder: createImg(),
     };
+
     const renderer = new HexMapRenderer(map);
-    renderer.draw(ctx, images);
-    expect(ctx.drawImage).toHaveBeenCalledWith(
-      images['building-barracks'],
-      expect.any(Number),
-      expect.any(Number),
-      expect.any(Number),
-      expect.any(Number)
-    );
+    try {
+      renderer.draw(ctx, images);
+
+      expect(offscreenDrawImage).toHaveBeenCalledWith(
+        images['building-barracks'],
+        expect.any(Number),
+        expect.any(Number),
+        expect.any(Number),
+        expect.any(Number)
+      );
+    } finally {
+      createElementSpy.mockRestore();
+    }
   });
 
   it('expands bounds when accessing tiles outside initial area', () => {

--- a/src/map/hex/chunking.ts
+++ b/src/map/hex/chunking.ts
@@ -1,0 +1,183 @@
+import type { CameraState } from '../../camera/autoFrame.ts';
+import type { HexMap } from '../../hexmap.ts';
+import { pixelToAxialUnrounded } from '../../hex/HexUtils.ts';
+
+export const HEX_CHUNK_SIZE = 16;
+
+export interface AxialBounds {
+  qMin: number;
+  qMax: number;
+  rMin: number;
+  rMax: number;
+}
+
+export interface ChunkRange {
+  qMin: number;
+  qMax: number;
+  rMin: number;
+  rMax: number;
+}
+
+export interface ChunkCoord {
+  q: number;
+  r: number;
+}
+
+export type ChunkKey = string;
+
+const VIEWPORT_MARGIN = 2;
+
+function getDevicePixelRatio(): number {
+  return typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+}
+
+function clampBoundsToMap(bounds: AxialBounds, map: HexMap): AxialBounds | null {
+  const qMin = Math.max(bounds.qMin, map.minQ);
+  const qMax = Math.min(bounds.qMax, map.maxQ);
+  const rMin = Math.max(bounds.rMin, map.minR);
+  const rMax = Math.min(bounds.rMax, map.maxR);
+
+  if (qMin > qMax || rMin > rMax) {
+    return null;
+  }
+
+  return { qMin, qMax, rMin, rMax };
+}
+
+function computeViewportRect(
+  cam: CameraState,
+  canvas: HTMLCanvasElement
+): { x: number; y: number; width: number; height: number } {
+  const dpr = getDevicePixelRatio();
+  const width = canvas.width / (dpr * cam.zoom);
+  const height = canvas.height / (dpr * cam.zoom);
+  return {
+    x: cam.x - width / 2,
+    y: cam.y - height / 2,
+    width,
+    height,
+  };
+}
+
+function computeAxialBounds(
+  rect: { x: number; y: number; width: number; height: number },
+  hexSize: number
+): AxialBounds {
+  const corners = [
+    pixelToAxialUnrounded(rect.x, rect.y, hexSize),
+    pixelToAxialUnrounded(rect.x + rect.width, rect.y, hexSize),
+    pixelToAxialUnrounded(rect.x, rect.y + rect.height, hexSize),
+    pixelToAxialUnrounded(rect.x + rect.width, rect.y + rect.height, hexSize),
+  ];
+
+  let qMin = Infinity;
+  let qMax = -Infinity;
+  let rMin = Infinity;
+  let rMax = -Infinity;
+
+  for (const corner of corners) {
+    qMin = Math.min(qMin, corner.q);
+    qMax = Math.max(qMax, corner.q);
+    rMin = Math.min(rMin, corner.r);
+    rMax = Math.max(rMax, corner.r);
+  }
+
+  return {
+    qMin: Math.floor(qMin) - VIEWPORT_MARGIN,
+    qMax: Math.ceil(qMax) + VIEWPORT_MARGIN,
+    rMin: Math.floor(rMin) - VIEWPORT_MARGIN,
+    rMax: Math.ceil(rMax) + VIEWPORT_MARGIN,
+  };
+}
+
+export function computeVisibleBounds(
+  map: HexMap,
+  cam: CameraState,
+  canvas: HTMLCanvasElement | null,
+  hexSize: number
+): AxialBounds | null {
+  if (!canvas || typeof canvas.width !== 'number' || typeof canvas.height !== 'number') {
+    return {
+      qMin: map.minQ,
+      qMax: map.maxQ,
+      rMin: map.minR,
+      rMax: map.maxR,
+    };
+  }
+
+  if (canvas.width === 0 || canvas.height === 0) {
+    return {
+      qMin: map.minQ,
+      qMax: map.maxQ,
+      rMin: map.minR,
+      rMax: map.maxR,
+    };
+  }
+
+  const rect = computeViewportRect(cam, canvas);
+  return clampBoundsToMap(computeAxialBounds(rect, hexSize), map);
+}
+
+function toChunkIndex(value: number): number {
+  return Math.floor(value / HEX_CHUNK_SIZE);
+}
+
+export function chunkKeyFromCoord(coord: ChunkCoord): ChunkKey {
+  return `${coord.q},${coord.r}`;
+}
+
+export function chunkKeyFromAxial(q: number, r: number): ChunkKey {
+  return chunkKeyFromCoord({ q: toChunkIndex(q), r: toChunkIndex(r) });
+}
+
+export function chunkCoordFromKey(key: ChunkKey): ChunkCoord {
+  const [q, r] = key.split(',').map(Number);
+  return { q, r };
+}
+
+export function chunkRangeFromBounds(bounds: AxialBounds): ChunkRange {
+  return {
+    qMin: toChunkIndex(bounds.qMin),
+    qMax: toChunkIndex(bounds.qMax),
+    rMin: toChunkIndex(bounds.rMin),
+    rMax: toChunkIndex(bounds.rMax),
+  };
+}
+
+export function enumerateChunks(range: ChunkRange): ChunkCoord[] {
+  const chunks: ChunkCoord[] = [];
+  for (let r = range.rMin; r <= range.rMax; r++) {
+    for (let q = range.qMin; q <= range.qMax; q++) {
+      chunks.push({ q, r });
+    }
+  }
+  return chunks;
+}
+
+export function ensureChunkPopulated(map: HexMap, chunk: ChunkCoord): void {
+  const qStart = chunk.q * HEX_CHUNK_SIZE;
+  const rStart = chunk.r * HEX_CHUNK_SIZE;
+  const qEnd = qStart + HEX_CHUNK_SIZE - 1;
+  const rEnd = rStart + HEX_CHUNK_SIZE - 1;
+
+  const clampedQStart = Math.max(qStart, map.minQ);
+  const clampedQEnd = Math.min(qEnd, map.maxQ);
+  const clampedRStart = Math.max(rStart, map.minR);
+  const clampedREnd = Math.min(rEnd, map.maxR);
+
+  if (clampedQStart > clampedQEnd || clampedRStart > clampedREnd) {
+    return;
+  }
+
+  for (let r = clampedRStart; r <= clampedREnd; r++) {
+    for (let q = clampedQStart; q <= clampedQEnd; q++) {
+      map.ensureTile(q, r);
+    }
+  }
+}
+
+export function ensureChunksPopulated(map: HexMap, range: ChunkRange): void {
+  for (const chunk of enumerateChunks(range)) {
+    ensureChunkPopulated(map, chunk);
+  }
+}

--- a/src/render/HexMapRenderer.ts
+++ b/src/render/HexMapRenderer.ts
@@ -1,144 +1,22 @@
 import type { AxialCoord, PixelCoord } from '../hex/HexUtils.ts';
-import { axialToPixel, pixelToAxialUnrounded } from '../hex/HexUtils.ts';
+import { axialToPixel } from '../hex/HexUtils.ts';
 import { getHexDimensions } from '../hex/HexDimensions.ts';
 import type { HexMap } from '../hexmap.ts';
-import type { HexPatternOptions } from '../map/hexPatterns.ts';
-import { drawForest, drawHills, drawPlains, drawWater } from '../map/hexPatterns.ts';
 import type { LoadedAssets } from '../loader.ts';
-import { TerrainId } from '../map/terrain.ts';
-import { TERRAIN } from './TerrainPalette.ts';
-import { loadIcon } from './loadIcon.ts';
-import { camera, type CameraState } from '../camera/autoFrame.ts';
+import { camera } from '../camera/autoFrame.ts';
+import {
+  computeVisibleBounds,
+  chunkRangeFromBounds,
+  ensureChunksPopulated,
+  type AxialBounds,
+} from '../map/hex/chunking.ts';
+import { TerrainCache, type ChunkCanvas } from './terrain_cache.ts';
 
 const DEFAULT_HIGHLIGHT = 'rgba(56, 189, 248, 0.85)';
 const DEFAULT_HIGHLIGHT_GLOW = 'rgba(56, 189, 248, 0.45)';
 
 let highlightStroke: string | null = null;
 let highlightGlow: string | null = null;
-
-const CHUNK = 16; // hexes per side
-type ChunkKey = string;
-
-interface ChunkCanvas {
-  canvas: HTMLCanvasElement;
-  origin: PixelCoord; // position relative to the map origin
-}
-
-function chunkKey(q: number, r: number): ChunkKey {
-  return `${Math.floor(q / CHUNK)},${Math.floor(r / CHUNK)}`;
-}
-
-function parseTileKey(key: string): { q: number; r: number } {
-  const [q, r] = key.split(',').map(Number);
-  return { q, r };
-}
-
-const TERRAIN_PATTERNS: Record<TerrainId, (options: HexPatternOptions) => void> = {
-  [TerrainId.Plains]: drawPlains,
-  [TerrainId.Forest]: drawForest,
-  [TerrainId.Hills]: drawHills,
-  [TerrainId.Lake]: drawWater,
-};
-
-interface WorldRect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
-interface AxialBounds {
-  qMin: number;
-  qMax: number;
-  rMin: number;
-  rMax: number;
-}
-
-const VIEWPORT_MARGIN = 2;
-
-function getDevicePixelRatio(): number {
-  return typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
-}
-
-function getWorldViewportRect(cam: CameraState, canvas: HTMLCanvasElement): WorldRect {
-  const dpr = getDevicePixelRatio();
-  const width = canvas.width / (dpr * cam.zoom);
-  const height = canvas.height / (dpr * cam.zoom);
-  return {
-    x: cam.x - width / 2,
-    y: cam.y - height / 2,
-    width,
-    height,
-  };
-}
-
-function computeAxialBounds(rect: WorldRect, hexSize: number): AxialBounds {
-  const corners = [
-    pixelToAxialUnrounded(rect.x, rect.y, hexSize),
-    pixelToAxialUnrounded(rect.x + rect.width, rect.y, hexSize),
-    pixelToAxialUnrounded(rect.x, rect.y + rect.height, hexSize),
-    pixelToAxialUnrounded(rect.x + rect.width, rect.y + rect.height, hexSize),
-  ];
-
-  let qMin = Infinity;
-  let qMax = -Infinity;
-  let rMin = Infinity;
-  let rMax = -Infinity;
-
-  for (const corner of corners) {
-    qMin = Math.min(qMin, corner.q);
-    qMax = Math.max(qMax, corner.q);
-    rMin = Math.min(rMin, corner.r);
-    rMax = Math.max(rMax, corner.r);
-  }
-
-  return {
-    qMin: Math.floor(qMin) - VIEWPORT_MARGIN,
-    qMax: Math.ceil(qMax) + VIEWPORT_MARGIN,
-    rMin: Math.floor(rMin) - VIEWPORT_MARGIN,
-    rMax: Math.ceil(rMax) + VIEWPORT_MARGIN,
-  };
-}
-
-function clampBoundsToMap(bounds: AxialBounds, map: HexMap): AxialBounds | null {
-  const qMin = Math.max(bounds.qMin, map.minQ);
-  const qMax = Math.min(bounds.qMax, map.maxQ);
-  const rMin = Math.max(bounds.rMin, map.minR);
-  const rMax = Math.min(bounds.rMax, map.maxR);
-  if (qMin > qMax || rMin > rMax) {
-    return null;
-  }
-  return { qMin, qMax, rMin, rMax };
-}
-
-function resolveVisibleBounds(
-  ctx: CanvasRenderingContext2D,
-  map: HexMap,
-  hexSize: number
-): AxialBounds | null {
-  const canvasElement = (ctx.canvas ?? null) as HTMLCanvasElement | null;
-  if (!canvasElement || typeof canvasElement.width !== 'number' || typeof canvasElement.height !== 'number') {
-    return {
-      qMin: map.minQ,
-      qMax: map.maxQ,
-      rMin: map.minR,
-      rMax: map.maxR,
-    };
-  }
-  if (canvasElement.width === 0 || canvasElement.height === 0) {
-    return {
-      qMin: map.minQ,
-      qMax: map.maxQ,
-      rMin: map.minR,
-      rMax: map.maxR,
-    };
-  }
-
-  return clampBoundsToMap(
-    computeAxialBounds(getWorldViewportRect(camera, canvasElement), hexSize),
-    map
-  );
-}
 
 function getHighlightTokens(): { stroke: string; glow: string } {
   if (highlightStroke && highlightGlow) {
@@ -159,40 +37,14 @@ function getHighlightTokens(): { stroke: string; glow: string } {
   return { stroke: highlightStroke, glow: highlightGlow };
 }
 
-function toRgb(color: string): [number, number, number] {
-  const hex = color.replace('#', '');
-  const value = Number.parseInt(hex, 16);
-  const r = (value >> 16) & 0xff;
-  const g = (value >> 8) & 0xff;
-  const b = value & 0xff;
-  return [r, g, b];
-}
-
-function mixColor(
-  [r, g, b]: [number, number, number],
-  [tr, tg, tb]: [number, number, number],
-  amount: number
-): string {
-  const clamped = Math.min(1, Math.max(0, amount));
-  const mix = (channel: number, target: number) => Math.round(channel + (target - channel) * clamped);
-  return `rgb(${mix(r, tr)}, ${mix(g, tg)}, ${mix(b, tb)})`;
-}
-
-function withAlpha([r, g, b]: [number, number, number], alpha: number): string {
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
 export class HexMapRenderer {
-  private cachedCanvasElement?: HTMLCanvasElement;
-  private cachedCanvasOffset: PixelCoord = { x: 0, y: 0 };
-  private cachedHexSize: number | null = null;
-  private cachedPixelBounds: WorldRect | null = null;
-  private readonly chunkCanvases = new Map<ChunkKey, ChunkCanvas>();
-  private readonly dirtyChunks = new Set<ChunkKey>();
-  private readonly tileRenderState = new Map<string, string>();
-  private cachedImages?: Record<string, HTMLImageElement>;
+  private readonly terrainCache: TerrainCache;
+  private cachedHexSize: number;
 
-  constructor(private readonly mapRef: HexMap) {}
+  constructor(private readonly mapRef: HexMap) {
+    this.terrainCache = new TerrainCache(mapRef);
+    this.cachedHexSize = mapRef.hexSize;
+  }
 
   get hexSize(): number {
     return this.mapRef.hexSize;
@@ -202,100 +54,42 @@ export class HexMapRenderer {
     return axialToPixel({ q: this.mapRef.minQ, r: this.mapRef.minR }, this.hexSize);
   }
 
-  get cachedCanvas(): HTMLCanvasElement | undefined {
-    this.ensureChunkCache();
-    return this.cachedCanvasElement;
-  }
-
-  get cachedOffset(): PixelCoord {
-    return this.cachedCanvasOffset;
-  }
-
-  buildCache(images: LoadedAssets['images']): void {
-    if (typeof document === 'undefined') {
-      return;
-    }
-
-    const pixelBounds = this.computePixelBoundsFromMap();
-    if (!pixelBounds) {
-      this.cachedCanvasElement = undefined;
-      this.cachedCanvasOffset = { x: 0, y: 0 };
-      this.cachedPixelBounds = null;
-      return;
-    }
-
-    const cacheWidth = pixelBounds.width;
-    const cacheHeight = pixelBounds.height;
-    const canvas = document.createElement('canvas');
-    canvas.width = cacheWidth;
-    canvas.height = cacheHeight;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) {
-      throw new Error('Canvas 2D context not available for cache rendering');
-    }
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    ctx.clearRect(0, 0, cacheWidth, cacheHeight);
-
-    this.cachedCanvasElement = canvas;
-    this.cachedCanvasOffset = { x: pixelBounds.x, y: pixelBounds.y };
-    this.cachedHexSize = this.hexSize;
-    this.cachedPixelBounds = pixelBounds;
-    this.cachedImages = images;
-    this.chunkCanvases.clear();
-    this.dirtyChunks.clear();
-    this.tileRenderState.clear();
-    this.ensureChunkCache(images);
-  }
-
   invalidateCache(): void {
-    this.cachedCanvasElement = undefined;
-    this.cachedCanvasOffset = { x: 0, y: 0 };
-    this.cachedHexSize = null;
-    this.cachedPixelBounds = null;
-    this.chunkCanvases.clear();
-    this.dirtyChunks.clear();
-    this.tileRenderState.clear();
-    this.cachedImages = undefined;
+    this.terrainCache.invalidate();
+  }
+
+  dispose(): void {
+    this.terrainCache.dispose();
   }
 
   draw(
     ctx: CanvasRenderingContext2D,
-    images: Record<string, HTMLImageElement>,
+    images: LoadedAssets['images'],
     selected?: AxialCoord
   ): void {
-    if (this.cachedCanvasElement && this.cachedHexSize !== this.hexSize) {
-      this.invalidateCache();
-    }
-    this.cachedImages = images;
-    if (this.cachedCanvasElement) {
-      this.ensureChunkCache(images);
-    }
-    const origin = this.getOrigin();
-    const bounds = resolveVisibleBounds(ctx, this.mapRef, this.hexSize);
-
-    if (!this.cachedCanvasElement) {
-      this.drawVisibleTiles(ctx, images, origin, bounds, selected);
+    this.ensureHexSize();
+    const canvasElement = (ctx.canvas ?? null) as HTMLCanvasElement | null;
+    const bounds = computeVisibleBounds(this.mapRef, camera, canvasElement, this.hexSize);
+    if (!bounds) {
       return;
     }
 
-    const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
-    const halfHexWidth = hexWidth / 2;
-    const halfHexHeight = hexHeight / 2;
+    const chunkRange = chunkRangeFromBounds(bounds);
+    ensureChunksPopulated(this.mapRef, chunkRange);
 
-    if (bounds) {
-      this.drawFogLayer(ctx, origin, bounds);
-    }
+    const origin = this.getOrigin();
+    const chunks = this.terrainCache.getRenderableChunks(chunkRange, this.hexSize, images, origin);
+    this.drawChunks(ctx, chunks);
+    this.drawFogLayer(ctx, origin, bounds);
+
     if (selected) {
-      const { x, y } = axialToPixel(selected, this.hexSize);
-      const drawX = x - origin.x - halfHexWidth;
-      const drawY = y - origin.y - halfHexHeight;
-      this.strokeHex(ctx, drawX + hexWidth / 2, drawY + hexHeight / 2, this.hexSize, true);
+      this.drawSelection(ctx, origin, selected);
     }
   }
 
   drawToCanvas(
     canvas: HTMLCanvasElement,
-    images: Record<string, HTMLImageElement>,
+    images: LoadedAssets['images'],
     selected?: AxialCoord
   ): void {
     const ctx = canvas.getContext('2d');
@@ -305,117 +99,29 @@ export class HexMapRenderer {
     this.draw(ctx, images, selected);
   }
 
-  private drawVisibleTiles(
-    ctx: CanvasRenderingContext2D,
-    images: Record<string, HTMLImageElement>,
-    origin: PixelCoord,
-    bounds: AxialBounds | null,
-    selected?: AxialCoord
-  ): void {
-    if (!bounds) {
-      return;
-    }
-
-    const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
-    const halfHexWidth = hexWidth / 2;
-    const halfHexHeight = hexHeight / 2;
-    for (let r = bounds.rMin; r <= bounds.rMax; r++) {
-      for (let q = bounds.qMin; q <= bounds.qMax; q++) {
-        const tile = this.mapRef.getTile(q, r);
-        if (!tile) {
-          continue;
-        }
-
-        const { x, y } = axialToPixel({ q, r }, this.hexSize);
-        const drawX = x - origin.x - halfHexWidth;
-        const drawY = y - origin.y - halfHexHeight;
-        ctx.save();
-        if (tile.isFogged) {
-          ctx.globalAlpha = 0.4;
-        }
-        this.drawTerrainAndBuilding(ctx, tile, images, drawX, drawY, hexWidth, hexHeight);
-        const isSelected = selected && q === selected.q && r === selected.r;
-        this.strokeHex(
-          ctx,
-          drawX + hexWidth / 2,
-          drawY + hexHeight / 2,
-          this.hexSize,
-          Boolean(isSelected)
-        );
-        ctx.restore();
-      }
+  private ensureHexSize(): void {
+    if (this.cachedHexSize !== this.hexSize) {
+      this.cachedHexSize = this.hexSize;
+      this.terrainCache.invalidate();
     }
   }
 
-  private drawTerrainAndBuilding(
-    ctx: CanvasRenderingContext2D,
-    tile: { terrain: TerrainId; building: string | null },
-    images: Record<string, HTMLImageElement>,
-    x: number,
-    y: number,
-    width: number,
-    height: number
-  ): void {
-    const palette = TERRAIN[tile.terrain] ?? TERRAIN[TerrainId.Plains];
-    const rgb = toRgb(palette.baseColor);
-    const radius = this.hexSize;
-    const centerX = x + width / 2;
-    const centerY = y + height / 2;
-
-    ctx.save();
-    this.hexPath(ctx, centerX, centerY, radius);
-    ctx.clip();
-
-    const gradient = ctx.createRadialGradient(centerX, centerY, radius * 0.2, centerX, centerY, radius * 1.05);
-    gradient.addColorStop(0, mixColor(rgb, [255, 255, 255], 0.3));
-    gradient.addColorStop(0.7, palette.baseColor);
-    gradient.addColorStop(1, mixColor(rgb, [12, 18, 28], 0.4));
-
-    ctx.fillStyle = gradient;
-    ctx.shadowColor = withAlpha(rgb, 0.35);
-    ctx.shadowBlur = radius * 0.9;
-    ctx.shadowOffsetX = 0;
-    ctx.shadowOffsetY = 0;
-    ctx.fillRect(x - radius * 0.1, y - radius * 0.1, width + radius * 0.2, height + radius * 0.2);
-
-    const patternOptions: HexPatternOptions = {
-      ctx,
-      x,
-      y,
-      width,
-      height,
-      radius,
-      centerX,
-      centerY,
-      baseColor: palette.baseColor,
-    };
-    const drawPattern = TERRAIN_PATTERNS[tile.terrain] ?? drawPlains;
-    drawPattern(patternOptions);
-
-    ctx.globalCompositeOperation = 'lighter';
-    const rim = ctx.createRadialGradient(centerX, centerY, radius * 0.85, centerX, centerY, radius * 1.18);
-    rim.addColorStop(0, 'rgba(255, 255, 255, 0)');
-    rim.addColorStop(1, withAlpha(rgb, 0.18));
-    ctx.fillStyle = rim;
-    ctx.fillRect(x - radius * 0.1, y - radius * 0.1, width + radius * 0.2, height + radius * 0.2);
-    ctx.globalCompositeOperation = 'source-over';
-    ctx.restore();
-
-    const icon = loadIcon(palette.icon);
-    if (icon) {
-      const iconSize = Math.min(width, height) * 0.62;
-      const iconX = centerX - iconSize / 2;
-      const iconY = centerY - iconSize / 2;
-      ctx.save();
-      ctx.globalAlpha *= 0.92;
-      ctx.drawImage(icon, iconX, iconY, iconSize, iconSize);
-      ctx.restore();
+  private drawChunks(ctx: CanvasRenderingContext2D, chunks: ChunkCanvas[]): void {
+    if (chunks.length === 0) {
+      return;
     }
 
-    if (tile.building) {
-      const building = images[`building-${tile.building}`] ?? images['placeholder'];
-      ctx.drawImage(building, x, y, width, height);
+    for (const chunk of chunks) {
+      ctx.drawImage(chunk.canvas, chunk.origin.x, chunk.origin.y);
     }
+  }
+
+  private drawSelection(ctx: CanvasRenderingContext2D, origin: PixelCoord, coord: AxialCoord): void {
+    const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
+    const { x, y } = axialToPixel(coord, this.hexSize);
+    const drawX = x - origin.x - hexWidth / 2;
+    const drawY = y - origin.y - hexHeight / 2;
+    this.strokeHex(ctx, drawX + hexWidth / 2, drawY + hexHeight / 2, this.hexSize, true);
   }
 
   private drawFogLayer(
@@ -502,214 +208,5 @@ export class HexMapRenderer {
       }
     }
     ctx.closePath();
-  }
-
-  private ensureChunkCache(images?: Record<string, HTMLImageElement>): void {
-    if (!this.cachedCanvasElement) {
-      return;
-    }
-    if (images) {
-      this.cachedImages = images;
-    }
-
-    const currentBounds = this.computePixelBoundsFromMap();
-    if (currentBounds && this.cachedPixelBounds) {
-      const cachedRight = this.cachedPixelBounds.x + this.cachedPixelBounds.width;
-      const cachedBottom = this.cachedPixelBounds.y + this.cachedPixelBounds.height;
-      const currentRight = currentBounds.x + currentBounds.width;
-      const currentBottom = currentBounds.y + currentBounds.height;
-      const exceedsBounds =
-        currentBounds.x < this.cachedPixelBounds.x ||
-        currentBounds.y < this.cachedPixelBounds.y ||
-        currentRight > cachedRight ||
-        currentBottom > cachedBottom;
-      if (exceedsBounds) {
-        const assets = images ?? this.cachedImages;
-        this.invalidateCache();
-        if (assets) {
-          this.buildCache(assets);
-        }
-        return;
-      }
-    }
-
-    this.refreshDirtyChunks();
-    if (this.dirtyChunks.size === 0) {
-      return;
-    }
-
-    const terrainCtx = this.cachedCanvasElement.getContext('2d');
-    if (!terrainCtx) {
-      throw new Error('Canvas 2D context not available for terrain cache');
-    }
-
-    terrainCtx.save();
-    terrainCtx.setTransform(1, 0, 0, 1, 0, 0);
-
-    const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
-    const assets = this.cachedImages!;
-    for (const key of this.dirtyChunks) {
-      const previous = this.chunkCanvases.get(key);
-      const chunk = this.renderChunk(key, hexWidth, hexHeight, assets);
-      if (!chunk) {
-        if (previous) {
-          const clearX = previous.origin.x - this.cachedCanvasOffset.x;
-          const clearY = previous.origin.y - this.cachedCanvasOffset.y;
-          terrainCtx.clearRect(clearX, clearY, previous.canvas.width, previous.canvas.height);
-          this.chunkCanvases.delete(key);
-        }
-        continue;
-      }
-
-      this.chunkCanvases.set(key, chunk);
-      const drawX = chunk.origin.x - this.cachedCanvasOffset.x;
-      const drawY = chunk.origin.y - this.cachedCanvasOffset.y;
-      terrainCtx.clearRect(drawX, drawY, chunk.canvas.width, chunk.canvas.height);
-      terrainCtx.drawImage(chunk.canvas, drawX, drawY);
-    }
-
-    terrainCtx.restore();
-    this.dirtyChunks.clear();
-  }
-
-  private refreshDirtyChunks(): void {
-    for (const [key, tile] of this.mapRef.tiles) {
-      const signature = tile.isFogged ? 'fogged' : `${tile.terrain}:${tile.building ?? ''}`;
-      const previousSignature = this.tileRenderState.get(key);
-      if (previousSignature !== signature) {
-        this.tileRenderState.set(key, signature);
-        const { q, r } = parseTileKey(key);
-        this.dirtyChunks.add(chunkKey(q, r));
-      }
-    }
-
-    for (const key of Array.from(this.tileRenderState.keys())) {
-      if (!this.mapRef.tiles.has(key)) {
-        this.tileRenderState.delete(key);
-        const { q, r } = parseTileKey(key);
-        this.dirtyChunks.add(chunkKey(q, r));
-      }
-    }
-  }
-
-  private renderChunk(
-    key: ChunkKey,
-    hexWidth: number,
-    hexHeight: number,
-    images: Record<string, HTMLImageElement>
-  ): ChunkCanvas | null {
-    const [chunkQ, chunkR] = key.split(',').map(Number);
-    const qStart = chunkQ * CHUNK;
-    const qEnd = qStart + CHUNK - 1;
-    const rStart = chunkR * CHUNK;
-    const rEnd = rStart + CHUNK - 1;
-    const origin = this.getOrigin();
-    const halfHexWidth = hexWidth / 2;
-    const halfHexHeight = hexHeight / 2;
-
-    let minX = Infinity;
-    let minY = Infinity;
-    let maxX = -Infinity;
-    let maxY = -Infinity;
-    const tiles: Array<{ tile: { terrain: TerrainId; building: string | null }; x: number; y: number }>
-      = [];
-
-    for (let q = qStart; q <= qEnd; q++) {
-      for (let r = rStart; r <= rEnd; r++) {
-        const tile = this.mapRef.getTile(q, r);
-        if (!tile || tile.isFogged) {
-          continue;
-        }
-
-        const { x, y } = axialToPixel({ q, r }, this.hexSize);
-        const drawX = x - origin.x - halfHexWidth;
-        const drawY = y - origin.y - halfHexHeight;
-        minX = Math.min(minX, drawX);
-        minY = Math.min(minY, drawY);
-        maxX = Math.max(maxX, drawX + hexWidth);
-        maxY = Math.max(maxY, drawY + hexHeight);
-        tiles.push({ tile, x: drawX, y: drawY });
-      }
-    }
-
-    if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
-      return null;
-    }
-
-    const width = Math.max(1, Math.ceil(maxX - minX));
-    const height = Math.max(1, Math.ceil(maxY - minY));
-
-    let canvas = this.chunkCanvases.get(key)?.canvas;
-    if (!canvas || canvas.width !== width || canvas.height !== height) {
-      canvas = document.createElement('canvas');
-      canvas.width = width;
-      canvas.height = height;
-    }
-
-    const ctx = canvas.getContext('2d');
-    if (!ctx) {
-      throw new Error('Canvas 2D context not available for chunk rendering');
-    }
-
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    ctx.clearRect(0, 0, width, height);
-
-    for (const { tile, x, y } of tiles) {
-      const drawX = x - minX;
-      const drawY = y - minY;
-      ctx.save();
-      this.drawTerrainAndBuilding(ctx, tile, images, drawX, drawY, hexWidth, hexHeight);
-      this.strokeHex(ctx, drawX + hexWidth / 2, drawY + hexHeight / 2, this.hexSize, false);
-      ctx.restore();
-    }
-
-    return {
-      canvas,
-      origin: { x: minX, y: minY },
-    };
-  }
-
-  private computePixelBoundsFromMap(): WorldRect | null {
-    const { minQ, maxQ, minR, maxR } = this.mapRef;
-    if (!Number.isFinite(minQ) || !Number.isFinite(maxQ) || !Number.isFinite(minR) || !Number.isFinite(maxR)) {
-      return null;
-    }
-
-    const { width: hexWidth, height: hexHeight } = getHexDimensions(this.hexSize);
-    const halfHexWidth = hexWidth / 2;
-    const halfHexHeight = hexHeight / 2;
-    const origin = this.getOrigin();
-
-    const corners: PixelCoord[] = [
-      axialToPixel({ q: minQ, r: minR }, this.hexSize),
-      axialToPixel({ q: minQ, r: maxR }, this.hexSize),
-      axialToPixel({ q: maxQ, r: minR }, this.hexSize),
-      axialToPixel({ q: maxQ, r: maxR }, this.hexSize),
-    ];
-
-    let minX = Infinity;
-    let minY = Infinity;
-    let maxX = -Infinity;
-    let maxY = -Infinity;
-
-    for (const { x, y } of corners) {
-      const drawX = x - origin.x - halfHexWidth;
-      const drawY = y - origin.y - halfHexHeight;
-      minX = Math.min(minX, drawX);
-      minY = Math.min(minY, drawY);
-      maxX = Math.max(maxX, drawX + hexWidth);
-      maxY = Math.max(maxY, drawY + hexHeight);
-    }
-
-    if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
-      return null;
-    }
-
-    return {
-      x: minX,
-      y: minY,
-      width: Math.max(1, Math.ceil(maxX - minX)),
-      height: Math.max(1, Math.ceil(maxY - minY)),
-    };
   }
 }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -51,15 +51,6 @@ export function draw(
   const origin = mapRenderer.getOrigin();
   ctx.translate(-(camera.x - origin.x), -(camera.y - origin.y));
 
-  if (!mapRenderer.cachedCanvas) {
-    mapRenderer.buildCache(assets);
-  }
-  const cachedTerrain = mapRenderer.cachedCanvas;
-  if (cachedTerrain) {
-    const offset = mapRenderer.cachedOffset;
-    ctx.drawImage(cachedTerrain, -origin.x + offset.x, -origin.y + offset.y);
-  }
-
   mapRenderer.draw(ctx, assets, selected ?? undefined);
   const saunojaLayer = options?.saunojas;
   if (saunojaLayer && Array.isArray(saunojaLayer.units) && saunojaLayer.units.length > 0) {

--- a/src/render/terrain_cache.test.ts
+++ b/src/render/terrain_cache.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HexMap } from '../hexmap.ts';
+import { TerrainCache } from './terrain_cache.ts';
+import { ensureChunksPopulated } from '../map/hex/chunking.ts';
+import { axialToPixel } from '../hex/HexUtils.ts';
+
+function createStubContext(drawImage: ReturnType<typeof vi.fn>) {
+  const gradient = { addColorStop: vi.fn() };
+  return {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    createRadialGradient: vi.fn(() => gradient),
+    fillRect: vi.fn(),
+    drawImage,
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    clip: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    globalAlpha: 1,
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    lineJoin: 'round' as CanvasLineJoin,
+    lineCap: 'round' as CanvasLineCap,
+    shadowColor: '',
+    shadowBlur: 0,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0,
+    globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('TerrainCache', () => {
+  it('re-renders chunks when tiles mutate', () => {
+    const map = new HexMap(2, 2);
+    const tile = map.ensureTile(0, 0);
+    tile.reveal();
+    tile.placeBuilding('farm');
+
+    const offscreenDrawImage = vi.fn();
+    const offscreenCtx = createStubContext(offscreenDrawImage);
+
+    const originalCreateElement = document.createElement;
+    const offscreenCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => offscreenCtx),
+    } as unknown as HTMLCanvasElement;
+    const createElementSpy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation((tagName: string) => {
+        if (tagName === 'canvas') {
+          offscreenCanvas.width = 0;
+          offscreenCanvas.height = 0;
+          return offscreenCanvas;
+        }
+        return originalCreateElement.call(document, tagName);
+      });
+
+    try {
+      const cache = new TerrainCache(map);
+      const range = { qMin: 0, qMax: 0, rMin: 0, rMax: 0 };
+      ensureChunksPopulated(map, range);
+      const origin = axialToPixel({ q: map.minQ, r: map.minR }, map.hexSize);
+      const images = {
+        'building-farm': originalCreateElement.call(document, 'img') as HTMLImageElement,
+        'building-barracks': originalCreateElement.call(document, 'img') as HTMLImageElement,
+        placeholder: originalCreateElement.call(document, 'img') as HTMLImageElement,
+      };
+
+      cache.getRenderableChunks(range, map.hexSize, images, origin);
+      const initialCalls = offscreenDrawImage.mock.calls.length;
+      expect(initialCalls).toBeGreaterThan(0);
+
+      offscreenDrawImage.mockClear();
+      tile.placeBuilding('barracks');
+      cache.getRenderableChunks(range, map.hexSize, images, origin);
+      expect(offscreenDrawImage).toHaveBeenCalled();
+    } finally {
+      createElementSpy.mockRestore();
+    }
+  });
+});

--- a/src/render/terrain_cache.ts
+++ b/src/render/terrain_cache.ts
@@ -1,0 +1,351 @@
+import { axialToPixel } from '../hex/HexUtils.ts';
+import { getHexDimensions } from '../hex/HexDimensions.ts';
+import type { HexMap } from '../hexmap.ts';
+import type { LoadedAssets } from '../loader.ts';
+import { TerrainId } from '../map/terrain.ts';
+import type { PixelCoord } from '../hex/HexUtils.ts';
+import { TERRAIN } from './TerrainPalette.ts';
+import type { HexPatternOptions } from '../map/hexPatterns.ts';
+import { drawForest, drawHills, drawPlains, drawWater } from '../map/hexPatterns.ts';
+import {
+  chunkKeyFromAxial,
+  chunkKeyFromCoord,
+  type ChunkRange,
+  enumerateChunks,
+  HEX_CHUNK_SIZE,
+} from '../map/hex/chunking.ts';
+import type { ChunkKey, ChunkCoord } from '../map/hex/chunking.ts';
+import type { TileChangeType } from '../hexmap.ts';
+import { loadIcon } from './loadIcon.ts';
+
+const TERRAIN_PATTERNS: Record<TerrainId, (options: HexPatternOptions) => void> = {
+  [TerrainId.Plains]: drawPlains,
+  [TerrainId.Forest]: drawForest,
+  [TerrainId.Hills]: drawHills,
+  [TerrainId.Lake]: drawWater,
+};
+
+interface ChunkCanvas {
+  key: ChunkKey;
+  canvas: HTMLCanvasElement;
+  origin: PixelCoord;
+  width: number;
+  height: number;
+}
+
+function toRgb(color: string): [number, number, number] {
+  const hex = color.replace('#', '');
+  const value = Number.parseInt(hex, 16);
+  const r = (value >> 16) & 0xff;
+  const g = (value >> 8) & 0xff;
+  const b = value & 0xff;
+  return [r, g, b];
+}
+
+function mixColor(
+  [r, g, b]: [number, number, number],
+  [tr, tg, tb]: [number, number, number],
+  amount: number
+): string {
+  const clamped = Math.min(1, Math.max(0, amount));
+  const mix = (channel: number, target: number) => Math.round(channel + (target - channel) * clamped);
+  return `rgb(${mix(r, tr)}, ${mix(g, tg)}, ${mix(b, tb)})`;
+}
+
+function withAlpha([r, g, b]: [number, number, number], alpha: number): string {
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function hexPath(ctx: CanvasRenderingContext2D, x: number, y: number, size: number): void {
+  ctx.beginPath();
+  for (let i = 0; i < 6; i++) {
+    const angle = (Math.PI / 180) * (60 * i - 30);
+    const px = x + size * Math.cos(angle);
+    const py = y + size * Math.sin(angle);
+    if (i === 0) {
+      ctx.moveTo(px, py);
+    } else {
+      ctx.lineTo(px, py);
+    }
+  }
+  ctx.closePath();
+}
+
+function strokeHex(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number
+): void {
+  hexPath(ctx, x, y, size);
+  ctx.save();
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+  ctx.lineWidth = Math.max(1, size * 0.05);
+  ctx.strokeStyle = 'rgba(12, 18, 28, 0.55)';
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawTerrainAndBuilding(
+  ctx: CanvasRenderingContext2D,
+  tile: { terrain: TerrainId; building: string | null },
+  images: Record<string, HTMLImageElement>,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+): void {
+  const palette = TERRAIN[tile.terrain] ?? TERRAIN[TerrainId.Plains];
+  const rgb = toRgb(palette.baseColor);
+  const centerX = x + width / 2;
+  const centerY = y + height / 2;
+
+  ctx.save();
+  hexPath(ctx, centerX, centerY, radius);
+  ctx.clip();
+
+  const gradient = ctx.createRadialGradient(centerX, centerY, radius * 0.2, centerX, centerY, radius * 1.05);
+  gradient.addColorStop(0, mixColor(rgb, [255, 255, 255], 0.3));
+  gradient.addColorStop(0.7, palette.baseColor);
+  gradient.addColorStop(1, mixColor(rgb, [12, 18, 28], 0.4));
+
+  ctx.fillStyle = gradient;
+  ctx.shadowColor = withAlpha(rgb, 0.35);
+  ctx.shadowBlur = radius * 0.9;
+  ctx.shadowOffsetX = 0;
+  ctx.shadowOffsetY = 0;
+  ctx.fillRect(x - radius * 0.1, y - radius * 0.1, width + radius * 0.2, height + radius * 0.2);
+
+  const patternOptions: HexPatternOptions = {
+    ctx,
+    x,
+    y,
+    width,
+    height,
+    radius,
+    centerX,
+    centerY,
+    baseColor: palette.baseColor,
+  };
+  const drawPattern = TERRAIN_PATTERNS[tile.terrain] ?? drawPlains;
+  drawPattern(patternOptions);
+
+  ctx.globalCompositeOperation = 'lighter';
+  const rim = ctx.createRadialGradient(centerX, centerY, radius * 0.85, centerX, centerY, radius * 1.18);
+  rim.addColorStop(0, 'rgba(255, 255, 255, 0)');
+  rim.addColorStop(1, withAlpha(rgb, 0.18));
+  ctx.fillStyle = rim;
+  ctx.fillRect(x - radius * 0.1, y - radius * 0.1, width + radius * 0.2, height + radius * 0.2);
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.restore();
+
+  const icon = loadIcon(palette.icon);
+  if (icon) {
+    const iconSize = Math.min(width, height) * 0.62;
+    const iconX = centerX - iconSize / 2;
+    const iconY = centerY - iconSize / 2;
+    ctx.save();
+    ctx.globalAlpha *= 0.92;
+    ctx.drawImage(icon, iconX, iconY, iconSize, iconSize);
+    ctx.restore();
+  }
+
+  if (tile.building) {
+    const building = images[`building-${tile.building}`] ?? images['placeholder'];
+    ctx.drawImage(building, x, y, width, height);
+  }
+}
+
+function chunkBounds(chunk: ChunkCoord, map: HexMap): { qStart: number; qEnd: number; rStart: number; rEnd: number } {
+  const qStart = Math.max(chunk.q * HEX_CHUNK_SIZE, map.minQ);
+  const qEnd = Math.min(qStart + HEX_CHUNK_SIZE - 1, map.maxQ);
+  const rStart = Math.max(chunk.r * HEX_CHUNK_SIZE, map.minR);
+  const rEnd = Math.min(rStart + HEX_CHUNK_SIZE - 1, map.maxR);
+  return { qStart, qEnd, rStart, rEnd };
+}
+
+export class TerrainCache {
+  private readonly chunkCanvases = new Map<ChunkKey, ChunkCanvas>();
+  private readonly dirtyChunks = new Set<ChunkKey>();
+  private cachedImages?: Record<string, HTMLImageElement>;
+  private readonly unsubscribe: () => void;
+
+  constructor(private readonly map: HexMap) {
+    this.unsubscribe = map.addTileChangeListener((coord, _tile, change) => {
+      this.onTileChange(coord, change);
+    });
+  }
+
+  dispose(): void {
+    this.unsubscribe();
+    this.chunkCanvases.clear();
+    this.dirtyChunks.clear();
+    this.cachedImages = undefined;
+  }
+
+  invalidate(): void {
+    this.chunkCanvases.clear();
+    this.dirtyChunks.clear();
+    this.cachedImages = undefined;
+  }
+
+  markChunkDirty(key: ChunkKey): void {
+    this.dirtyChunks.add(key);
+  }
+
+  markTileDirty(q: number, r: number): void {
+    this.dirtyChunks.add(chunkKeyFromAxial(q, r));
+  }
+
+  getRenderableChunks(
+    range: ChunkRange,
+    hexSize: number,
+    images: LoadedAssets['images'],
+    origin: PixelCoord
+  ): ChunkCanvas[] {
+    this.refreshAssets(images);
+    const renderable: ChunkCanvas[] = [];
+    const { width: hexWidth, height: hexHeight } = getHexDimensions(hexSize);
+
+    for (const chunkCoord of enumerateChunks(range)) {
+      const key = chunkKeyFromCoord(chunkCoord);
+      const chunkCanvas = this.ensureChunk(key, chunkCoord, hexSize, hexWidth, hexHeight, images, origin);
+      if (chunkCanvas) {
+        renderable.push(chunkCanvas);
+      }
+    }
+
+    return renderable;
+  }
+
+  private refreshAssets(images: LoadedAssets['images']): void {
+    if (this.cachedImages === images) {
+      return;
+    }
+
+    this.cachedImages = images;
+    for (const key of this.chunkCanvases.keys()) {
+      this.dirtyChunks.add(key);
+    }
+  }
+
+  private onTileChange(coord: { q: number; r: number }, change: TileChangeType): void {
+    if (change === 'created' || change === 'terrain' || change === 'building' || change === 'fog') {
+      this.markTileDirty(coord.q, coord.r);
+    }
+  }
+
+  private ensureChunk(
+    key: ChunkKey,
+    chunkCoord: ChunkCoord,
+    hexSize: number,
+    hexWidth: number,
+    hexHeight: number,
+    images: LoadedAssets['images'],
+    origin: PixelCoord
+  ): ChunkCanvas | null {
+    const existing = this.chunkCanvases.get(key);
+    if (!existing || this.dirtyChunks.has(key)) {
+      const updated = this.renderChunk(key, chunkCoord, hexSize, hexWidth, hexHeight, images, origin, existing);
+      this.dirtyChunks.delete(key);
+      if (!updated) {
+        this.chunkCanvases.delete(key);
+        return null;
+      }
+      this.chunkCanvases.set(key, updated);
+      return updated;
+    }
+
+    return existing;
+  }
+
+  private renderChunk(
+    key: ChunkKey,
+    chunkCoord: ChunkCoord,
+    hexSize: number,
+    hexWidth: number,
+    hexHeight: number,
+    images: LoadedAssets['images'],
+    origin: PixelCoord,
+    existing?: ChunkCanvas
+  ): ChunkCanvas | null {
+    if (typeof document === 'undefined') {
+      return null;
+    }
+
+    const { qStart, qEnd, rStart, rEnd } = chunkBounds(chunkCoord, this.map);
+    if (qStart > qEnd || rStart > rEnd) {
+      return null;
+    }
+
+    const halfHexWidth = hexWidth / 2;
+    const halfHexHeight = hexHeight / 2;
+
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    const tiles: Array<{ tile: { terrain: TerrainId; building: string | null }; x: number; y: number }> = [];
+
+    for (let q = qStart; q <= qEnd; q++) {
+      for (let r = rStart; r <= rEnd; r++) {
+        const tile = this.map.getTile(q, r);
+        if (!tile || tile.isFogged) {
+          continue;
+        }
+
+        const { x, y } = axialToPixel({ q, r }, hexSize);
+        const drawX = x - origin.x - halfHexWidth;
+        const drawY = y - origin.y - halfHexHeight;
+        minX = Math.min(minX, drawX);
+        minY = Math.min(minY, drawY);
+        maxX = Math.max(maxX, drawX + hexWidth);
+        maxY = Math.max(maxY, drawY + hexHeight);
+        tiles.push({ tile, x: drawX, y: drawY });
+      }
+    }
+
+    if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+      return null;
+    }
+
+    const width = Math.max(1, Math.ceil(maxX - minX));
+    const height = Math.max(1, Math.ceil(maxY - minY));
+
+    let canvas = existing?.canvas;
+    if (!canvas || canvas.width !== width || canvas.height !== height) {
+      canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+    }
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas 2D context not available for chunk rendering');
+    }
+
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+
+    for (const { tile, x, y } of tiles) {
+      const drawX = x - minX;
+      const drawY = y - minY;
+      ctx.save();
+      drawTerrainAndBuilding(ctx, tile, images, drawX, drawY, hexWidth, hexHeight, hexSize);
+      strokeHex(ctx, drawX + hexWidth / 2, drawY + hexHeight / 2, hexSize);
+      ctx.restore();
+    }
+
+    return {
+      key,
+      canvas,
+      origin: { x: minX, y: minY },
+      width,
+      height,
+    };
+  }
+}
+
+export type { ChunkCanvas };


### PR DESCRIPTION
## Summary
- compute visible hex chunk bounds and lazy tile population through a new chunking helper
- add an event-driven terrain cache that reuses offscreen chunk canvases for terrain, buildings, and fog
- refactor the hex map renderer, tile model, and tests to consume the cache and exercise chunk invalidation

## Testing
- npm run build
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cc34664da88330b33caf2222a65b20