### PR TITLE
Stop the game loop after cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Halt the main animation loop during teardown by tracking the active frame ID,
+  cancelling it in `cleanup()`, guarding the callback against post-shutdown
+  ticks, and covering the lifecycle with a Vitest regression so repeated
+  restarts stay polished and leak-free
 - Centralize terrain palette tokens into `src/render/palette.ts`, introduce
   zoom-aware outline helpers, render fog-of-war through cached Perlin masks
   with multi-stop gradients, and refresh the README feature callouts to


### PR DESCRIPTION
## Summary
- track the active animation frame in the game loop and guard the callback once teardown begins
- cancel the pending frame during cleanup so repeated startups do not spawn duplicate loops
- cover the lifecycle with a vitest regression and document the fix in the changelog

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc53e23888833094b883ed0b509f96