### PR TITLE
Add sauna ambience loop and HUD controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Layer a Web Audio sauna-and-forest ambience loop with seamless crossfades,
+  surface a top-bar ambience toggle and volume slider that persist
+  `audio_enabled`, sync with the master mute, honor reduced-motion
+  preferences, and document the new controls
 - Introduce an `src/audio` suite with registry-driven SFX playback, hook combat
   hits, kills, and SISU bursts into the event bus so polished cues fire while
   honoring the shared mute toggle, and document the procedurally generated WAV

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ with cinematic UI flourishes.
 - **Glass HUD overlays** (resource bar, build badge, and right-panel cards)
   are layered over the canvas with high-end gradients, blur, and accessible
   aria labels.
+- **Immersive ambience** crossfades a sauna-and-forest soundscape through Web
+  Audio, with top-bar controls that remember volume, honor the mute toggle, and
+  respect reduced-motion preferences.
 - **Hand-painted tactical sprites** render terrain, structures, and units with
   crisp vector art that scales cleanly across every zoom level.
 - **Perlin-sculpted fog-of-war** renders with cached noise masks and multi-stop
@@ -42,9 +45,12 @@ with cinematic UI flourishes.
    and the timer badge keeps the current session readable.
 3. **Trigger SISU** to launch a temporary combat surge and watch the countdown
    indicator pulse while the ability is active.
-4. **Adjust sauna tactics** from the sauna card: expand the card from the top
+4. **Dial the ambience** from the top-bar controls—toggle the sauna forest loop
+   or adjust the volume slider, and the preference will persist across future
+   sessions.
+5. **Adjust sauna tactics** from the sauna card: expand the card from the top
    bar to toggle the rally option and monitor spawn progress.
-5. **Review events and policies** from the right panel. Apply policies when you
+6. **Review events and policies** from the right panel. Apply policies when you
    have the gold, acknowledge events to clear the queue, and scan the log for a
    curated history of recent actions.
 

--- a/src/audio/ambience.ts
+++ b/src/audio/ambience.ts
@@ -1,0 +1,354 @@
+import { initAudioSafe, isMuted, onMuteChange } from './sfx.ts';
+
+type AmbienceLayer = {
+  source: AudioBufferSourceNode;
+  gain: GainNode;
+  stopTime: number;
+};
+
+export type AmbienceState = {
+  enabled: boolean;
+  playing: boolean;
+  volume: number;
+  globallyMuted: boolean;
+};
+
+const AMBIENCE_SOURCES = ['/assets/sounds/sauna-forest.ogg', '/assets/sounds/sauna-forest.mp3'];
+const ENABLED_KEY = 'audio_enabled';
+const VOLUME_KEY = 'audio_volume';
+
+const listeners = new Set<(state: AmbienceState) => void>();
+const layers = new Set<AmbienceLayer>();
+
+let buffer: AudioBuffer | null = null;
+let bufferPromise: Promise<AudioBuffer> | null = null;
+let masterGain: GainNode | null = null;
+let nextStartTimer: ReturnType<typeof setTimeout> | null = null;
+
+const storedEnabled = typeof localStorage !== 'undefined' ? localStorage.getItem(ENABLED_KEY) : null;
+let enabled = storedEnabled === 'true';
+let hasExplicitPreference = storedEnabled !== null;
+
+const storedVolume = typeof localStorage !== 'undefined' ? localStorage.getItem(VOLUME_KEY) : null;
+let volume = clampNumber(storedVolume ? Number(storedVolume) : NaN, 0.65);
+
+let playing = false;
+let globallyMuted = isMuted();
+
+const reduceMotionQuery =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)')
+    : null;
+let prefersReducedMotion = reduceMotionQuery?.matches ?? false;
+
+if (reduceMotionQuery) {
+  const handleChange = (event: MediaQueryListEvent) => {
+    prefersReducedMotion = event.matches;
+  };
+  if (typeof reduceMotionQuery.addEventListener === 'function') {
+    reduceMotionQuery.addEventListener('change', handleChange);
+  } else if (typeof reduceMotionQuery.addListener === 'function') {
+    reduceMotionQuery.addListener(handleChange);
+  }
+}
+
+if (typeof window !== 'undefined' && !hasExplicitPreference) {
+  const grantDefaultAudio = () => {
+    if (hasExplicitPreference) {
+      return;
+    }
+    hasExplicitPreference = true;
+    setEnabled(true);
+    void play();
+  };
+  window.addEventListener('pointerdown', grantDefaultAudio, { once: true });
+  window.addEventListener('keydown', grantDefaultAudio, { once: true });
+}
+
+onMuteChange((muted) => {
+  globallyMuted = muted;
+  if (muted) {
+    stop();
+  } else if (enabled) {
+    void play();
+  } else {
+    updateMasterGainTarget(true);
+  }
+  notifyState();
+});
+
+function clampNumber(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+}
+
+function notifyState(): void {
+  const state = getState();
+  for (const listener of listeners) {
+    listener(state);
+  }
+}
+
+function saveEnabled(value: boolean): void {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(ENABLED_KEY, value ? 'true' : 'false');
+  } catch (error) {
+    console.warn('Unable to persist ambience preference', error);
+  }
+}
+
+function saveVolume(value: number): void {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(VOLUME_KEY, value.toFixed(3));
+  } catch (error) {
+    console.warn('Unable to persist ambience volume', error);
+  }
+}
+
+function ensureMasterGain(ctx: AudioContext): GainNode {
+  if (masterGain) {
+    return masterGain;
+  }
+  const node = ctx.createGain();
+  node.gain.value = enabled && !globallyMuted ? volume : 0;
+  node.connect(ctx.destination);
+  masterGain = node;
+  return node;
+}
+
+function updateMasterGainTarget(immediate = false): void {
+  if (!masterGain) {
+    return;
+  }
+  const ctx = masterGain.context;
+  const target = enabled && !globallyMuted ? volume : 0;
+  const now = ctx.currentTime;
+  masterGain.gain.cancelScheduledValues(now);
+  if (immediate) {
+    masterGain.gain.setValueAtTime(target, now);
+  } else {
+    masterGain.gain.setTargetAtTime(target, now, 0.25);
+  }
+}
+
+function computeFadeDuration(): number {
+  return prefersReducedMotion ? 0.6 : 4.2;
+}
+
+function cancelNextStart(): void {
+  if (nextStartTimer !== null) {
+    clearTimeout(nextStartTimer);
+    nextStartTimer = null;
+  }
+}
+
+function cleanupLayer(layer: AmbienceLayer): void {
+  try {
+    layer.source.stop();
+  } catch (error) {
+    // ignore
+  }
+  layer.source.disconnect();
+  layer.gain.disconnect();
+  layers.delete(layer);
+}
+
+function teardownLayers(): void {
+  for (const layer of [...layers]) {
+    cleanupLayer(layer);
+  }
+}
+
+async function loadBuffer(ctx: AudioContext): Promise<AudioBuffer> {
+  if (buffer) {
+    return buffer;
+  }
+  if (!bufferPromise) {
+    bufferPromise = (async () => {
+      for (const url of AMBIENCE_SOURCES) {
+        try {
+          const response = await fetch(url);
+          if (!response.ok) {
+            continue;
+          }
+          const data = await response.arrayBuffer();
+          return await ctx.decodeAudioData(data);
+        } catch (error) {
+          console.warn('Failed to fetch ambience source', url, error);
+        }
+      }
+      throw new Error('No ambience sources available');
+    })()
+      .then((decoded) => {
+        buffer = decoded;
+        return decoded;
+      })
+      .catch((error) => {
+        bufferPromise = null;
+        throw error;
+      });
+  }
+  return bufferPromise;
+}
+
+function scheduleNext(startTime: number, ctx: AudioContext): void {
+  if (!playing) {
+    return;
+  }
+  cancelNextStart();
+  const delaySeconds = Math.max(0, startTime - ctx.currentTime - 0.05);
+  nextStartTimer = setTimeout(() => {
+    nextStartTimer = null;
+    if (!playing) {
+      return;
+    }
+    spawnLayer(startTime);
+  }, delaySeconds * 1000);
+}
+
+function spawnLayer(startTime: number): void {
+  const ctx = masterGain?.context ?? initAudioSafe();
+  if (!ctx || !buffer) {
+    return;
+  }
+  const gain = ctx.createGain();
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+  source.loop = false;
+  source.connect(gain);
+  gain.connect(ensureMasterGain(ctx));
+
+  const fade = Math.min(computeFadeDuration(), buffer.duration / 2);
+  const effectiveFade = Number.isFinite(fade) && fade > 0 ? fade : 0.25;
+  const startFade = Math.max(ctx.currentTime, startTime);
+  gain.gain.setValueAtTime(0, startFade);
+  gain.gain.linearRampToValueAtTime(1, startFade + effectiveFade);
+
+  const stopTime = startTime + buffer.duration;
+  const fadeOutStart = stopTime - effectiveFade;
+  if (fadeOutStart > startFade) {
+    gain.gain.setValueAtTime(1, fadeOutStart);
+    gain.gain.linearRampToValueAtTime(0.001, stopTime + 0.1);
+  } else {
+    gain.gain.linearRampToValueAtTime(0.001, stopTime + 0.1);
+  }
+
+  const layer: AmbienceLayer = { source, gain, stopTime };
+  layers.add(layer);
+  source.addEventListener('ended', () => {
+    cleanupLayer(layer);
+  });
+
+  try {
+    source.start(startTime);
+  } catch (error) {
+    console.warn('Failed to start ambience layer', error);
+    cleanupLayer(layer);
+    return;
+  }
+
+  scheduleNext(stopTime - effectiveFade, ctx);
+}
+
+export async function play(): Promise<void> {
+  if (playing || !enabled || globallyMuted) {
+    updateMasterGainTarget();
+    return;
+  }
+  const ctx = initAudioSafe();
+  if (!ctx) {
+    return;
+  }
+  ensureMasterGain(ctx);
+  updateMasterGainTarget();
+
+  try {
+    const decoded = await loadBuffer(ctx);
+    if (!enabled || globallyMuted) {
+      return;
+    }
+    await ctx.resume().catch(() => undefined);
+    playing = true;
+    const startTime = Math.max(ctx.currentTime + 0.12, ctx.currentTime);
+    spawnLayer(startTime);
+    notifyState();
+  } catch (error) {
+    console.warn('Unable to start ambience', error);
+  }
+}
+
+export function stop(): void {
+  if (!playing && layers.size === 0) {
+    updateMasterGainTarget(true);
+    return;
+  }
+  playing = false;
+  cancelNextStart();
+  teardownLayers();
+  updateMasterGainTarget(true);
+  notifyState();
+}
+
+export function setEnabled(value: boolean): void {
+  if (enabled === value && hasExplicitPreference) {
+    return;
+  }
+  enabled = value;
+  hasExplicitPreference = true;
+  saveEnabled(value);
+  if (!value) {
+    stop();
+  } else if (!globallyMuted) {
+    void play();
+  }
+  notifyState();
+}
+
+export function isEnabled(): boolean {
+  return enabled;
+}
+
+export function setVolume(value: number): void {
+  const clamped = Math.max(0, Math.min(1, value));
+  if (clamped === volume) {
+    return;
+  }
+  volume = clamped;
+  saveVolume(volume);
+  updateMasterGainTarget();
+  notifyState();
+}
+
+export function getVolume(): number {
+  return volume;
+}
+
+export function getState(): AmbienceState {
+  return { enabled, playing, volume, globallyMuted };
+}
+
+export function onStateChange(listener: (state: AmbienceState) => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Kick off playback if a preference was previously stored.
+if (enabled && !globallyMuted) {
+  void play();
+}

--- a/src/style.css
+++ b/src/style.css
@@ -288,6 +288,270 @@ body > #game-container {
   box-shadow: var(--shadow-glow);
 }
 
+.topbar-ambience {
+  pointer-events: auto;
+  display: grid;
+  gap: 12px;
+  min-width: clamp(220px, 24vw, 280px);
+  padding: 14px 18px;
+  border-radius: var(--radius-panel);
+  border: 1px solid color-mix(in srgb, var(--hud-border) 70%, rgba(59, 130, 246, 0.45));
+  background:
+    radial-gradient(circle at 0% 0%, rgba(94, 234, 212, 0.18), transparent 60%),
+    linear-gradient(150deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.54));
+  backdrop-filter: blur(16px) saturate(140%);
+  box-shadow: var(--shadow-soft);
+  color: var(--color-foreground);
+}
+
+.topbar-ambience.is-off {
+  border-color: color-mix(in srgb, var(--hud-border) 85%, rgba(148, 163, 184, 0.35));
+  background:
+    radial-gradient(circle at 0% 0%, rgba(148, 163, 184, 0.12), transparent 65%),
+    linear-gradient(150deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.5));
+}
+
+.topbar-ambience.is-globally-muted .topbar-ambience__status {
+  color: var(--color-warning);
+}
+
+.topbar-ambience__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.topbar-ambience__icon {
+  font-size: clamp(20px, 2.4vw, 24px);
+  filter: drop-shadow(0 0 14px rgba(94, 234, 212, 0.35));
+}
+
+.topbar-ambience.is-off .topbar-ambience__icon {
+  filter: drop-shadow(0 0 10px rgba(148, 163, 184, 0.28));
+  opacity: 0.85;
+}
+
+.topbar-ambience__title {
+  font-size: clamp(11px, 1vw, 12px);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.ambience-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 6px 16px 6px 60px;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--hud-border-strong) 65%, rgba(59, 130, 246, 0.45));
+  background:
+    linear-gradient(135deg, rgba(30, 41, 59, 0.6), rgba(15, 23, 42, 0.55));
+  color: var(--color-foreground);
+  font-size: clamp(11px, 1vw, 12px);
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    color var(--transition-snappy),
+    border-color var(--transition-snappy),
+    box-shadow var(--transition-snappy),
+    background var(--transition-snappy);
+}
+
+.ambience-toggle__track {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  width: 36px;
+  height: 18px;
+  transform: translateY(-50%);
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.38), rgba(30, 64, 175, 0.42));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+  transition: background var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.ambience-toggle__thumb {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  width: 22px;
+  height: 22px;
+  transform: translate(0, -50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(226, 232, 240, 0.98), rgba(148, 163, 184, 0.82));
+  box-shadow: 0 0 14px rgba(148, 163, 184, 0.45);
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.ambience-toggle__label {
+  position: relative;
+  z-index: 1;
+}
+
+.ambience-toggle.is-on {
+  border-color: color-mix(in srgb, rgba(94, 234, 212, 0.7) 70%, var(--hud-border));
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.32), rgba(59, 130, 246, 0.28));
+  box-shadow: 0 12px 30px rgba(94, 234, 212, 0.28);
+}
+
+.ambience-toggle.is-on .ambience-toggle__track {
+  background: linear-gradient(135deg, rgba(94, 234, 212, 0.85), rgba(56, 189, 248, 0.75));
+  box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.25);
+}
+
+.ambience-toggle.is-on .ambience-toggle__thumb {
+  transform: translate(18px, -50%);
+  box-shadow: 0 0 16px rgba(94, 234, 212, 0.65);
+}
+
+.ambience-toggle.is-muted {
+  color: color-mix(in srgb, var(--color-muted) 80%, var(--color-foreground) 20%);
+  border-color: color-mix(in srgb, var(--hud-border) 80%, rgba(148, 163, 184, 0.4));
+  box-shadow: none;
+}
+
+.ambience-toggle.is-muted .ambience-toggle__track {
+  background: linear-gradient(135deg, rgba(51, 65, 85, 0.6), rgba(30, 41, 59, 0.6));
+  box-shadow: inset 0 0 0 1px rgba(71, 85, 105, 0.65);
+}
+
+.ambience-toggle.is-muted .ambience-toggle__thumb {
+  box-shadow: 0 0 10px rgba(30, 41, 59, 0.6);
+}
+
+.ambience-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, rgba(94, 234, 212, 0.8) 70%, rgba(59, 130, 246, 0.7));
+  outline-offset: 3px;
+}
+
+.topbar-ambience__slider {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.topbar-ambience__caption {
+  font-size: clamp(11px, 1vw, 12px);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.topbar-ambience__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--color-foreground);
+  min-width: 48px;
+  text-align: right;
+}
+
+.topbar-ambience__range {
+  --value: 65;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background:
+    linear-gradient(90deg, rgba(94, 234, 212, 0.7) calc(var(--value) * 1%), rgba(30, 41, 59, 0.65) calc(var(--value) * 1%));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+  transition: background var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.topbar-ambience__range::-webkit-slider-runnable-track {
+  appearance: none;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: transparent;
+}
+
+.topbar-ambience__range::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(226, 232, 240, 0.98), rgba(148, 163, 184, 0.82));
+  border: 1px solid rgba(94, 234, 212, 0.6);
+  box-shadow: 0 0 12px rgba(94, 234, 212, 0.45);
+  cursor: pointer;
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy);
+  margin-top: -5px;
+}
+
+.topbar-ambience__range::-moz-range-track {
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: transparent;
+}
+
+.topbar-ambience__range::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(226, 232, 240, 0.98), rgba(148, 163, 184, 0.82));
+  border: 1px solid rgba(94, 234, 212, 0.6);
+  box-shadow: 0 0 12px rgba(94, 234, 212, 0.45);
+  cursor: pointer;
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.topbar-ambience__range:focus-visible {
+  outline: 2px solid color-mix(in srgb, rgba(94, 234, 212, 0.8) 70%, rgba(59, 130, 246, 0.7));
+  outline-offset: 3px;
+}
+
+.topbar-ambience__range:active::-webkit-slider-thumb,
+.topbar-ambience__range:active::-moz-range-thumb {
+  transform: scale(1.05);
+  box-shadow: 0 0 18px rgba(94, 234, 212, 0.6);
+}
+
+.topbar-ambience__range:disabled {
+  cursor: not-allowed;
+  box-shadow: inset 0 0 0 1px rgba(71, 85, 105, 0.4);
+  background:
+    linear-gradient(90deg, rgba(51, 65, 85, 0.75) calc(var(--value) * 1%), rgba(30, 41, 59, 0.5) calc(var(--value) * 1%));
+}
+
+.topbar-ambience__range:disabled::-webkit-slider-thumb,
+.topbar-ambience__range:disabled::-moz-range-thumb {
+  cursor: not-allowed;
+  box-shadow: 0 0 8px rgba(15, 23, 42, 0.6);
+  border-color: rgba(71, 85, 105, 0.6);
+}
+
+.topbar-ambience__status {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 70%, var(--color-foreground) 30%);
+}
+
+.topbar-ambience.is-off .topbar-ambience__status {
+  color: color-mix(in srgb, var(--color-muted) 80%, var(--color-foreground) 20%);
+}
+
+.topbar-ambience.is-off .topbar-ambience__value {
+  color: color-mix(in srgb, var(--color-muted) 75%, var(--color-foreground) 25%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ambience-toggle,
+  .ambience-toggle__thumb,
+  .topbar-ambience__range,
+  .topbar-ambience__range::-webkit-slider-thumb,
+  .topbar-ambience__range::-moz-range-thumb {
+    transition-duration: 120ms;
+  }
+}
+
 .hud-panel-toggle {
   pointer-events: auto;
   display: none;


### PR DESCRIPTION
## Summary
- add a Web Audio ambience controller that preloads the sauna forest loop, crossfades layers, syncs with the mute toggle, and persists audio preferences
- extend the top bar with an ambience switch and volume slider, wiring polished HUD styling and localStorage-backed state updates
- document the new controls in the README and changelog

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc5bf75214833091dd8f34b453dfac