### PR TITLE
Add animated unit feedback overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Launch a battlefield feedback suite that emits glassy damage/heal floaters,
+  eases fatal fades, and jostles the canvas on major hits via
+  `src/ui/fx/Floater.tsx`, `src/render/unit_fx.ts`, and updated `game.ts`
+  wiring, all while honoring reduced-motion preferences and documenting the
+  new overlays
 - Layer a Web Audio sauna-and-forest ambience loop with seamless crossfades,
   surface a top-bar ambience toggle and volume slider that persist
   `audio_enabled`, sync with the master mute, honor reduced-motion

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ with cinematic UI flourishes.
   respect reduced-motion preferences.
 - **Hand-painted tactical sprites** render terrain, structures, and units with
   crisp vector art that scales cleanly across every zoom level.
+- **Combat feedback floaters** pop luxe damage and heal numbers over units,
+  mix canvas shakes with casualty fades, and respect reduced-motion
+  preferences for mobile players.
 - **Perlin-sculpted fog-of-war** renders with cached noise masks and multi-stop
   gradients so frontier edges stay crisp at every zoom level.
 - **Sauna operations** expose a toggleable control card to manage rally
@@ -119,4 +122,23 @@ documentation, changelog entries, and domain checks.
 ## Changelog
 
 Key updates are catalogued in [CHANGELOG.md](CHANGELOG.md).
+
+## Combat Feedback System
+
+The battlefield now routes combat events through a dedicated FX manager:
+
+- `src/ui/fx/Floater.tsx` mounts an overlay layer that spawns glassy number
+  badges above units. Each floater accepts color and directional parameters, so
+  damage bursts can blaze crimson while heals surge in sauna-green hues.
+- `src/render/unit_fx.ts` subscribes to the `unitDamaged`, `unitHealed`, and
+  `unitDied` events. It projects unit coordinates into screen space, queues
+  screen shakes, and eases casualty fades without stalling the main loop. The
+  helper automatically tempers intensity on coarse pointers and honors
+  `prefers-reduced-motion` so handheld devices degrade gracefully.
+- `src/game.ts` wires the manager into the primary draw routine, translating
+  shake offsets at 60fps while feeding per-unit alpha overrides into the canvas
+  renderer.
+
+These layers keep frontline skirmishes legible with premium polish while
+respecting accessibility settings.
 

--- a/src/audio/events.ts
+++ b/src/audio/events.ts
@@ -1,19 +1,6 @@
 import { eventBus } from '../events/EventBus.ts';
+import type { UnitDamagedPayload, UnitDiedPayload } from '../events/types.ts';
 import { playSafe } from './sfx.ts';
-
-type UnitDamagedPayload = {
-  attackerId?: string;
-  targetId: string;
-  amount: number;
-  remainingHealth: number;
-};
-
-type UnitDiedPayload = {
-  unitId: string;
-  attackerId?: string;
-  unitFaction: string;
-  attackerFaction?: string;
-};
 
 type SisuBurstPayload = {
   remaining: number;

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,0 +1,19 @@
+export interface UnitDamagedPayload {
+  attackerId?: string;
+  targetId: string;
+  amount: number;
+  remainingHealth: number;
+}
+
+export interface UnitHealedPayload {
+  unitId: string;
+  amount: number;
+  remainingHealth: number;
+}
+
+export interface UnitDiedPayload {
+  unitId: string;
+  attackerId?: string;
+  unitFaction: string;
+  attackerFaction?: string;
+}

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -18,7 +18,8 @@ async function initGame() {
   const game = await import('./game.ts');
   const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
   const resourceBar = document.getElementById('resource-bar') as HTMLElement;
-  game.setupGame(canvas, resourceBar);
+  const overlay = document.getElementById('ui-overlay') as HTMLElement;
+  game.setupGame(canvas, resourceBar, overlay);
   return { eventBus, ...game };
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -263,7 +263,7 @@ export function init(): void {
   canvasRef = canvas;
   hud = createHud(overlay);
 
-  setupGame(canvas, resourceBar);
+  setupGame(canvas, resourceBar, overlay);
   attachCanvasInputs(canvas);
 
   const resize = () => resizeCanvasToDisplaySize(canvas);

--- a/src/render/unit_fx.ts
+++ b/src/render/unit_fx.ts
@@ -1,0 +1,236 @@
+import { camera } from '../camera/autoFrame.ts';
+import { axialToPixel, type AxialCoord } from '../hex/HexUtils.ts';
+import { eventBus } from '../events/index.ts';
+import type {
+  UnitDamagedPayload,
+  UnitDiedPayload,
+  UnitHealedPayload
+} from '../events/types.ts';
+import type { HexMapRenderer } from './HexMapRenderer.ts';
+import type { Unit } from '../units/Unit.ts';
+import { createFloaterLayer, type FloaterLayer } from '../ui/fx/Floater.tsx';
+
+export interface UnitFxOptions {
+  canvas: HTMLCanvasElement;
+  overlay: HTMLElement;
+  mapRenderer: HexMapRenderer;
+  getUnitById: (id: string) => Unit | undefined;
+  requestDraw?: () => void;
+}
+
+export interface UnitFxManager {
+  step(now: number): void;
+  getShakeOffset(): { x: number; y: number };
+  getUnitAlpha(unitId: string): number;
+  dispose(): void;
+}
+
+interface ShakeState {
+  start: number;
+  duration: number;
+  intensity: number;
+  seedX: number;
+  seedY: number;
+}
+
+interface FadeState {
+  start: number;
+  duration: number;
+}
+
+const damageFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0
+});
+
+const healFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0
+});
+
+function easeOutQuad(t: number): number {
+  return 1 - (1 - t) * (1 - t);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+const DAMAGE_COLOR = 'var(--color-danger)';
+const HEAL_COLOR = 'color-mix(in srgb, #34d399 88%, white 12%)';
+const FADE_DURATION_DESKTOP = 720;
+const FADE_DURATION_MOBILE = 540;
+const SHAKE_DURATION = 220;
+const SHAKE_DURATION_MOBILE = 180;
+const SHAKE_INTENSITY_DESKTOP = 6;
+const SHAKE_INTENSITY_MOBILE = 3;
+const KILL_FLOATER_COLOR = 'color-mix(in srgb, #fbbf24 82%, white 10%)';
+
+const reduceMotionQuery = typeof matchMedia === 'function'
+  ? matchMedia('(prefers-reduced-motion: reduce)')
+  : null;
+const coarsePointerQuery = typeof matchMedia === 'function'
+  ? matchMedia('(pointer: coarse)')
+  : null;
+
+export function createUnitFxManager(options: UnitFxOptions): UnitFxManager {
+  const { canvas, overlay, mapRenderer, getUnitById, requestDraw } = options;
+  const floaterLayer: FloaterLayer = createFloaterLayer(overlay);
+  const fades = new Map<string, FadeState>();
+  const alphas = new Map<string, number>();
+  const shakes: ShakeState[] = [];
+  const offset = { x: 0, y: 0 };
+  const prefersReducedMotion = Boolean(reduceMotionQuery?.matches);
+  const coarsePointer = Boolean(coarsePointerQuery?.matches);
+  const fadeDuration = coarsePointer ? FADE_DURATION_MOBILE : FADE_DURATION_DESKTOP;
+  const shakeDuration = coarsePointer ? SHAKE_DURATION_MOBILE : SHAKE_DURATION;
+  const shakeIntensity = coarsePointer ? SHAKE_INTENSITY_MOBILE : SHAKE_INTENSITY_DESKTOP;
+
+  const scheduleDraw = () => {
+    if (!requestDraw) {
+      return;
+    }
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => requestDraw());
+    } else {
+      requestDraw();
+    }
+  };
+
+  const project = (coord: AxialCoord): { x: number; y: number } | null => {
+    const canvasRect = canvas.getBoundingClientRect();
+    const overlayRect = overlay.getBoundingClientRect();
+    if (canvasRect.width === 0 || canvasRect.height === 0) {
+      return null;
+    }
+    const { x, y } = axialToPixel(coord, mapRenderer.hexSize);
+    const relativeX = (x - camera.x) * camera.zoom + canvasRect.width / 2;
+    const relativeY = (y - camera.y) * camera.zoom + canvasRect.height / 2;
+    const verticalLift = mapRenderer.hexSize * camera.zoom * 0.75;
+    return {
+      x: relativeX + (canvasRect.left - overlayRect.left),
+      y: relativeY + (canvasRect.top - overlayRect.top) - verticalLift
+    };
+  };
+
+  const spawnFloater = (
+    unitId: string,
+    text: string,
+    color: string,
+    direction: 'up' | 'down' | 'left' | 'right' = 'up'
+  ) => {
+    const unit = getUnitById(unitId);
+    if (!unit) {
+      return;
+    }
+    const position = project(unit.coord);
+    if (!position) {
+      return;
+    }
+    floaterLayer.spawn({
+      text,
+      x: position.x,
+      y: position.y,
+      color,
+      direction,
+      fontSize: coarsePointer ? 18 : undefined
+    });
+  };
+
+  const onDamaged = (payload: UnitDamagedPayload) => {
+    if (!payload || payload.amount <= 0) {
+      return;
+    }
+    const amount = damageFormatter.format(Math.max(1, Math.round(payload.amount)));
+    spawnFloater(payload.targetId, `-${amount}`, DAMAGE_COLOR, 'up');
+    if (!prefersReducedMotion) {
+      const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+      shakes.push({
+        start: now,
+        duration: shakeDuration,
+        intensity: shakeIntensity,
+        seedX: Math.random() * 500,
+        seedY: Math.random() * 500
+      });
+    }
+    scheduleDraw();
+  };
+
+  const onHealed = (payload: UnitHealedPayload) => {
+    if (!payload || payload.amount <= 0) {
+      return;
+    }
+    const rounded = payload.amount >= 1
+      ? damageFormatter.format(Math.round(payload.amount))
+      : healFormatter.format(clamp(payload.amount, 0, 9.9));
+    spawnFloater(payload.unitId, `+${rounded}`, HEAL_COLOR, 'up');
+    scheduleDraw();
+  };
+
+  const onDied = (payload: UnitDiedPayload) => {
+    if (!payload) {
+      return;
+    }
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    fades.set(payload.unitId, { start: now, duration: fadeDuration });
+    spawnFloater(payload.unitId, '✖', KILL_FLOATER_COLOR, 'down');
+    scheduleDraw();
+  };
+
+  eventBus.on<UnitDamagedPayload>('unitDamaged', onDamaged);
+  eventBus.on<UnitHealedPayload>('unitHealed', onHealed);
+  eventBus.on<UnitDiedPayload>('unitDied', onDied);
+
+  const step = (now: number) => {
+    if (!prefersReducedMotion) {
+      let shakeX = 0;
+      let shakeY = 0;
+      for (let i = shakes.length - 1; i >= 0; i--) {
+        const shake = shakes[i];
+        const elapsed = now - shake.start;
+        if (elapsed >= shake.duration) {
+          shakes.splice(i, 1);
+          continue;
+        }
+        const progress = clamp(elapsed / shake.duration, 0, 1);
+        const strength = shake.intensity * easeOutQuad(1 - progress);
+        shakeX += Math.sin((now + shake.seedX) / 16) * strength;
+        shakeY += Math.cos((now + shake.seedY) / 18) * strength;
+      }
+      offset.x = shakeX;
+      offset.y = shakeY;
+    } else {
+      offset.x = 0;
+      offset.y = 0;
+    }
+
+    for (const [unitId, fade] of fades) {
+      const elapsed = now - fade.start;
+      const progress = clamp(elapsed / fade.duration, 0, 1);
+      const alpha = 1 - easeOutQuad(progress);
+      if (progress >= 1) {
+        alphas.delete(unitId);
+        fades.delete(unitId);
+        continue;
+      }
+      alphas.set(unitId, clamp(alpha, 0, 1));
+    }
+  };
+
+  const getShakeOffset = () => ({ x: offset.x, y: offset.y });
+
+  const getUnitAlpha = (unitId: string) => {
+    return alphas.get(unitId) ?? 1;
+  };
+
+  const dispose = () => {
+    eventBus.off<UnitDamagedPayload>('unitDamaged', onDamaged);
+    eventBus.off<UnitHealedPayload>('unitHealed', onHealed);
+    eventBus.off<UnitDiedPayload>('unitDied', onDied);
+    shakes.length = 0;
+    fades.clear();
+    alphas.clear();
+    floaterLayer.destroy();
+  };
+
+  return { step, getShakeOffset, getUnitAlpha, dispose };
+}

--- a/src/style.css
+++ b/src/style.css
@@ -141,6 +141,31 @@ body > #game-container {
   gap: clamp(20px, 3vw, 32px);
 }
 
+.ui-floater-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.ui-floater {
+  position: absolute;
+  transform: translate3d(-50%, -50%, 0);
+  font-size: clamp(16px, 2.4vw, 24px);
+  color: color-mix(in srgb, var(--color-danger) 80%, white 10%);
+  text-shadow:
+    0 12px 32px rgba(0, 0, 0, 0.55),
+    0 0 24px color-mix(in srgb, currentColor 40%, transparent),
+    0 2px 8px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  will-change: transform, opacity;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
 .hud-row {
   display: flex;
   align-items: flex-start;

--- a/src/ui/fx/Floater.tsx
+++ b/src/ui/fx/Floater.tsx
@@ -1,0 +1,128 @@
+interface FloaterOptions {
+  text: string;
+  x: number;
+  y: number;
+  color?: string;
+  direction?: 'up' | 'down' | 'left' | 'right';
+  durationMs?: number;
+  fontSize?: number;
+}
+
+interface FloaterLayer {
+  spawn(options: FloaterOptions): void;
+  destroy(): void;
+}
+
+const reduceMotionQuery = typeof matchMedia === 'function'
+  ? matchMedia('(prefers-reduced-motion: reduce)')
+  : null;
+
+const coarsePointerQuery = typeof matchMedia === 'function'
+  ? matchMedia('(pointer: coarse)')
+  : null;
+
+const BASE_DURATION = 900;
+const MOBILE_DURATION = 650;
+
+function resolveVector(direction: FloaterOptions['direction']): { x: number; y: number } {
+  switch (direction) {
+    case 'down':
+      return { x: 0, y: 36 };
+    case 'left':
+      return { x: -26, y: -18 };
+    case 'right':
+      return { x: 26, y: -18 };
+    case 'up':
+    default:
+      return { x: 0, y: -40 };
+  }
+}
+
+export function createFloaterLayer(root: HTMLElement): FloaterLayer {
+  const layer = document.createElement('div');
+  layer.className = 'ui-floater-layer';
+  root.appendChild(layer);
+
+  const prefersReducedMotion = Boolean(reduceMotionQuery?.matches);
+  const coarsePointer = Boolean(coarsePointerQuery?.matches);
+
+  const spawn = ({
+    text,
+    x,
+    y,
+    color,
+    direction = 'up',
+    durationMs,
+    fontSize
+  }: FloaterOptions): void => {
+    const floater = document.createElement('span');
+    floater.className = 'ui-floater';
+    floater.textContent = text;
+    floater.style.left = `${Math.round(x)}px`;
+    floater.style.top = `${Math.round(y)}px`;
+    if (color) {
+      floater.style.color = color;
+    }
+    if (fontSize) {
+      floater.style.fontSize = `${fontSize}px`;
+    }
+
+    const limit = coarsePointer ? 12 : 24;
+    while (layer.childElementCount >= limit) {
+      layer.firstElementChild?.remove();
+    }
+
+    layer.appendChild(floater);
+
+    const duration = durationMs ?? (coarsePointer ? MOBILE_DURATION : BASE_DURATION);
+
+    if (prefersReducedMotion || !floater.animate) {
+      floater.style.opacity = '0';
+      floater.style.transition = `opacity ${Math.round(duration * 0.8)}ms ease-out`;
+      requestAnimationFrame(() => {
+        floater.style.opacity = '1';
+        requestAnimationFrame(() => {
+          floater.style.opacity = '0';
+        });
+      });
+      window.setTimeout(() => {
+        floater.remove();
+      }, duration);
+      return;
+    }
+
+    const vector = resolveVector(direction);
+    const keyframes: Keyframe[] = [
+      {
+        transform: 'translate3d(-50%, -50%, 0) translate3d(0, 0, 0)',
+        opacity: 0
+      },
+      {
+        transform: 'translate3d(-50%, -50%, 0) translate3d(0, 0, 0)',
+        opacity: 1,
+        offset: 0.18
+      },
+      {
+        transform: `translate3d(-50%, -50%, 0) translate3d(${vector.x}px, ${vector.y}px, 0)`,
+        opacity: 0
+      }
+    ];
+
+    const animation = floater.animate(keyframes, {
+      duration,
+      easing: 'cubic-bezier(0.18, 0.89, 0.32, 1.28)',
+      fill: 'forwards'
+    });
+    animation.onfinish = () => {
+      floater.remove();
+    };
+  };
+
+  const destroy = () => {
+    layer.remove();
+  };
+
+  return { spawn, destroy };
+}
+
+export type { FloaterLayer, FloaterOptions };


### PR DESCRIPTION
## Summary
- add a reusable Floater layer for damage and heal numbers with reduced-motion fallbacks
- introduce a unit FX manager that projects combat events into canvas shakes, fades, and floaters
- wire the manager into the render loop, emit unitHealed events, and document the new feedback polish

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cccd9e04c48330992ac3f553aab9b3