### PR TITLE
Add NG+ objective tracking and end screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a progression tracker in `src/progression/objectives.ts` to monitor strongholds,
+  roster wipes, and upkeep debt, surface a glassmorphism NG+ end screen via
+  `src/ui/overlays/EndScreen.tsx`, escalate enemy spawn cadence each prestige, and
+  document the refreshed loop.
 - Launch a battlefield feedback suite that emits glassy damage/heal floaters,
   eases fatal fades, and jostles the canvas on major hits via
   `src/ui/fx/Floater.tsx`, `src/render/unit_fx.ts`, and updated `game.ts`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ with cinematic UI flourishes.
 - **Glass HUD overlays** (resource bar, build badge, and right-panel cards)
   are layered over the canvas with high-end gradients, blur, and accessible
   aria labels.
+- **NG+ progression end screen** tallies liberated strongholds, roster attrition,
+  and resource rewards in a glassmorphism overlay that invites the next prestige run.
 - **Immersive ambience** crossfades a sauna-and-forest soundscape through Web
   Audio, with top-bar controls that remember volume, honor the mute toggle, and
   respect reduced-motion preferences.
@@ -56,6 +58,8 @@ with cinematic UI flourishes.
 6. **Review events and policies** from the right panel. Apply policies when you
    have the gold, acknowledge events to clear the queue, and scan the log for a
    curated history of recent actions.
+7. **Break the siege** to trigger the end screen—inspect stronghold progress,
+   harvest your rewards, and launch straight into the next NG+ run.
 
 ## Local Development
 

--- a/src/sim/EnemySpawner.ts
+++ b/src/sim/EnemySpawner.ts
@@ -8,18 +8,25 @@ export interface EnemySpawnerOptions {
   readonly factionId?: string;
   readonly random?: () => number;
   readonly idFactory?: () => string;
+  readonly difficulty?: number;
 }
 
 export class EnemySpawner {
-  private timer = 30; // seconds
-  private interval = 30; // cadence
+  private timer: number;
+  private interval: number;
   private readonly factionId: string;
   private readonly random: () => number;
   private readonly makeId: () => string;
+  private readonly difficulty: number;
 
   constructor(options: EnemySpawnerOptions = {}) {
     this.factionId = options.factionId ?? 'enemy';
     this.random = typeof options.random === 'function' ? options.random : Math.random;
+    const difficulty = Number.isFinite(options.difficulty) ? Number(options.difficulty) : 1;
+    this.difficulty = Math.max(0.5, difficulty);
+    const initialCadence = Math.max(10, 30 / this.difficulty);
+    this.interval = initialCadence;
+    this.timer = initialCadence;
     const fallbackIdFactory = (() => {
       let counter = 0;
       return () => `e${Date.now()}-${(counter += 1)}`;
@@ -52,7 +59,8 @@ export class EnemySpawner {
       });
     }
 
-    this.interval = Math.max(10, this.interval * 0.95); // escalate slowly
+    const decay = Math.pow(0.95, this.difficulty);
+    this.interval = Math.max(8, this.interval * decay); // escalate faster with higher difficulty
     this.timer = this.interval;
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -2080,3 +2080,232 @@ body > #game-container {
     flex: 1 1 calc(50% - 10px);
   }
 }
+
+.end-screen {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 6vw, 72px);
+  pointer-events: auto;
+  background:
+    radial-gradient(circle at 18% 20%, rgba(56, 189, 248, 0.32), transparent 62%),
+    radial-gradient(circle at 82% 82%, rgba(248, 113, 113, 0.28), transparent 68%),
+    linear-gradient(135deg, rgba(2, 6, 23, 0.88), rgba(15, 23, 42, 0.94));
+  backdrop-filter: blur(28px) saturate(140%);
+  z-index: 1600;
+}
+
+.end-screen__panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 32px);
+  width: min(680px, 92vw);
+  padding: clamp(28px, 4vw, 52px);
+  border-radius: 28px;
+  background:
+    linear-gradient(165deg, rgba(15, 23, 42, 0.94), rgba(30, 41, 59, 0.78));
+  border: 1px solid color-mix(in srgb, var(--hud-border-strong) 70%, rgba(148, 163, 184, 0.35));
+  box-shadow:
+    0 32px 88px rgba(8, 20, 43, 0.72),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  color: var(--color-foreground);
+}
+
+.end-screen__title {
+  margin: 0;
+  font-size: clamp(28px, 4.8vw, 44px);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  text-transform: capitalize;
+  background: linear-gradient(135deg, rgba(148, 197, 255, 0.9), rgba(56, 189, 248, 0.8));
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.end-screen__panel[data-outcome='lose'] .end-screen__title {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.95), rgba(244, 114, 182, 0.75));
+  -webkit-background-clip: text;
+}
+
+.end-screen__subtitle {
+  margin: 0;
+  font-size: clamp(16px, 2.4vw, 20px);
+  color: color-mix(in srgb, var(--color-muted) 80%, white 20%);
+  max-width: 52ch;
+}
+
+.end-screen__badges {
+  display: flex;
+  gap: 12px;
+}
+
+.end-screen__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 16px;
+  border-radius: var(--radius-pill);
+  background:
+    linear-gradient(135deg, rgba(56, 189, 248, 0.25), rgba(14, 165, 233, 0.18));
+  border: 1px solid rgba(148, 197, 255, 0.35);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-foreground) 90%, white 10%);
+}
+
+.end-screen__metrics {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 28px;
+}
+
+.end-screen__metric-label {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--color-muted) 80%, white 10%);
+}
+
+.end-screen__metric-value {
+  margin: 0;
+  font-size: clamp(18px, 3vw, 26px);
+  font-weight: 600;
+  color: var(--color-foreground);
+}
+
+.end-screen__section-title {
+  margin: 0;
+  font-size: clamp(18px, 2.6vw, 22px);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 60%, white 20%);
+}
+
+.end-screen__rewards-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.end-screen__reward-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px 18px;
+  align-items: baseline;
+  padding: 14px 18px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.end-screen__reward-label {
+  font-size: 15px;
+  color: color-mix(in srgb, var(--color-muted) 70%, white 15%);
+  letter-spacing: 0.02em;
+}
+
+.end-screen__reward-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-foreground);
+}
+
+.end-screen__reward-delta {
+  font-size: 14px;
+  font-weight: 600;
+  justify-self: end;
+  color: rgba(56, 189, 248, 0.85);
+}
+
+.end-screen__reward-delta[data-polarity='negative'] {
+  color: rgba(248, 113, 113, 0.85);
+}
+
+.end-screen__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: flex-end;
+}
+
+.end-screen__button {
+  min-width: 0;
+  padding: 12px 24px;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--color-foreground);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.end-screen__button:hover {
+  transform: translateY(-1px);
+  background: rgba(30, 41, 59, 0.75);
+  box-shadow: 0 12px 28px rgba(8, 20, 43, 0.35);
+}
+
+.end-screen__button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.85), 0 0 0 6px rgba(56, 189, 248, 0.3);
+}
+
+.end-screen__button--primary {
+  background:
+    linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(59, 130, 246, 0.82));
+  border: 1px solid rgba(148, 197, 255, 0.6);
+  box-shadow: 0 18px 38px rgba(14, 165, 233, 0.35);
+}
+
+.end-screen__button--primary:hover {
+  background:
+    linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(37, 99, 235, 0.82));
+}
+
+.end-screen__button--primary:focus-visible {
+  box-shadow:
+    0 0 0 2px rgba(255, 255, 255, 0.8),
+    0 0 0 6px rgba(56, 189, 248, 0.35);
+}
+
+@media (max-width: 640px) {
+  .end-screen__metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .end-screen__reward-item {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'label value'
+      'label delta';
+  }
+
+  .end-screen__reward-label {
+    grid-area: label;
+  }
+
+  .end-screen__reward-value {
+    grid-area: value;
+  }
+
+  .end-screen__reward-delta {
+    grid-area: delta;
+    justify-self: start;
+  }
+
+  .end-screen__actions {
+    justify-content: center;
+  }
+}
+

--- a/src/ui/overlays/EndScreen.tsx
+++ b/src/ui/overlays/EndScreen.tsx
@@ -1,0 +1,250 @@
+import { Resource } from '../../core/GameState.ts';
+import type { ObjectiveResolution } from '../../progression/objectives.ts';
+
+export interface EndScreenOptions {
+  container: HTMLElement | null;
+  resolution: ObjectiveResolution;
+  currentNgPlusLevel: number;
+  onNewRun: () => void;
+  onDismiss?: () => void;
+  resourceLabels?: Record<Resource, string>;
+}
+
+export interface EndScreenController {
+  destroy(): void;
+  focusPrimary(): void;
+}
+
+const DEFAULT_RESOURCE_LABELS: Record<Resource, string> = {
+  [Resource.SAUNA_BEER]: 'Sauna Beer',
+  [Resource.SAUNAKUNNIA]: 'Saunakunnia',
+  [Resource.SISU]: 'Sisu'
+};
+
+const FOCUSABLE_SELECTORS =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return '0:00';
+  }
+  const totalSeconds = Math.round(ms / 1000);
+  const seconds = Math.max(0, totalSeconds % 60).toString().padStart(2, '0');
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = (totalMinutes % 60).toString().padStart(2, '0');
+  const hours = Math.floor(totalMinutes / 60);
+  if (hours > 0) {
+    return `${hours}:${minutes}:${seconds}`;
+  }
+  return `${totalMinutes}:${seconds}`;
+}
+
+function describeCause(resolution: ObjectiveResolution): string {
+  switch (resolution.cause) {
+    case 'strongholds':
+      return 'All rival strongholds have fallen.';
+    case 'rosterWipe':
+      return 'Every attendant is down—no one remains to hold the line.';
+    case 'bankruptcy':
+      return 'Upkeep debts have exhausted the steam reserves.';
+    default:
+      return '';
+  }
+}
+
+function formatSigned(value: number): string {
+  if (!Number.isFinite(value) || value === 0) {
+    return '±0';
+  }
+  const rounded = Math.round(value * 100) / 100;
+  return `${rounded > 0 ? '+' : ''}${rounded}`;
+}
+
+function buildRewardList(
+  resolution: ObjectiveResolution,
+  labels: Record<Resource, string>
+): HTMLUListElement {
+  const rewards = document.createElement('ul');
+  rewards.className = 'end-screen__rewards-list';
+  for (const resource of Object.values(Resource) as Resource[]) {
+    const reward = resolution.rewards.resources[resource];
+    if (!reward) {
+      continue;
+    }
+    const item = document.createElement('li');
+    item.className = 'end-screen__reward-item';
+
+    const label = document.createElement('span');
+    label.className = 'end-screen__reward-label';
+    label.textContent = labels[resource] ?? resource;
+
+    const value = document.createElement('span');
+    value.className = 'end-screen__reward-value';
+    value.textContent = new Intl.NumberFormat('en-US', {
+      maximumFractionDigits: 0
+    }).format(Math.round(reward.final));
+
+    const delta = document.createElement('span');
+    delta.className = 'end-screen__reward-delta';
+    delta.textContent = formatSigned(reward.delta);
+    delta.dataset.polarity = reward.delta >= 0 ? 'positive' : 'negative';
+
+    item.append(label, value, delta);
+    rewards.append(item);
+  }
+  return rewards;
+}
+
+function createFocusTrap(
+  overlay: HTMLElement,
+  panel: HTMLElement,
+  onDismiss?: () => void
+): () => void {
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onDismiss?.();
+      return;
+    }
+    if (event.key !== 'Tab') {
+      return;
+    }
+    const focusable = panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      panel.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    if (event.shiftKey) {
+      if (active === first || !panel.contains(active)) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last || !panel.contains(active)) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  overlay.addEventListener('keydown', handleKeyDown);
+  return () => overlay.removeEventListener('keydown', handleKeyDown);
+}
+
+export function showEndScreen(options: EndScreenOptions): EndScreenController {
+  const { container, resolution, onNewRun, onDismiss, currentNgPlusLevel } = options;
+  if (!container) {
+    return {
+      destroy() {
+        /* noop */
+      },
+      focusPrimary() {
+        /* noop */
+      }
+    };
+  }
+
+  const labels = { ...DEFAULT_RESOURCE_LABELS, ...(options.resourceLabels ?? {}) };
+
+  const overlay = document.createElement('div');
+  overlay.className = 'end-screen';
+  overlay.setAttribute('role', 'presentation');
+
+  const panel = document.createElement('section');
+  panel.className = 'end-screen__panel';
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'true');
+  const headingId = `end-screen-title-${Date.now()}`;
+  panel.setAttribute('aria-labelledby', headingId);
+  panel.tabIndex = -1;
+  panel.dataset.outcome = resolution.outcome;
+
+  const title = document.createElement('h2');
+  title.className = 'end-screen__title';
+  title.id = headingId;
+  title.textContent = resolution.outcome === 'win' ? 'Steamforged Victory' : 'Sauna Lost';
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'end-screen__subtitle';
+  subtitle.textContent = describeCause(resolution);
+
+  const metrics = document.createElement('dl');
+  metrics.className = 'end-screen__metrics';
+
+  const metric = (label: string, value: string) => {
+    const term = document.createElement('dt');
+    term.textContent = label;
+    term.className = 'end-screen__metric-label';
+    const desc = document.createElement('dd');
+    desc.textContent = value;
+    desc.className = 'end-screen__metric-value';
+    metrics.append(term, desc);
+  };
+
+  metric('Run time', formatDuration(resolution.durationMs));
+  metric(
+    'Strongholds',
+    `${resolution.summary.strongholds.destroyed}/${resolution.summary.strongholds.total}`
+  );
+  metric('Roster losses', `${resolution.summary.roster.totalDeaths}`);
+  metric('Deepest beer reserve', `${Math.round(resolution.summary.economy.worstBeer)}`);
+
+  const badgeRow = document.createElement('div');
+  badgeRow.className = 'end-screen__badges';
+
+  const badge = document.createElement('span');
+  badge.className = 'end-screen__badge';
+  badge.textContent = `NG+ ${Math.max(0, currentNgPlusLevel)}`;
+  badgeRow.append(badge);
+
+  const rewardHeading = document.createElement('h3');
+  rewardHeading.className = 'end-screen__section-title';
+  rewardHeading.textContent = 'Rewards';
+
+  const rewards = buildRewardList(resolution, labels);
+
+  const actions = document.createElement('div');
+  actions.className = 'end-screen__actions';
+
+  const newRunButton = document.createElement('button');
+  newRunButton.type = 'button';
+  newRunButton.className = 'end-screen__button end-screen__button--primary';
+  newRunButton.textContent = 'New run (NG+)';
+  newRunButton.addEventListener('click', () => {
+    onNewRun();
+  });
+
+  const dismissButton = document.createElement('button');
+  dismissButton.type = 'button';
+  dismissButton.className = 'end-screen__button';
+  dismissButton.textContent = 'Review battlefield';
+  dismissButton.addEventListener('click', () => {
+    onDismiss?.();
+  });
+
+  actions.append(newRunButton, dismissButton);
+
+  panel.append(title, subtitle, badgeRow, metrics, rewardHeading, rewards, actions);
+  overlay.append(panel);
+  container.append(overlay);
+
+  const releaseTrap = createFocusTrap(overlay, panel, onDismiss);
+
+  const destroy = (): void => {
+    releaseTrap();
+    overlay.remove();
+  };
+
+  const focusPrimary = (): void => {
+    requestAnimationFrame(() => {
+      newRunButton.focus({ preventScroll: true });
+    });
+  };
+
+  focusPrimary();
+
+  return { destroy, focusPrimary };
+}
+


### PR DESCRIPTION
## Summary
- add a progression tracker that records strongholds, roster wipes, and upkeep bankruptcy while surfacing NG+ rewards
- introduce a glassmorphism NG+ end screen overlay with accessible focus management and reward displays
- integrate the tracker into the game loop with NG+ start bonuses, tougher spawns, and cleanup hooks while updating docs for the new flow

## Testing
- npm run build
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ccd30bd6488330a48ef8b189bc7874