### PR TITLE
Document docs mirror refresh workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 
+- Document the `docs/` mirror refresh workflow in the README deployment section,
+  highlighting the `npm run build` + sync step and cross-linking to the
+  contributing notes about the custom domain records.
 - Encapsulate NG+ progression in `src/progression/ngplus.ts`, persist run seeds,
   levels, and unlock slots through `GameState`, wire the modifiers into economy
   upkeep, reinforcement slots, enemy aggression, and elite loot odds, and cover

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ publishes the contents of `dist/` directly to GitHub Pages. The workflow uploads
 the artifact and releases it without committing generated files back to the
 repository, keeping the default branch clean.
 
+The repository still tracks a `docs/` mirror so historic GitHub Pages snapshots
+and the custom domain records stay versioned. When you cut a release (or any
+change that should be reflected on the live site), run `npm run build` locally
+and copy the resulting `dist/` output into `docs/` before committing (for
+example, `rsync -a dist/ docs/`). That manual refresh keeps the checked-in
+mirror aligned with the action-managed deployment and preserves the
+`docs/CNAME` expectations documented in
+[CONTRIBUTING.md](CONTRIBUTING.md#before-you-start).
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Summary
- explain that the actions workflow deploys from `dist/` while the repository still tracks a `docs/` mirror
- document the manual `npm run build` plus sync expectation so releases keep `docs/` aligned
- note the documentation tweak in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cce8b92bf88330b93a0d7cb6608e02