### PR TITLE
Implement Saunoja equipment system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Introduce a dedicated equipment system that maps item slots and stat
+  modifiers through `src/items/`, threads equip/unequip guards into
+  `src/game.ts`, refreshes roster storage plus calculations, polishes the
+  roster panel UI with per-slot controls, and covers the flow with Vitest
+  suites.
 - Rebuild the GitHub Pages mirror from commit 8f618f4 so the hashed Vite
   bundle, published HTML, and build badge all advertise the latest deploy.
 - Introduce a guided HUD tutorial with spotlight tooltips, keyboard navigation,

--- a/src/game/rosterStorage.test.ts
+++ b/src/game/rosterStorage.test.ts
@@ -43,10 +43,10 @@ describe('rosterStorage', () => {
         upkeep: 9,
         items: [
           {
-            id: 'artifact-1',
-            name: 'Polished Banner',
-            description: 'A radiant standard gleaming with sauna steam.',
-            icon: 'icon-banner',
+            id: 'emberglass-arrow',
+            name: 'Emberglass Arrow',
+            description: 'Ignites targets on hit',
+            icon: '/assets/items/emberglass.svg',
             rarity: 'rare',
             quantity: 1
           }
@@ -79,7 +79,14 @@ describe('rosterStorage', () => {
     expect(unit.traits).toEqual(expect.arrayContaining(['Bold', 'Veteran']));
     expect(unit.upkeep).toBe(9);
     expect(unit.items).toHaveLength(1);
+    expect(unit.items[0]?.id).toBe('emberglass-arrow');
     expect(unit.modifiers).toHaveLength(1);
+    expect(unit.baseStats.health).toBeGreaterThan(0);
+    expect(unit.effectiveStats.health).toBeGreaterThan(0);
+    expect(Object.keys(unit.equipment)).toEqual(
+      expect.arrayContaining(['weapon', 'supply', 'focus', 'relic'])
+    );
+    expect(unit.equipment.weapon?.id).toBe('emberglass-arrow');
   });
 
   it('handles malformed storage payloads gracefully', () => {

--- a/src/game/rosterStorage.ts
+++ b/src/game/rosterStorage.ts
@@ -1,5 +1,6 @@
 import type { Saunoja } from '../units/saunoja.ts';
 import { makeSaunoja } from '../units/saunoja.ts';
+import { EQUIPMENT_SLOT_IDS } from '../items/types.ts';
 
 export const SAUNOJA_STORAGE_KEY = 'autobattles:saunojas';
 
@@ -68,6 +69,9 @@ export function loadUnits(): Saunoja[] {
           xp: xpValue,
           selected: Boolean(data.selected),
           items: Array.isArray(data.items) ? data.items : undefined,
+          baseStats: data.baseStats,
+          effectiveStats: data.effectiveStats,
+          equipment: data.equipment,
           modifiers: Array.isArray(data.modifiers) ? data.modifiers : undefined
         })
       );
@@ -98,6 +102,52 @@ export function saveUnits(units: readonly Saunoja[]): void {
       upkeep: unit.upkeep,
       xp: unit.xp,
       selected: unit.selected,
+      baseStats: {
+        health: unit.baseStats.health,
+        attackDamage: unit.baseStats.attackDamage,
+        attackRange: unit.baseStats.attackRange,
+        movementRange: unit.baseStats.movementRange,
+        ...(typeof unit.baseStats.defense === 'number' && Number.isFinite(unit.baseStats.defense)
+          ? { defense: unit.baseStats.defense }
+          : {}),
+        ...(typeof unit.baseStats.shield === 'number' && Number.isFinite(unit.baseStats.shield)
+          ? { shield: unit.baseStats.shield }
+          : {}),
+        ...(typeof unit.baseStats.visionRange === 'number' && Number.isFinite(unit.baseStats.visionRange)
+          ? { visionRange: unit.baseStats.visionRange }
+          : {})
+      },
+      effectiveStats: {
+        health: unit.effectiveStats.health,
+        attackDamage: unit.effectiveStats.attackDamage,
+        attackRange: unit.effectiveStats.attackRange,
+        movementRange: unit.effectiveStats.movementRange,
+        ...(typeof unit.effectiveStats.defense === 'number' && Number.isFinite(unit.effectiveStats.defense)
+          ? { defense: unit.effectiveStats.defense }
+          : {}),
+        ...(typeof unit.effectiveStats.shield === 'number' && Number.isFinite(unit.effectiveStats.shield)
+          ? { shield: unit.effectiveStats.shield }
+          : {}),
+        ...(typeof unit.effectiveStats.visionRange === 'number' &&
+        Number.isFinite(unit.effectiveStats.visionRange)
+          ? { visionRange: unit.effectiveStats.visionRange }
+          : {})
+      },
+      equipment: EQUIPMENT_SLOT_IDS.reduce<Record<string, unknown>>((acc, slot) => {
+        const equipped = unit.equipment?.[slot] ?? null;
+        acc[slot] = equipped
+          ? {
+              id: equipped.id,
+              name: equipped.name,
+              description: equipped.description,
+              icon: equipped.icon,
+              rarity: equipped.rarity,
+              quantity: equipped.quantity,
+              slot: equipped.slot
+            }
+          : null;
+        return acc;
+      }, {}),
       items: unit.items.map((item) => ({
         id: item.id,
         name: item.name,

--- a/src/inventory/state.test.ts
+++ b/src/inventory/state.test.ts
@@ -69,4 +69,22 @@ describe('InventoryState', () => {
     expect(removed?.id).toBe('emberglass-arrow');
     expect(inventory.getStashSize()).toBe(0);
   });
+
+  it('moves unequipped items back into the stash', () => {
+    const inventory = new InventoryState({ now: () => 1000 });
+    const unequip = vi
+      .fn()
+      .mockReturnValue({ id: 'glacier-brand', name: 'Glacier Brand', quantity: 1 });
+    const events: string[] = [];
+    const stop = inventory.on((event) => {
+      events.push(event.type);
+    });
+
+    const success = inventory.unequipToStash('unit-1', 'weapon', unequip);
+    expect(success).toBe(true);
+    expect(unequip).toHaveBeenCalledWith('unit-1', 'weapon');
+    expect(inventory.getStashSize()).toBe(1);
+    expect(events).toContain('item-unequipped');
+    stop();
+  });
 });

--- a/src/items/equip.test.ts
+++ b/src/items/equip.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { makeSaunoja } from '../units/saunoja.ts';
+import type { SaunojaItem } from '../units/saunoja.ts';
+import { equip, unequip, matchesSlot, loadoutItems } from './equip.ts';
+
+describe('items/equip', () => {
+  const weapon: SaunojaItem = {
+    id: 'glacier-brand',
+    name: 'Glacier Brand',
+    quantity: 1
+  };
+
+  const alternateWeapon: SaunojaItem = {
+    id: 'emberglass-arrow',
+    name: 'Emberglass Arrow',
+    quantity: 1
+  };
+
+  const supply: SaunojaItem = {
+    id: 'birch-sap-satchel',
+    name: 'Birch Sap Satchel',
+    quantity: 2
+  };
+
+  it('equips items into their designated slots', () => {
+    const unit = makeSaunoja({ id: 's1' });
+    const outcome = equip(unit, weapon);
+    expect(outcome.success).toBe(true);
+    expect(outcome.slot).toBe('weapon');
+    expect(unit.equipment.weapon?.id).toBe('glacier-brand');
+    expect(matchesSlot('glacier-brand', 'weapon')).toBe(true);
+    expect(unit.items).toHaveLength(1);
+  });
+
+  it('rejects conflicting equipment occupying the same slot', () => {
+    const unit = makeSaunoja({ id: 's2' });
+    expect(equip(unit, weapon).success).toBe(true);
+    const outcome = equip(unit, alternateWeapon);
+    expect(outcome.success).toBe(false);
+    expect(outcome.reason).toBe('slot-occupied');
+    expect(unit.equipment.weapon?.id).toBe('glacier-brand');
+  });
+
+  it('enforces stack limits when combining quantities', () => {
+    const unit = makeSaunoja({ id: 's3' });
+    expect(equip(unit, supply).success).toBe(true);
+    const overflow = equip(unit, { ...supply });
+    expect(overflow.success).toBe(false);
+    expect(overflow.reason).toBe('stack-limit');
+    const loadout = loadoutItems(unit.equipment);
+    expect(loadout).toHaveLength(1);
+    expect(loadout[0]?.quantity).toBe(2);
+  });
+
+  it('returns unequipped items to empty the slot', () => {
+    const unit = makeSaunoja({ id: 's4' });
+    expect(equip(unit, weapon).success).toBe(true);
+    const outcome = unequip(unit, 'weapon');
+    expect(outcome.success).toBe(true);
+    expect(outcome.removed?.id).toBe('glacier-brand');
+    expect(unit.equipment.weapon).toBeNull();
+    expect(unit.items).toHaveLength(0);
+  });
+});

--- a/src/items/equip.ts
+++ b/src/items/equip.ts
@@ -1,0 +1,323 @@
+import {
+  createEmptyLoadout,
+  EQUIPMENT_SLOT_IDS,
+  type EquipmentItemDefinition,
+  type EquipmentMap,
+  type EquipmentModifier,
+  type EquipmentSlotDefinition,
+  type EquipmentSlotId,
+  type EquippedItem
+} from './types.ts';
+import type { Saunoja, SaunojaItem } from '../units/saunoja.ts';
+
+const SLOT_DEFINITIONS: Record<EquipmentSlotId, EquipmentSlotDefinition> = Object.freeze({
+  supply: Object.freeze({
+    id: 'supply',
+    label: 'Supply Satchel',
+    description: 'Consumables and restorative provisions carried into battle.',
+    maxStacks: 5
+  }),
+  weapon: Object.freeze({
+    id: 'weapon',
+    label: 'Primary Armament',
+    description: 'The attendant\'s main weapon or ranged kit.',
+    maxStacks: 1
+  }),
+  focus: Object.freeze({
+    id: 'focus',
+    label: 'Battle Focus',
+    description: 'Tools that sharpen aim, steps, or battlefield intuition.',
+    maxStacks: 1
+  }),
+  relic: Object.freeze({
+    id: 'relic',
+    label: 'Sauna Relic',
+    description: 'Charms and relics that empower the attendant\'s resolve.',
+    maxStacks: 1
+  })
+});
+
+const ITEM_DEFINITIONS: Record<string, EquipmentItemDefinition> = Object.freeze({
+  'birch-sap-satchel': Object.freeze({
+    id: 'birch-sap-satchel',
+    slot: 'supply',
+    modifiers: { health: 3 },
+    maxStacks: 3
+  }),
+  'steamed-bandages': Object.freeze({
+    id: 'steamed-bandages',
+    slot: 'supply',
+    modifiers: { shield: 4 },
+    maxStacks: 2
+  }),
+  'aurora-distillate': Object.freeze({
+    id: 'aurora-distillate',
+    slot: 'supply',
+    modifiers: { attackDamage: 2, defense: 1 },
+    maxStacks: 1
+  }),
+  'stolen-sauna-tokens': Object.freeze({
+    id: 'stolen-sauna-tokens',
+    slot: 'supply',
+    modifiers: { movementRange: 0.5 },
+    maxStacks: 5
+  }),
+  'midnight-bloodwine': Object.freeze({
+    id: 'midnight-bloodwine',
+    slot: 'supply',
+    modifiers: { health: 6, attackDamage: 1 },
+    maxStacks: 1
+  }),
+  'sauna-incense': Object.freeze({
+    id: 'sauna-incense',
+    slot: 'supply',
+    modifiers: { attackRange: 1 },
+    maxStacks: 2
+  }),
+  'glacier-brand': Object.freeze({
+    id: 'glacier-brand',
+    slot: 'weapon',
+    modifiers: { attackDamage: 3 },
+    maxStacks: 1
+  }),
+  'emberglass-arrow': Object.freeze({
+    id: 'emberglass-arrow',
+    slot: 'weapon',
+    modifiers: { attackDamage: 1, attackRange: 2 },
+    maxStacks: 1
+  }),
+  'aurora-lattice': Object.freeze({
+    id: 'aurora-lattice',
+    slot: 'focus',
+    modifiers: { attackDamage: 2, attackRange: 1 },
+    maxStacks: 1
+  }),
+  'emberglass-shard': Object.freeze({
+    id: 'emberglass-shard',
+    slot: 'focus',
+    modifiers: { attackDamage: 1, movementRange: 1 },
+    maxStacks: 1
+  }),
+  'windstep-totem': Object.freeze({
+    id: 'windstep-totem',
+    slot: 'focus',
+    modifiers: { movementRange: 1, defense: 1 },
+    maxStacks: 1
+  }),
+  'searing-chant-censer': Object.freeze({
+    id: 'searing-chant-censer',
+    slot: 'focus',
+    modifiers: { attackDamage: 2, shield: 2 },
+    maxStacks: 1
+  }),
+  'cracked-ice-amulet': Object.freeze({
+    id: 'cracked-ice-amulet',
+    slot: 'relic',
+    modifiers: { defense: 2 },
+    maxStacks: 1
+  }),
+  'myrsky-charm': Object.freeze({
+    id: 'myrsky-charm',
+    slot: 'relic',
+    modifiers: { attackRange: 1, defense: 1 },
+    maxStacks: 1
+  }),
+  'frostwyrm-signet': Object.freeze({
+    id: 'frostwyrm-signet',
+    slot: 'relic',
+    modifiers: { shield: 5 },
+    maxStacks: 1
+  }),
+  'spirit-oak-charm': Object.freeze({
+    id: 'spirit-oak-charm',
+    slot: 'relic',
+    modifiers: { defense: 1, health: 2 },
+    maxStacks: 1
+  })
+});
+
+export function getSlotDefinition(slotId: EquipmentSlotId): EquipmentSlotDefinition {
+  const definition = SLOT_DEFINITIONS[slotId];
+  if (!definition) {
+    throw new Error(`Unknown equipment slot: ${slotId}`);
+  }
+  return definition;
+}
+
+export function getItemDefinition(itemId: string): EquipmentItemDefinition | undefined {
+  return ITEM_DEFINITIONS[itemId];
+}
+
+function normalizeQuantity(value: number | undefined): number {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  return Math.max(1, Math.round(value as number));
+}
+
+function cloneItem(item: SaunojaItem, quantity: number): SaunojaItem {
+  return {
+    id: item.id,
+    name: item.name,
+    description: item.description,
+    icon: item.icon,
+    rarity: item.rarity,
+    quantity
+  } satisfies SaunojaItem;
+}
+
+function toEquippedItem(
+  source: SaunojaItem,
+  slot: EquipmentSlotId,
+  definition: EquipmentItemDefinition,
+  quantity: number
+): EquippedItem {
+  const slotDef = getSlotDefinition(slot);
+  const limit = Math.max(1, Math.floor(definition.maxStacks ?? slotDef.maxStacks));
+  const resolvedQuantity = Math.min(limit, quantity);
+  const modifiers = definition.modifiers ?? ({} as EquipmentModifier);
+  return {
+    ...cloneItem(source, resolvedQuantity),
+    slot,
+    maxStacks: limit,
+    modifiers
+  } satisfies EquippedItem;
+}
+
+function ensureEquipment(unit: Saunoja): EquipmentMap {
+  if (!unit.equipment) {
+    unit.equipment = createEmptyLoadout();
+  }
+  for (const slot of EQUIPMENT_SLOT_IDS) {
+    unit.equipment[slot] ??= null;
+  }
+  return unit.equipment;
+}
+
+export function loadoutItems(equipment: EquipmentMap): EquippedItem[] {
+  const slots: EquippedItem[] = [];
+  for (const slot of EQUIPMENT_SLOT_IDS) {
+    const item = equipment[slot];
+    if (item) {
+      slots.push({ ...item });
+    }
+  }
+  return slots;
+}
+
+export function loadoutToItems(equipment: EquipmentMap): SaunojaItem[] {
+  return loadoutItems(equipment).map((item) => cloneItem(item, item.quantity));
+}
+
+export function createLoadoutFromItems(items: readonly SaunojaItem[]): EquipmentMap {
+  const loadout = createEmptyLoadout();
+  for (const item of items) {
+    const definition = getItemDefinition(item.id);
+    if (!definition) {
+      continue;
+    }
+    const quantity = normalizeQuantity(item.quantity);
+    const current = loadout[definition.slot];
+    if (current && current.id !== item.id) {
+      continue;
+    }
+    const nextQuantity = (current?.quantity ?? 0) + quantity;
+    const equipped = toEquippedItem(item, definition.slot, definition, nextQuantity);
+    loadout[definition.slot] = equipped;
+  }
+  return loadout;
+}
+
+export interface EquipOutcome {
+  readonly success: boolean;
+  readonly slot: EquipmentSlotId;
+  readonly loadout: readonly EquippedItem[];
+  readonly item: EquippedItem | null;
+  readonly reason?: string;
+}
+
+export interface UnequipOutcome {
+  readonly success: boolean;
+  readonly slot: EquipmentSlotId;
+  readonly loadout: readonly EquippedItem[];
+  readonly removed: EquippedItem | null;
+  readonly reason?: string;
+}
+
+export function equip(unit: Saunoja, item: SaunojaItem): EquipOutcome {
+  const definition = getItemDefinition(item.id);
+  if (!definition) {
+    return {
+      success: false,
+      slot: 'supply',
+      loadout: loadoutItems(ensureEquipment(unit)),
+      item: null,
+      reason: 'unknown-item'
+    } satisfies EquipOutcome;
+  }
+
+  const equipment = ensureEquipment(unit);
+  const slot = definition.slot;
+  const slotDef = getSlotDefinition(slot);
+  const incomingQuantity = normalizeQuantity(item.quantity);
+  const limit = Math.max(1, Math.floor(definition.maxStacks ?? slotDef.maxStacks));
+  const existing = equipment[slot];
+
+  if (existing && existing.id !== item.id) {
+    return {
+      success: false,
+      slot,
+      loadout: loadoutItems(equipment),
+      item: existing,
+      reason: 'slot-occupied'
+    } satisfies EquipOutcome;
+  }
+
+  const nextQuantity = Math.min(limit, (existing?.quantity ?? 0) + incomingQuantity);
+  if ((existing?.quantity ?? 0) + incomingQuantity > limit) {
+    return {
+      success: false,
+      slot,
+      loadout: loadoutItems(equipment),
+      item: existing,
+      reason: 'stack-limit'
+    } satisfies EquipOutcome;
+  }
+
+  const equipped = toEquippedItem(item, slot, definition, nextQuantity);
+  equipment[slot] = equipped;
+  unit.items = loadoutToItems(equipment);
+  return {
+    success: true,
+    slot,
+    loadout: loadoutItems(equipment),
+    item: equipped
+  } satisfies EquipOutcome;
+}
+
+export function unequip(unit: Saunoja, slot: EquipmentSlotId): UnequipOutcome {
+  const equipment = ensureEquipment(unit);
+  const existing = equipment[slot];
+  if (!existing) {
+    return {
+      success: false,
+      slot,
+      loadout: loadoutItems(equipment),
+      removed: null,
+      reason: 'empty-slot'
+    } satisfies UnequipOutcome;
+  }
+  equipment[slot] = null;
+  unit.items = loadoutToItems(equipment);
+  return {
+    success: true,
+    slot,
+    loadout: loadoutItems(equipment),
+    removed: existing
+  } satisfies UnequipOutcome;
+}
+
+export function matchesSlot(itemId: string, slot: EquipmentSlotId): boolean {
+  const definition = getItemDefinition(itemId);
+  return definition?.slot === slot;
+}

--- a/src/items/types.ts
+++ b/src/items/types.ts
@@ -1,0 +1,52 @@
+import type { SaunojaItem } from '../units/saunoja.ts';
+
+export type EquipmentSlotId = 'supply' | 'weapon' | 'focus' | 'relic';
+
+export interface EquipmentSlotDefinition {
+  readonly id: EquipmentSlotId;
+  readonly label: string;
+  readonly description: string;
+  readonly maxStacks: number;
+}
+
+export interface EquipmentModifier {
+  readonly health?: number;
+  readonly attackDamage?: number;
+  readonly attackRange?: number;
+  readonly movementRange?: number;
+  readonly defense?: number;
+  readonly shield?: number;
+}
+
+export interface EquipmentItemDefinition {
+  readonly id: string;
+  readonly slot: EquipmentSlotId;
+  readonly modifiers?: EquipmentModifier;
+  readonly maxStacks?: number;
+}
+
+export interface EquippedItem extends SaunojaItem {
+  readonly slot: EquipmentSlotId;
+  readonly maxStacks: number;
+  readonly modifiers: EquipmentModifier;
+}
+
+export type EquipmentMap = Record<EquipmentSlotId, EquippedItem | null>;
+
+export type EquipmentLoadout = Readonly<EquipmentMap>;
+
+export const EQUIPMENT_SLOT_IDS: readonly EquipmentSlotId[] = Object.freeze([
+  'supply',
+  'weapon',
+  'focus',
+  'relic'
+]);
+
+export function createEmptyLoadout(): EquipmentMap {
+  return {
+    supply: null,
+    weapon: null,
+    focus: null,
+    relic: null
+  } satisfies EquipmentMap;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1445,6 +1445,93 @@ body > #game-container {
   border-top: 1px solid rgba(148, 163, 184, 0.16);
 }
 
+.panel-roster__slots {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.panel-roster__slot {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px 16px;
+  align-items: center;
+  padding: 12px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.65), rgba(15, 23, 42, 0.95));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2), 0 18px 28px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(12px);
+}
+
+.panel-roster__slot-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.panel-roster__slot-label {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.panel-roster__slot-summary {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-foreground);
+}
+
+.panel-roster__slot-icons {
+  display: flex;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.panel-roster__slot-modifiers {
+  grid-column: 1 / -1;
+  font-size: 13px;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.panel-roster__slot-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.panel-roster__slot-action {
+  appearance: none;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.6);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 6px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background var(--transition-snappy), transform var(--transition-snappy),
+    border-color var(--transition-snappy);
+}
+
+.panel-roster__slot-action:is(:hover, :focus-visible) {
+  background: rgba(59, 130, 246, 0.22);
+  border-color: rgba(59, 130, 246, 0.55);
+  transform: translateY(-1px);
+}
+
+.panel-roster__slot-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  transform: none;
+}
+
 .panel-roster__items,
 .panel-roster__mods {
   display: flex;

--- a/src/ui/inventoryHud.ts
+++ b/src/ui/inventoryHud.ts
@@ -227,6 +227,9 @@ export function setupInventoryHud(
       case 'item-equipped':
         showToast(`${event.item.name} equipped to the selected attendant.`, 'info');
         break;
+      case 'item-unequipped':
+        showToast(`${event.item.name} returned to the stash.`, 'info');
+        break;
       case 'item-discarded':
         showToast(`${event.item.name} discarded from the stash.`, 'warn');
         break;

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -4,6 +4,7 @@ import { ensureHudLayout } from './layout.ts';
 import { subscribeToIsMobile } from './hooks/useIsMobile.ts';
 import { createRosterPanel } from './panels/RosterPanel.tsx';
 import type { RosterEntry } from './panels/RosterPanel.tsx';
+import type { EquipmentSlotId } from '../items/types.ts';
 
 export type { RosterEntry, RosterItem, RosterModifier, RosterStats } from './panels/RosterPanel.tsx';
 
@@ -19,6 +20,8 @@ const numberFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 
 type RightPanelOptions = {
   onRosterSelect?: (unitId: string) => void;
   onRosterRendererReady?: (renderer: (entries: RosterEntry[]) => void) => void;
+  onRosterEquipSlot?: (unitId: string, slot: EquipmentSlotId) => void;
+  onRosterUnequipSlot?: (unitId: string, slot: EquipmentSlotId) => void;
 };
 
 export function setupRightPanel(
@@ -393,7 +396,7 @@ export function setupRightPanel(
     Log: logTab
   };
 
-  const { onRosterSelect, onRosterRendererReady } = options;
+  const { onRosterSelect, onRosterRendererReady, onRosterEquipSlot, onRosterUnequipSlot } = options;
   for (const [name, section] of Object.entries(tabs)) {
     section.classList.add('panel-section', 'panel-section--scroll');
     section.dataset.tab = name;
@@ -430,7 +433,11 @@ export function setupRightPanel(
   }
 
   // --- Roster ---
-  const rosterPanel = createRosterPanel(rosterTab, { onSelect: onRosterSelect });
+  const rosterPanel = createRosterPanel(rosterTab, {
+    onSelect: onRosterSelect,
+    onEquipSlot: onRosterEquipSlot,
+    onUnequipSlot: onRosterUnequipSlot
+  });
 
   const renderRoster = (entries: RosterEntry[]): void => {
     rosterPanel.render(entries);

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -214,6 +214,23 @@ export class Unit {
     this.shield = value;
   }
 
+  updateStats(stats: UnitStats): void {
+    this.stats.attackDamage = stats.attackDamage;
+    this.stats.attackRange = stats.attackRange;
+    this.stats.movementRange = stats.movementRange;
+    if (typeof stats.defense === 'number' && Number.isFinite(stats.defense)) {
+      this.stats.defense = stats.defense;
+    } else {
+      delete this.stats.defense;
+    }
+    if (typeof stats.visionRange === 'number' && Number.isFinite(stats.visionRange)) {
+      this.stats.visionRange = stats.visionRange;
+    }
+    const newMax = Math.max(1, Math.round(stats.health));
+    this.maxHealth = newMax;
+    this.stats.health = Math.min(newMax, Math.max(0, this.stats.health));
+  }
+
   isImmortal(): boolean {
     return this.immortal;
   }

--- a/src/units/saunoja.test.ts
+++ b/src/units/saunoja.test.ts
@@ -32,6 +32,9 @@ describe('makeSaunoja', () => {
     expect(saunoja.traits).toEqual(['Stoic', 'Swift']);
     expect(saunoja.upkeep).toBe(4.5);
     expect(saunoja.xp).toBe(27);
+    expect(saunoja.baseStats.health).toBe(20);
+    expect(saunoja.effectiveStats.health).toBe(20);
+    expect(saunoja.equipment.weapon).toBeNull();
   });
 
   it('falls back to safe defaults for invalid data', () => {
@@ -57,6 +60,8 @@ describe('makeSaunoja', () => {
     expect(saunoja.traits).toEqual(['Brash', 'Focused']);
     expect(saunoja.upkeep).toBe(SAUNOJA_DEFAULT_UPKEEP);
     expect(saunoja.xp).toBe(0);
+    expect(saunoja.baseStats.health).toBe(1);
+    expect(saunoja.equipment.weapon).toBeNull();
     randomSpy.mockRestore();
   });
 
@@ -131,9 +136,10 @@ describe('makeSaunoja', () => {
         description: 'Ignites targets on hit',
         icon: '/assets/items/emberglass.svg',
         rarity: 'rare',
-        quantity: 3
+        quantity: 1
       }
     ]);
+    expect(saunoja.equipment.weapon?.id).toBe('emberglass-arrow');
     expect(saunoja.modifiers).toEqual([
       {
         id: 'barkskin-ritual',


### PR DESCRIPTION
## Summary
- add a dedicated items module that tracks slot metadata, modifiers, and equip/unequip helpers
- extend Saunoja data, storage, and stat calculations while wiring game and inventory flows to the new equipment system
- refresh the roster panel UI with slot controls, CSS polish, and updated Vitest coverage

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ccef1f6c248330b63127f376c9a4ca