### PR TITLE
Add stash inventory panel and selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   `src/game.ts`, refreshes roster storage plus calculations, polishes the
   roster panel UI with per-slot controls, and covers the flow with Vitest
   suites.
+- Rebuild the inventory HUD with a responsive stash panel suite in
+  `src/ui/stash/`, derived selectors from `src/state/inventory.ts`, expanded
+  `InventoryState` transfer/equip events, comparison-driven quick actions,
+  polished CSS modules, and Vitest coverage for selectors and the panel
+  behaviour.
 - Rebuild the GitHub Pages mirror from commit 8f618f4 so the hashed Vite
   bundle, published HTML, and build badge all advertise the latest deploy.
 - Introduce a guided HUD tutorial with spotlight tooltips, keyboard navigation,

--- a/src/inventory/state.test.ts
+++ b/src/inventory/state.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { InventoryState } from './state.ts';
+import {
+  InventoryState,
+  type InventoryEvent,
+  type InventoryComparison,
+  type EquipAttemptResult
+} from './state.ts';
 
 const SAMPLE_ITEM = {
   id: 'emberglass-arrow',
@@ -31,6 +36,7 @@ describe('InventoryState', () => {
     const inventory = new InventoryState({ now: () => 500 });
     const receipt = inventory.addItem(SAMPLE_ITEM, { unitId: 's1', equip });
     expect(receipt.equipped).toBe(true);
+    expect(receipt.location).toBe('equipped');
     expect(equip).toHaveBeenCalledTimes(1);
     expect(inventory.getStashSize()).toBe(0);
   });
@@ -40,6 +46,7 @@ describe('InventoryState', () => {
     const inventory = new InventoryState({ now: () => 600, autoEquip: false });
     const receipt = inventory.addItem(SAMPLE_ITEM, { unitId: 's1', equip });
     expect(receipt.equipped).toBe(false);
+    expect(receipt.location).toBe('stash');
     expect(inventory.getStashSize()).toBe(1);
   });
 
@@ -48,17 +55,20 @@ describe('InventoryState', () => {
     const inventory = new InventoryState({ now: () => 700 });
     inventory.addItem(SAMPLE_ITEM, { autoEquip: false });
 
-    const events: string[] = [];
+    const events: InventoryEvent[] = [];
     const stop = inventory.on((event) => {
-      events.push(event.type);
+      events.push(event);
     });
 
     const equipped = inventory.equipFromStash(0, 's1', equip);
     expect(equipped).toBe(true);
     expect(equip).toHaveBeenCalledWith('s1', expect.objectContaining({ id: 'emberglass-arrow' }));
     expect(inventory.getStashSize()).toBe(0);
-    expect(events).toContain('item-equipped');
-    expect(events).toContain('stash-updated');
+    expect(events.map((event) => event.type)).toContain('item-equipped');
+    const equipEvent = events.find((event) => event.type === 'item-equipped');
+    expect(equipEvent).toBeDefined();
+    expect(equipEvent?.from).toBe('stash');
+    expect(equipEvent?.comparison).toBeUndefined();
     stop();
   });
 
@@ -75,16 +85,63 @@ describe('InventoryState', () => {
     const unequip = vi
       .fn()
       .mockReturnValue({ id: 'glacier-brand', name: 'Glacier Brand', quantity: 1 });
-    const events: string[] = [];
+    const events: InventoryEvent[] = [];
     const stop = inventory.on((event) => {
-      events.push(event.type);
+      events.push(event);
     });
 
     const success = inventory.unequipToStash('unit-1', 'weapon', unequip);
     expect(success).toBe(true);
     expect(unequip).toHaveBeenCalledWith('unit-1', 'weapon');
     expect(inventory.getStashSize()).toBe(1);
-    expect(events).toContain('item-unequipped');
+    const event = events.find((entry) => entry.type === 'item-unequipped');
+    expect(event?.to).toBe('stash');
     stop();
+  });
+
+  it('moves items between stash and ready inventory', () => {
+    const inventory = new InventoryState({ now: () => 1100 });
+    inventory.addItem(SAMPLE_ITEM, { autoEquip: false });
+    const moved = inventory.moveToInventory(0);
+    expect(moved?.id).toBe('emberglass-arrow');
+    expect(inventory.getInventory()).toHaveLength(1);
+    const restored = inventory.moveToStash(0);
+    expect(restored?.id).toBe('emberglass-arrow');
+    expect(inventory.getInventory()).toHaveLength(0);
+    expect(inventory.getStash()).toHaveLength(1);
+  });
+
+  it('supports equipping from the ready inventory and emits comparison data', () => {
+    const comparison: InventoryComparison = {
+      slot: 'weapon',
+      previous: null,
+      next: { id: 'emberglass-arrow', name: 'Emberglass Arrow', quantity: 2, rarity: 'rare' },
+      deltas: [{ stat: 'attackDamage', delta: 2 }]
+    };
+    const equipResult = { success: true, comparison } satisfies EquipAttemptResult;
+    const equip = vi.fn().mockReturnValue(equipResult);
+    const inventory = new InventoryState({ now: () => 1200 });
+    inventory.addItem(SAMPLE_ITEM, { autoEquip: false });
+    inventory.moveToInventory(0);
+
+    const events: InventoryEvent[] = [];
+    const stop = inventory.on((event) => events.push(event));
+
+    const success = inventory.equipFromInventory(0, 's1', equip);
+    expect(success).toBe(true);
+    expect(inventory.getInventory()).toHaveLength(0);
+    const equipEvent = events.find((event) => event.type === 'item-equipped');
+    expect(equipEvent?.from).toBe('inventory');
+    expect(equipEvent?.comparison).toEqual(comparison);
+    stop();
+  });
+
+  it('discards items from the ready inventory', () => {
+    const inventory = new InventoryState({ now: () => 1300 });
+    inventory.addItem(SAMPLE_ITEM, { autoEquip: false });
+    inventory.moveToInventory(0);
+    const removed = inventory.discardFromInventory(0);
+    expect(removed?.id).toBe('emberglass-arrow');
+    expect(inventory.getInventory()).toHaveLength(0);
   });
 });

--- a/src/inventory/state.ts
+++ b/src/inventory/state.ts
@@ -2,6 +2,44 @@ import type { RolledLootItem } from '../loot/roll.ts';
 import type { SaunojaItem } from '../units/saunoja.ts';
 import type { EquipmentSlotId } from '../items/types.ts';
 
+export type InventoryCollection = 'stash' | 'inventory';
+
+export type InventoryLocation = InventoryCollection | 'equipped';
+
+export type InventoryStatId =
+  | 'health'
+  | 'attackDamage'
+  | 'attackRange'
+  | 'movementRange'
+  | 'defense'
+  | 'shield';
+
+export interface InventoryItemSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly quantity: number;
+  readonly rarity?: string;
+}
+
+export interface InventoryStatDelta {
+  readonly stat: InventoryStatId;
+  readonly delta: number;
+}
+
+export interface InventoryComparison {
+  readonly slot: EquipmentSlotId | null;
+  readonly previous: InventoryItemSummary | null;
+  readonly next: InventoryItemSummary | null;
+  readonly deltas: readonly InventoryStatDelta[];
+  readonly reason?: string;
+}
+
+export interface EquipAttemptResult {
+  readonly success: boolean;
+  readonly comparison?: InventoryComparison;
+  readonly reason?: string;
+}
+
 export interface InventoryItem extends SaunojaItem {
   readonly acquiredAt: number;
   readonly sourceTableId?: string;
@@ -13,31 +51,51 @@ export type InventoryEvent =
       readonly type: 'item-acquired';
       readonly item: InventoryItem;
       readonly equipped: boolean;
+      readonly location: InventoryLocation;
       readonly unitId?: string;
       readonly stashSize: number;
+      readonly inventorySize: number;
     }
   | {
       readonly type: 'item-equipped';
       readonly item: InventoryItem;
       readonly unitId: string;
-      readonly fromStash: boolean;
+      readonly from: InventoryCollection;
       readonly stashSize: number;
+      readonly inventorySize: number;
+      readonly comparison?: InventoryComparison;
     }
   | {
       readonly type: 'item-unequipped';
       readonly item: InventoryItem;
       readonly unitId: string;
       readonly slot: EquipmentSlotId;
+      readonly to: InventoryCollection;
       readonly stashSize: number;
+      readonly inventorySize: number;
     }
   | {
       readonly type: 'item-discarded';
       readonly item: InventoryItem;
+      readonly location: InventoryCollection;
       readonly stashSize: number;
+      readonly inventorySize: number;
+    }
+  | {
+      readonly type: 'item-moved';
+      readonly item: InventoryItem;
+      readonly from: InventoryCollection;
+      readonly to: InventoryCollection;
+      readonly stashSize: number;
+      readonly inventorySize: number;
     }
   | {
       readonly type: 'stash-updated';
       readonly stash: readonly InventoryItem[];
+    }
+  | {
+      readonly type: 'inventory-updated';
+      readonly inventory: readonly InventoryItem[];
     }
   | {
       readonly type: 'settings-updated';
@@ -58,18 +116,21 @@ export interface AcquisitionOptions {
   readonly autoEquip?: boolean;
   readonly sourceTableId?: string;
   readonly sourceEntryId?: string;
-  readonly equip?: (unitId: string, item: SaunojaItem) => boolean;
+  readonly equip?: (unitId: string, item: InventoryItem) => boolean | EquipAttemptResult;
 }
 
 export interface InventoryReceipt {
   readonly item: InventoryItem;
   readonly equipped: boolean;
   readonly stashIndex?: number;
+  readonly inventoryIndex?: number;
+  readonly location: InventoryLocation;
 }
 
 type SerializedInventory = {
   readonly autoEquip?: boolean;
   readonly stash?: readonly (InventoryItem & { readonly acquiredAt: number })[];
+  readonly inventory?: readonly (InventoryItem & { readonly acquiredAt: number })[];
 };
 
 function getStorage(): Storage | null {
@@ -128,6 +189,7 @@ export class InventoryState {
 
   private autoEquip: boolean;
   private stash: InventoryItem[] = [];
+  private inventory: InventoryItem[] = [];
 
   constructor(options: InventoryStateOptions = {}) {
     this.storageKey = options.storageKey ?? 'autobattles:inventory';
@@ -177,6 +239,37 @@ export class InventoryState {
       }
       this.stash = restored.slice(0, this.maxStashSize);
     }
+
+    if (Array.isArray(data.inventory)) {
+      const restoredInventory: InventoryItem[] = [];
+      for (const entry of data.inventory) {
+        if (!entry || typeof entry !== 'object') {
+          continue;
+        }
+        const { id, name, quantity } = entry as InventoryItem;
+        if (typeof id !== 'string' || typeof name !== 'string') {
+          continue;
+        }
+        const timestamp = Number.isFinite(entry.acquiredAt)
+          ? (entry.acquiredAt as number)
+          : this.now();
+        restoredInventory.push(
+          sanitizeItem(
+            {
+              id,
+              name,
+              description: entry.description,
+              icon: entry.icon,
+              rarity: entry.rarity,
+              quantity
+            },
+            timestamp,
+            { tableId: entry.sourceTableId, entryId: entry.sourceEntryId }
+          )
+        );
+      }
+      this.inventory = restoredInventory;
+    }
   }
 
   private persist(): void {
@@ -185,7 +278,8 @@ export class InventoryState {
     }
     const payload: SerializedInventory = {
       autoEquip: this.autoEquip,
-      stash: this.stash.map((item) => ({ ...item }))
+      stash: this.stash.map((item) => ({ ...item })),
+      inventory: this.inventory.map((item) => ({ ...item }))
     };
     try {
       this.storage.setItem(this.storageKey, JSON.stringify(payload));
@@ -198,6 +292,20 @@ export class InventoryState {
     for (const listener of this.listeners) {
       listener(event);
     }
+  }
+
+  private normalizeEquipResult(result: boolean | EquipAttemptResult): EquipAttemptResult {
+    if (typeof result === 'boolean') {
+      return { success: result } satisfies EquipAttemptResult;
+    }
+    if (!result || typeof result !== 'object') {
+      return { success: false } satisfies EquipAttemptResult;
+    }
+    return {
+      success: Boolean(result.success),
+      comparison: result.comparison,
+      reason: result.reason
+    } satisfies EquipAttemptResult;
   }
 
   on(listener: InventoryListener): () => void {
@@ -228,6 +336,14 @@ export class InventoryState {
     return this.stash.length;
   }
 
+  getInventory(): readonly InventoryItem[] {
+    return this.inventory.map((item) => ({ ...item }));
+  }
+
+  getInventorySize(): number {
+    return this.inventory.length;
+  }
+
   addLoot(drop: RolledLootItem, options: AcquisitionOptions = {}): InventoryReceipt {
     return this.addItem({ ...drop.item }, {
       ...options,
@@ -243,24 +359,31 @@ export class InventoryState {
       entryId: options.sourceEntryId
     });
     const preferEquip = options.autoEquip ?? this.autoEquip;
-    let equipped = false;
+    let equipOutcome: EquipAttemptResult = { success: false };
 
     if (preferEquip && options.unitId && typeof options.equip === 'function') {
       try {
-        equipped = options.equip(options.unitId, entry);
+        equipOutcome = this.normalizeEquipResult(options.equip(options.unitId, entry));
       } catch (error) {
         console.warn('Failed to auto-equip inventory item', { item: entry, error });
+        equipOutcome = { success: false } satisfies EquipAttemptResult;
       }
-      if (equipped) {
+      if (equipOutcome.success) {
+        this.persist();
         this.emit({
           type: 'item-acquired',
           item: entry,
           equipped: true,
+          location: 'equipped',
           unitId: options.unitId,
-          stashSize: this.stash.length
+          stashSize: this.stash.length,
+          inventorySize: this.inventory.length
         });
-        this.persist();
-        return { item: entry, equipped: true } satisfies InventoryReceipt;
+        return {
+          item: entry,
+          equipped: true,
+          location: 'equipped'
+        } satisfies InventoryReceipt;
       }
     }
 
@@ -278,24 +401,35 @@ export class InventoryState {
       item: entry,
       equipped: false,
       unitId: options.unitId,
-      stashSize: this.stash.length
+      location: 'stash',
+      stashSize: this.stash.length,
+      inventorySize: this.inventory.length
     });
-    return { item: entry, equipped: false, stashIndex: this.stash.length - 1 } satisfies InventoryReceipt;
+    return {
+      item: entry,
+      equipped: false,
+      location: 'stash',
+      stashIndex: this.stash.length - 1
+    } satisfies InventoryReceipt;
   }
 
-  equipFromStash(index: number, unitId: string, equip: (unitId: string, item: SaunojaItem) => boolean): boolean {
+  equipFromStash(
+    index: number,
+    unitId: string,
+    equip: (unitId: string, item: InventoryItem) => boolean | EquipAttemptResult
+  ): boolean {
     if (index < 0 || index >= this.stash.length) {
       return false;
     }
     const target = this.stash[index];
-    let equipped = false;
+    let outcome: EquipAttemptResult = { success: false };
     try {
-      equipped = equip(unitId, target);
+      outcome = this.normalizeEquipResult(equip(unitId, target));
     } catch (error) {
       console.warn('Failed to equip stash item', { item: target, error });
-      equipped = false;
+      outcome = { success: false } satisfies EquipAttemptResult;
     }
-    if (!equipped) {
+    if (!outcome.success) {
       return false;
     }
     const [removed] = this.stash.splice(index, 1);
@@ -305,10 +439,109 @@ export class InventoryState {
       type: 'item-equipped',
       item: removed,
       unitId,
-      fromStash: true,
-      stashSize: this.stash.length
+      from: 'stash',
+      stashSize: this.stash.length,
+      inventorySize: this.inventory.length,
+      comparison: outcome.comparison
     });
     return true;
+  }
+
+  equipFromInventory(
+    index: number,
+    unitId: string,
+    equip: (unitId: string, item: InventoryItem) => boolean | EquipAttemptResult
+  ): boolean {
+    if (index < 0 || index >= this.inventory.length) {
+      return false;
+    }
+    const target = this.inventory[index];
+    let outcome: EquipAttemptResult = { success: false };
+    try {
+      outcome = this.normalizeEquipResult(equip(unitId, target));
+    } catch (error) {
+      console.warn('Failed to equip inventory item', { item: target, error });
+      outcome = { success: false } satisfies EquipAttemptResult;
+    }
+    if (!outcome.success) {
+      return false;
+    }
+    const [removed] = this.inventory.splice(index, 1);
+    this.persist();
+    this.emit({ type: 'inventory-updated', inventory: this.getInventory() });
+    this.emit({
+      type: 'item-equipped',
+      item: removed,
+      unitId,
+      from: 'inventory',
+      stashSize: this.stash.length,
+      inventorySize: this.inventory.length,
+      comparison: outcome.comparison
+    });
+    return true;
+  }
+
+  moveToInventory(index: number): InventoryItem | null {
+    if (index < 0 || index >= this.stash.length) {
+      return null;
+    }
+    const [moved] = this.stash.splice(index, 1);
+    this.inventory.push(moved);
+    this.persist();
+    this.emit({ type: 'stash-updated', stash: this.getStash() });
+    this.emit({ type: 'inventory-updated', inventory: this.getInventory() });
+    this.emit({
+      type: 'item-moved',
+      item: moved,
+      from: 'stash',
+      to: 'inventory',
+      stashSize: this.stash.length,
+      inventorySize: this.inventory.length
+    });
+    return moved;
+  }
+
+  moveToStash(index: number): InventoryItem | null {
+    if (this.stash.length >= this.maxStashSize) {
+      return null;
+    }
+    if (index < 0 || index >= this.inventory.length) {
+      return null;
+    }
+    const [moved] = this.inventory.splice(index, 1);
+    this.stash.push(moved);
+    if (this.stash.length > this.maxStashSize) {
+      this.stash.splice(0, this.stash.length - this.maxStashSize);
+    }
+    this.persist();
+    this.emit({ type: 'inventory-updated', inventory: this.getInventory() });
+    this.emit({ type: 'stash-updated', stash: this.getStash() });
+    this.emit({
+      type: 'item-moved',
+      item: moved,
+      from: 'inventory',
+      to: 'stash',
+      stashSize: this.stash.length,
+      inventorySize: this.inventory.length
+    });
+    return moved;
+  }
+
+  discardFromInventory(index: number): InventoryItem | null {
+    if (index < 0 || index >= this.inventory.length) {
+      return null;
+    }
+    const [removed] = this.inventory.splice(index, 1);
+    this.persist();
+    this.emit({ type: 'inventory-updated', inventory: this.getInventory() });
+    this.emit({
+      type: 'item-discarded',
+      item: removed,
+      location: 'inventory',
+      stashSize: this.stash.length,
+      inventorySize: this.inventory.length
+    });
+    return removed;
   }
 
   unequipToStash(
@@ -343,7 +576,9 @@ export class InventoryState {
       item: entry,
       unitId,
       slot,
-      stashSize: this.stash.length
+      to: 'stash',
+      stashSize: this.stash.length,
+      inventorySize: this.inventory.length
     });
     return true;
   }
@@ -355,7 +590,13 @@ export class InventoryState {
     const [removed] = this.stash.splice(index, 1);
     this.persist();
     this.emit({ type: 'stash-updated', stash: this.getStash() });
-    this.emit({ type: 'item-discarded', item: removed, stashSize: this.stash.length });
+    this.emit({
+      type: 'item-discarded',
+      item: removed,
+      location: 'stash',
+      stashSize: this.stash.length,
+      inventorySize: this.inventory.length
+    });
     return removed;
   }
 }

--- a/src/state/inventory.test.ts
+++ b/src/state/inventory.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultFilterState,
+  selectInventoryView,
+  type InventoryComparisonContext
+} from './inventory.ts';
+import type { InventoryItem } from '../inventory/state.ts';
+
+function createItem(id: string, name: string, acquiredAt: number, overrides: Partial<InventoryItem> = {}): InventoryItem {
+  return {
+    id,
+    name,
+    quantity: 1,
+    acquiredAt,
+    ...overrides
+  } as InventoryItem;
+}
+
+describe('selectInventoryView', () => {
+  it('filters items by slot, rarity, and tags', () => {
+    const stash: InventoryItem[] = [
+      createItem('glacier-brand', 'Glacier Brand', 1000, { rarity: 'rare' }),
+      createItem('midnight-bloodwine', 'Midnight Bloodwine', 1200, { rarity: 'epic' })
+    ];
+    const filters = createDefaultFilterState();
+    (filters.slots as Set<string>).add('weapon');
+    (filters.rarities as Set<string>).add('rare');
+    const view = selectInventoryView({
+      stash,
+      inventory: [],
+      filters,
+      search: '',
+      sort: 'newest',
+      page: 1,
+      pageSize: 24,
+      collection: 'stash',
+      comparisonContext: null
+    });
+    expect(view.items).toHaveLength(1);
+    expect(view.items[0]?.item.id).toBe('glacier-brand');
+  });
+
+  it('searches items by name and description', () => {
+    const stash: InventoryItem[] = [
+      createItem('aurora-distillate', 'Aurora Distillate', 1000, {
+        description: 'infuses defense'
+      }),
+      createItem('emberglass-arrow', 'Emberglass Arrow', 1100)
+    ];
+    const filters = createDefaultFilterState();
+    const view = selectInventoryView({
+      stash,
+      inventory: [],
+      filters,
+      search: 'defense',
+      sort: 'newest',
+      page: 1,
+      pageSize: 24,
+      collection: 'stash',
+      comparisonContext: null
+    });
+    expect(view.items).toHaveLength(1);
+    expect(view.items[0]?.item.id).toBe('aurora-distillate');
+  });
+
+  it('sorts items alphabetically', () => {
+    const stash: InventoryItem[] = [
+      createItem('midnight-bloodwine', 'Midnight Bloodwine', 1000),
+      createItem('aurora-distillate', 'Aurora Distillate', 1200)
+    ];
+    const filters = createDefaultFilterState();
+    const view = selectInventoryView({
+      stash,
+      inventory: [],
+      filters,
+      search: '',
+      sort: 'name',
+      page: 1,
+      pageSize: 24,
+      collection: 'stash',
+      comparisonContext: null
+    });
+    expect(view.items.map((entry) => entry.item.name)).toEqual([
+      'Aurora Distillate',
+      'Midnight Bloodwine'
+    ]);
+  });
+
+  it('paginates large result sets', () => {
+    const stash: InventoryItem[] = [
+      createItem('aurora-distillate', 'Aurora Distillate', 1000),
+      createItem('midnight-bloodwine', 'Midnight Bloodwine', 900)
+    ];
+    const filters = createDefaultFilterState();
+    const view = selectInventoryView({
+      stash,
+      inventory: [],
+      filters,
+      search: '',
+      sort: 'newest',
+      page: 1,
+      pageSize: 1,
+      collection: 'stash',
+      comparisonContext: null
+    });
+    expect(view.items).toHaveLength(1);
+    expect(view.hasMore).toBe(true);
+  });
+
+  it('produces comparison previews using loadout context', () => {
+    const stash: InventoryItem[] = [
+      createItem('glacier-brand', 'Glacier Brand', 1000, { rarity: 'rare' }),
+      createItem('emberglass-arrow', 'Emberglass Arrow', 1100, { rarity: 'rare', quantity: 1 })
+    ];
+    const filters = createDefaultFilterState();
+    const context: InventoryComparisonContext = {
+      baseStats: {
+        health: 10,
+        attackDamage: 2,
+        attackRange: 1,
+        movementRange: 3
+      },
+      loadout: [
+        {
+          id: 'emberglass-arrow',
+          name: 'Emberglass Arrow',
+          description: 'Ignites targets on impact',
+          icon: undefined,
+          rarity: 'rare',
+          quantity: 1,
+          slot: 'weapon',
+          maxStacks: 1,
+          modifiers: { attackDamage: 1, attackRange: 1 }
+        }
+      ],
+      currentStats: {
+        health: 10,
+        attackDamage: 3,
+        attackRange: 2,
+        movementRange: 3
+      }
+    };
+    const view = selectInventoryView({
+      stash,
+      inventory: [],
+      filters,
+      search: '',
+      sort: 'newest',
+      page: 1,
+      pageSize: 24,
+      collection: 'stash',
+      comparisonContext: context
+    });
+    const glacierPreview = view.items.find((entry) => entry.item.id === 'glacier-brand')?.comparison;
+    expect(glacierPreview?.canEquip).toBe(false);
+    expect(glacierPreview?.reason).toBe('slot-occupied');
+    const emberPreview = view.items.find((entry) => entry.item.id === 'emberglass-arrow')?.comparison;
+    expect(emberPreview?.canEquip).toBe(true);
+    const attackDelta = emberPreview?.stats.find((stat) => stat.stat === 'attackDamage');
+    expect(attackDelta?.delta).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/state/inventory.ts
+++ b/src/state/inventory.ts
@@ -1,0 +1,576 @@
+import type {
+  InventoryCollection,
+  InventoryItem,
+  InventoryItemSummary,
+  InventoryStatId
+} from '../inventory/state.ts';
+import { getItemDefinition, getSlotDefinition } from '../items/equip.ts';
+import {
+  EQUIPMENT_SLOT_IDS,
+  type EquipmentSlotId,
+  type EquippedItem,
+  type EquipmentModifier
+} from '../items/types.ts';
+import type { SaunojaStatBlock } from '../units/saunoja.ts';
+import { applyEquipment } from '../unit/calc.ts';
+
+export type InventorySort = 'newest' | 'oldest' | 'rarity' | 'name';
+
+export interface InventoryFilterState {
+  readonly slots: ReadonlySet<string>;
+  readonly rarities: ReadonlySet<string>;
+  readonly tags: ReadonlySet<string>;
+}
+
+export interface FilterChip {
+  readonly id: string;
+  readonly label: string;
+  readonly count: number;
+  readonly active: boolean;
+}
+
+export interface InventoryComparisonContext {
+  readonly baseStats: SaunojaStatBlock;
+  readonly loadout: readonly EquippedItem[];
+  readonly currentStats?: SaunojaStatBlock;
+}
+
+export interface InventoryStatProjection {
+  readonly stat: InventoryStatId;
+  readonly delta: number;
+  readonly current: number;
+  readonly projected: number;
+}
+
+export interface InventoryComparisonPreview {
+  readonly slot: EquipmentSlotId | null;
+  readonly canEquip: boolean;
+  readonly reason?: string;
+  readonly equipped: InventoryItemSummary | null;
+  readonly projected: InventoryItemSummary | null;
+  readonly stats: readonly InventoryStatProjection[];
+}
+
+export interface InventoryItemMetadata {
+  readonly slot: EquipmentSlotId | null;
+  readonly slotLabel: string;
+  readonly rarity: string;
+  readonly rarityRank: number;
+  readonly tags: readonly string[];
+  readonly acquiredAt: number;
+}
+
+export interface InventoryListItemView {
+  readonly item: InventoryItem;
+  readonly index: number;
+  readonly location: InventoryCollection;
+  readonly metadata: InventoryItemMetadata;
+  readonly comparison: InventoryComparisonPreview | null;
+}
+
+export interface InventoryCollectionSummary {
+  readonly id: InventoryCollection;
+  readonly label: string;
+  readonly count: number;
+  readonly active: boolean;
+}
+
+export interface InventoryFilterGroups {
+  readonly slots: readonly FilterChip[];
+  readonly rarities: readonly FilterChip[];
+  readonly tags: readonly FilterChip[];
+}
+
+export interface InventoryPanelView {
+  readonly collection: InventoryCollection;
+  readonly collections: readonly InventoryCollectionSummary[];
+  readonly filters: InventoryFilterGroups;
+  readonly items: readonly InventoryListItemView[];
+  readonly total: number;
+  readonly filteredTotal: number;
+  readonly search: string;
+  readonly sort: InventorySort;
+  readonly hasMore: boolean;
+  readonly emptyMessage: string;
+}
+
+export interface InventorySelectorParams {
+  readonly stash: readonly InventoryItem[];
+  readonly inventory: readonly InventoryItem[];
+  readonly filters: InventoryFilterState;
+  readonly search: string;
+  readonly sort: InventorySort;
+  readonly page: number;
+  readonly pageSize: number;
+  readonly collection: InventoryCollection;
+  readonly comparisonContext?: InventoryComparisonContext | null;
+}
+
+const COLLECTION_LABELS: Record<InventoryCollection, string> = {
+  stash: 'Quartermaster Stash',
+  inventory: 'Ready Inventory'
+};
+
+const EMPTY_MESSAGES: Record<InventoryCollection, string> = {
+  stash: 'Your stash is empty. Conquer enemy elites to gather new equipment.',
+  inventory: 'No gear staged. Move items into the ready inventory for quick equipping.'
+};
+
+const RARITY_ORDER: Record<string, number> = {
+  mythic: 6,
+  legendary: 5,
+  epic: 4,
+  rare: 3,
+  uncommon: 2,
+  common: 1
+};
+
+const STAT_KEYS: readonly InventoryStatId[] = [
+  'health',
+  'attackDamage',
+  'attackRange',
+  'movementRange',
+  'defense',
+  'shield'
+];
+
+const ITEM_TAGS: Record<string, readonly string[]> = {
+  'birch-sap-satchel': ['healing', 'support'],
+  'steamed-bandages': ['restoration', 'shielding'],
+  'aurora-distillate': ['damage', 'defense'],
+  'stolen-sauna-tokens': ['mobility'],
+  'midnight-bloodwine': ['healing', 'damage'],
+  'sauna-incense': ['range', 'focus'],
+  'glacier-brand': ['damage'],
+  'emberglass-arrow': ['damage', 'range'],
+  'aurora-lattice': ['damage', 'range'],
+  'emberglass-shard': ['damage', 'mobility'],
+  'windstep-totem': ['mobility', 'defense'],
+  'searing-chant-censer': ['damage', 'shielding'],
+  'cracked-ice-amulet': ['defense'],
+  'myrsky-charm': ['range', 'defense'],
+  'frostwyrm-signet': ['shielding'],
+  'spirit-oak-charm': ['healing', 'defense']
+};
+
+function normalizeToken(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+function normalizeSet(source: ReadonlySet<string>): Set<string> {
+  const next = new Set<string>();
+  for (const entry of source) {
+    const normalized = normalizeToken(entry);
+    if (normalized) {
+      next.add(normalized);
+    }
+  }
+  return next;
+}
+
+function summarizeInventoryItem(item: InventoryItem, quantity?: number): InventoryItemSummary {
+  return {
+    id: item.id,
+    name: item.name,
+    quantity: typeof quantity === 'number' ? quantity : item.quantity,
+    rarity: item.rarity
+  } satisfies InventoryItemSummary;
+}
+
+function summarizeEquippedItem(item: EquippedItem | null): InventoryItemSummary | null {
+  if (!item) {
+    return null;
+  }
+  return {
+    id: item.id,
+    name: item.name,
+    quantity: item.quantity,
+    rarity: item.rarity
+  } satisfies InventoryItemSummary;
+}
+
+function resolveTags(itemId: string): readonly string[] {
+  return ITEM_TAGS[itemId] ?? [];
+}
+
+function resolveRarity(value?: string | null): { key: string; label: string; rank: number } {
+  const normalized = normalizeToken(value) || 'common';
+  const label = normalized.charAt(0).toUpperCase() + normalized.slice(1);
+  return {
+    key: normalized,
+    label,
+    rank: RARITY_ORDER[normalized] ?? 0
+  };
+}
+
+function resolveMetadata(item: InventoryItem): InventoryItemMetadata {
+  const definition = getItemDefinition(item.id);
+  if (!definition) {
+    const rarity = resolveRarity(item.rarity);
+    return {
+      slot: null,
+      slotLabel: 'Unassigned',
+      rarity: rarity.key,
+      rarityRank: rarity.rank,
+      tags: resolveTags(item.id),
+      acquiredAt: item.acquiredAt
+    } satisfies InventoryItemMetadata;
+  }
+  const slotDef = getSlotDefinition(definition.slot);
+  const rarity = resolveRarity(item.rarity);
+  return {
+    slot: definition.slot,
+    slotLabel: slotDef.label,
+    rarity: rarity.key,
+    rarityRank: rarity.rank,
+    tags: resolveTags(item.id),
+    acquiredAt: item.acquiredAt
+  } satisfies InventoryItemMetadata;
+}
+
+function toEquippedItem(
+  item: InventoryItem,
+  slot: EquipmentSlotId,
+  maxStacks: number,
+  modifiers: EquipmentModifier | undefined,
+  quantity: number
+): EquippedItem {
+  return {
+    id: item.id,
+    name: item.name,
+    description: item.description,
+    icon: item.icon,
+    rarity: item.rarity,
+    quantity,
+    slot,
+    maxStacks,
+    modifiers: modifiers ?? ({} as EquipmentModifier)
+  } satisfies EquippedItem;
+}
+
+function resolveStatValue(stats: SaunojaStatBlock, key: InventoryStatId): number {
+  const value = stats[key as keyof SaunojaStatBlock];
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.round(value as number);
+  }
+  return 0;
+}
+
+function buildComparison(
+  record: InternalRecord,
+  context: InventoryComparisonContext
+): InventoryComparisonPreview {
+  const definition = getItemDefinition(record.item.id);
+  if (!definition) {
+    return {
+      slot: null,
+      canEquip: false,
+      reason: 'unknown-item',
+      equipped: null,
+      projected: summarizeInventoryItem(record.item),
+      stats: []
+    } satisfies InventoryComparisonPreview;
+  }
+
+  const slot = definition.slot;
+  const slotDef = getSlotDefinition(slot);
+  const existing = context.loadout.find((entry) => entry.slot === slot) ?? null;
+  const incomingQuantity = Math.max(1, Math.round(record.item.quantity));
+  const maxStacks = Math.max(1, Math.floor(definition.maxStacks ?? slotDef.maxStacks));
+  const totalQuantity = (existing?.quantity ?? 0) + incomingQuantity;
+  const overflow = totalQuantity > maxStacks;
+
+  if (existing && existing.id !== record.item.id) {
+    return {
+      slot,
+      canEquip: false,
+      reason: 'slot-occupied',
+      equipped: summarizeEquippedItem(existing),
+      projected: summarizeInventoryItem(record.item),
+      stats: []
+    } satisfies InventoryComparisonPreview;
+  }
+
+  if (overflow && (!existing || existing.id !== record.item.id)) {
+    return {
+      slot,
+      canEquip: false,
+      reason: 'stack-limit',
+      equipped: summarizeEquippedItem(existing),
+      projected: summarizeInventoryItem(
+        record.item,
+        Math.min(maxStacks, totalQuantity)
+      ),
+      stats: []
+    } satisfies InventoryComparisonPreview;
+  }
+
+  const nextQuantity = Math.min(maxStacks, totalQuantity);
+  const nextLoadout: EquippedItem[] = [];
+  for (const entry of context.loadout) {
+    if (entry.slot === slot) {
+      continue;
+    }
+    nextLoadout.push({ ...entry });
+  }
+  const projected =
+    existing && existing.id === record.item.id
+      ? { ...existing, quantity: nextQuantity }
+      : toEquippedItem(record.item, slot, maxStacks, definition.modifiers, nextQuantity);
+  nextLoadout.push(projected);
+
+  const currentStats = context.currentStats ?? applyEquipment(context.baseStats, context.loadout);
+  const projectedStats = applyEquipment(context.baseStats, nextLoadout);
+
+  const stats: InventoryStatProjection[] = STAT_KEYS.map((key) => {
+    const current = resolveStatValue(currentStats, key);
+    const projectedValue = resolveStatValue(projectedStats, key);
+    return {
+      stat: key,
+      current,
+      projected: projectedValue,
+      delta: projectedValue - current
+    } satisfies InventoryStatProjection;
+  });
+
+  return {
+    slot,
+    canEquip: true,
+    equipped: summarizeEquippedItem(existing),
+    projected: summarizeEquippedItem(projected),
+    stats
+  } satisfies InventoryComparisonPreview;
+}
+
+interface InternalRecord {
+  readonly item: InventoryItem;
+  readonly index: number;
+  readonly location: InventoryCollection;
+  readonly metadata: InventoryItemMetadata;
+}
+
+function buildRecords(
+  items: readonly InventoryItem[],
+  location: InventoryCollection
+): InternalRecord[] {
+  return items.map((item, index) => ({
+    item,
+    index,
+    location,
+    metadata: resolveMetadata(item)
+  }));
+}
+
+function buildFilterChips(
+  records: readonly InternalRecord[],
+  filters: InventoryFilterState
+): InventoryFilterGroups {
+  const slotCounts = new Map<string, { label: string; count: number }>();
+  const rarityCounts = new Map<string, { label: string; count: number; rank: number }>();
+  const tagCounts = new Map<string, { label: string; count: number }>();
+
+  for (const record of records) {
+    const { metadata } = record;
+    if (metadata.slot) {
+      const key = metadata.slot;
+      const current = slotCounts.get(key);
+      if (current) {
+        current.count += 1;
+      } else {
+        slotCounts.set(key, { label: metadata.slotLabel, count: 1 });
+      }
+    }
+    const rarityLabel = metadata.rarity;
+    const rarityDisplay = rarityLabel.charAt(0).toUpperCase() + rarityLabel.slice(1);
+    const rarityCurrent = rarityCounts.get(rarityLabel);
+    if (rarityCurrent) {
+      rarityCurrent.count += 1;
+    } else {
+      rarityCounts.set(rarityLabel, {
+        label: rarityDisplay,
+        count: 1,
+        rank: metadata.rarityRank
+      });
+    }
+
+    for (const tag of metadata.tags) {
+      const normalized = normalizeToken(tag);
+      if (!normalized) {
+        continue;
+      }
+      const display = tag
+        .split(/[-_]/g)
+        .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+        .join(' ');
+      const tagEntry = tagCounts.get(normalized);
+      if (tagEntry) {
+        tagEntry.count += 1;
+      } else {
+        tagCounts.set(normalized, { label: display, count: 1 });
+      }
+    }
+  }
+
+  const slotFilter = Array.from(slotCounts.entries())
+    .sort((a, b) => {
+      const orderA = EQUIPMENT_SLOT_IDS.indexOf(a[0] as EquipmentSlotId);
+      const orderB = EQUIPMENT_SLOT_IDS.indexOf(b[0] as EquipmentSlotId);
+      return orderA - orderB;
+    })
+    .map(([id, data]) => ({
+      id,
+      label: data.label,
+      count: data.count,
+      active: filters.slots.has(normalizeToken(id))
+    } satisfies FilterChip));
+
+  const rarityFilter = Array.from(rarityCounts.entries())
+    .sort((a, b) => (b[1].rank ?? 0) - (a[1].rank ?? 0))
+    .map(([id, data]) => ({
+      id,
+      label: data.label,
+      count: data.count,
+      active: filters.rarities.has(normalizeToken(id))
+    } satisfies FilterChip));
+
+  const tagFilter = Array.from(tagCounts.entries())
+    .sort((a, b) => a[1].label.localeCompare(b[1].label))
+    .map(([id, data]) => ({
+      id,
+      label: data.label,
+      count: data.count,
+      active: filters.tags.has(normalizeToken(id))
+    } satisfies FilterChip));
+
+  return {
+    slots: slotFilter,
+    rarities: rarityFilter,
+    tags: tagFilter
+  } satisfies InventoryFilterGroups;
+}
+
+function matchesFilters(record: InternalRecord, filters: InventoryFilterState): boolean {
+  if (filters.slots.size > 0) {
+    const slotKey = record.metadata.slot ? normalizeToken(record.metadata.slot) : '';
+    if (!slotKey || !filters.slots.has(slotKey)) {
+      return false;
+    }
+  }
+  if (filters.rarities.size > 0) {
+    if (!filters.rarities.has(record.metadata.rarity)) {
+      return false;
+    }
+  }
+  if (filters.tags.size > 0) {
+    const tags = record.metadata.tags.map((tag) => normalizeToken(tag));
+    const hasMatch = tags.some((tag) => filters.tags.has(tag));
+    if (!hasMatch) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function matchesSearch(record: InternalRecord, query: string): boolean {
+  if (!query) {
+    return true;
+  }
+  const haystack = [
+    record.item.name,
+    record.item.description ?? '',
+    record.metadata.tags.join(' ')
+  ]
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(query);
+}
+
+function sortRecords(records: InternalRecord[], sort: InventorySort): void {
+  switch (sort) {
+    case 'oldest':
+      records.sort((a, b) => a.metadata.acquiredAt - b.metadata.acquiredAt);
+      break;
+    case 'rarity':
+      records.sort((a, b) => {
+        if (b.metadata.rarityRank !== a.metadata.rarityRank) {
+          return b.metadata.rarityRank - a.metadata.rarityRank;
+        }
+        return b.metadata.acquiredAt - a.metadata.acquiredAt;
+      });
+      break;
+    case 'name':
+      records.sort((a, b) => a.item.name.localeCompare(b.item.name));
+      break;
+    case 'newest':
+    default:
+      records.sort((a, b) => b.metadata.acquiredAt - a.metadata.acquiredAt);
+      break;
+  }
+}
+
+export function selectInventoryView(params: InventorySelectorParams): InventoryPanelView {
+  const filters: InventoryFilterState = {
+    slots: normalizeSet(params.filters.slots ?? new Set<string>()),
+    rarities: normalizeSet(params.filters.rarities ?? new Set<string>()),
+    tags: normalizeSet(params.filters.tags ?? new Set<string>())
+  };
+
+  const searchQuery = normalizeToken(params.search);
+  const page = Math.max(1, Math.floor(params.page || 1));
+  const pageSize = Math.max(1, Math.floor(params.pageSize || 24));
+  const collection: InventoryCollection = params.collection ?? 'stash';
+
+  const stashRecords = buildRecords(params.stash, 'stash');
+  const inventoryRecords = buildRecords(params.inventory, 'inventory');
+  const allRecords = [...stashRecords, ...inventoryRecords];
+
+  const filterGroups = buildFilterChips(allRecords, filters);
+
+  const sourceRecords = collection === 'stash' ? stashRecords : inventoryRecords;
+  const filtered = sourceRecords.filter(
+    (record) => matchesFilters(record, filters) && matchesSearch(record, searchQuery)
+  );
+  const sorted = [...filtered];
+  sortRecords(sorted, params.sort ?? 'newest');
+
+  const visibleCount = Math.min(sorted.length, page * pageSize);
+  const visibleRecords = sorted.slice(0, visibleCount);
+  const hasMore = sorted.length > visibleCount;
+
+  const context = params.comparisonContext ?? null;
+  const items: InventoryListItemView[] = visibleRecords.map((record) => ({
+    item: record.item,
+    index: record.index,
+    location: record.location,
+    metadata: record.metadata,
+    comparison: context ? buildComparison(record, context) : null
+  }));
+
+  const collections: InventoryCollectionSummary[] = (['stash', 'inventory'] as const).map((key) => ({
+    id: key,
+    label: COLLECTION_LABELS[key],
+    count: key === 'stash' ? params.stash.length : params.inventory.length,
+    active: key === collection
+  }));
+
+  return {
+    collection,
+    collections,
+    filters: filterGroups,
+    items,
+    total: sourceRecords.length,
+    filteredTotal: sorted.length,
+    search: params.search,
+    sort: params.sort ?? 'newest',
+    hasMore,
+    emptyMessage: EMPTY_MESSAGES[collection]
+  } satisfies InventoryPanelView;
+}
+
+export function createDefaultFilterState(): InventoryFilterState {
+  return {
+    slots: new Set<string>(),
+    rarities: new Set<string>(),
+    tags: new Set<string>()
+  } satisfies InventoryFilterState;
+}

--- a/src/style.d.ts
+++ b/src/style.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: Record<string, string>;
+  export default classes;
+}

--- a/src/ui/stash/Filters.module.css
+++ b/src/ui/stash/Filters.module.css
@@ -1,0 +1,59 @@
+.group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.group + .group {
+  margin-top: 0.35rem;
+}
+
+.label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(244, 248, 255, 0.58);
+  margin-bottom: 0.35rem;
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(244, 248, 255, 0.08);
+  color: rgba(244, 248, 255, 0.72);
+  border: none;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: transform 160ms ease, box-shadow 200ms ease, background 180ms ease;
+}
+
+.chip[data-active='true'] {
+  background: linear-gradient(110deg, rgba(82, 154, 255, 0.36), rgba(114, 188, 255, 0.52));
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(48, 128, 238, 0.35);
+}
+
+.chip:hover,
+.chip:focus-visible {
+  background: rgba(244, 248, 255, 0.16);
+}
+
+.chip:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.count {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(244, 248, 255, 0.58);
+}

--- a/src/ui/stash/ItemCard.module.css
+++ b/src/ui/stash/ItemCard.module.css
@@ -1,0 +1,233 @@
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: linear-gradient(155deg, rgba(32, 40, 55, 0.72), rgba(16, 20, 28, 0.9));
+  border: 1px solid rgba(120, 144, 182, 0.16);
+  box-shadow: 0 18px 36px rgba(8, 12, 22, 0.35);
+  transition: transform 160ms ease, box-shadow 220ms ease, border-color 160ms ease;
+  min-height: 196px;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-2px);
+  border-color: rgba(138, 176, 242, 0.45);
+  box-shadow: 0 28px 48px rgba(24, 42, 78, 0.55);
+}
+
+.card[data-location='inventory'] {
+  border-color: rgba(114, 188, 255, 0.34);
+}
+
+.header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: rgba(244, 248, 255, 0.08);
+  display: grid;
+  place-items: center;
+  color: rgba(244, 248, 255, 0.72);
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.titleRow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.rarity {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(244, 248, 255, 0.58);
+}
+
+.slot {
+  font-size: 0.8rem;
+  color: rgba(244, 248, 255, 0.62);
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.tag {
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(244, 248, 255, 0.08);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(244, 248, 255, 0.68);
+}
+
+.compare {
+  align-self: flex-start;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(94, 164, 255, 0.18);
+  color: rgba(186, 214, 255, 0.95);
+  font-size: 0.78rem;
+  cursor: pointer;
+  border: none;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.compare:hover,
+.compare:focus-visible {
+  background: rgba(94, 164, 255, 0.32);
+  color: #fff;
+}
+
+.tooltip {
+  position: absolute;
+  inset: auto auto calc(100% + 12px) 0;
+  min-width: 240px;
+  max-width: 320px;
+  background: rgba(8, 12, 22, 0.95);
+  border-radius: 12px;
+  border: 1px solid rgba(102, 168, 255, 0.35);
+  padding: 0.75rem 0.9rem;
+  box-shadow: 0 18px 34px rgba(8, 18, 32, 0.6);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(0, 6px, 0);
+  transition: opacity 140ms ease, transform 180ms ease;
+  z-index: 4;
+}
+
+.compare:focus-visible + .tooltip,
+.compare:hover + .tooltip {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0);
+}
+
+.tooltip h4 {
+  margin: 0 0 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(186, 214, 255, 0.96);
+}
+
+.statList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.stat {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: rgba(244, 248, 255, 0.75);
+}
+
+.stat[data-delta='positive'] {
+  color: rgba(116, 221, 164, 0.95);
+}
+
+.stat[data-delta='negative'] {
+  color: rgba(255, 132, 132, 0.95);
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.action {
+  flex: 1;
+  min-width: 120px;
+  border: none;
+  border-radius: 12px;
+  padding: 0.55rem 0.8rem;
+  background: rgba(244, 248, 255, 0.08);
+  color: rgba(244, 248, 255, 0.9);
+  font-weight: 600;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: transform 160ms ease, background 180ms ease, box-shadow 200ms ease;
+}
+
+.action:hover,
+.action:focus-visible {
+  background: rgba(244, 248, 255, 0.18);
+}
+
+.action:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+.primary {
+  background: linear-gradient(115deg, rgba(114, 188, 255, 0.42), rgba(74, 124, 255, 0.58));
+  color: #fff;
+  box-shadow: 0 16px 32px rgba(48, 116, 255, 0.45);
+}
+
+.primary:hover,
+.primary:focus-visible {
+  box-shadow: 0 20px 36px rgba(48, 116, 255, 0.58);
+}
+
+.danger {
+  background: rgba(255, 96, 96, 0.16);
+  color: rgba(255, 185, 185, 0.95);
+}
+
+.danger[data-confirm='true'] {
+  background: rgba(255, 90, 90, 0.32);
+  color: #ffe5e5;
+}
+
+.quantity {
+  font-size: 0.78rem;
+  color: rgba(244, 248, 255, 0.58);
+}
+
+.badge {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: rgba(244, 248, 255, 0.12);
+  color: rgba(244, 248, 255, 0.86);
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.75rem;
+}

--- a/src/ui/stash/ItemCard.tsx
+++ b/src/ui/stash/ItemCard.tsx
@@ -1,0 +1,280 @@
+import styles from './ItemCard.module.css';
+import type {
+  InventoryListItemView,
+  InventoryComparisonPreview,
+  InventoryStatProjection
+} from '../../state/inventory.ts';
+import type { InventoryStatId } from '../../inventory/state.ts';
+
+export interface ItemCardHandlers {
+  readonly onEquip?: () => void;
+  readonly onTransfer?: () => void;
+  readonly onTrash?: () => void;
+}
+
+const STAT_LABELS: Record<InventoryStatId, string> = {
+  health: 'HP',
+  attackDamage: 'ATK',
+  attackRange: 'Range',
+  movementRange: 'Move',
+  defense: 'Defense',
+  shield: 'Shield'
+};
+
+const REASON_COPY: Record<string, string> = {
+  'slot-occupied': 'Slot occupied. Unequip the current item first.',
+  'stack-limit': 'Stack limit reached for this item.',
+  'unknown-item': 'This item cannot be equipped yet.'
+};
+
+const numberFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
+
+function renderIcon(container: HTMLElement, view: InventoryListItemView): void {
+  if (view.item.icon) {
+    const img = document.createElement('img');
+    img.src = view.item.icon;
+    img.alt = '';
+    img.loading = 'lazy';
+    img.decoding = 'async';
+    img.width = 48;
+    img.height = 48;
+    container.appendChild(img);
+    return;
+  }
+  const letter = document.createElement('span');
+  letter.textContent = view.item.name.trim()[0]?.toUpperCase() ?? '?';
+  container.appendChild(letter);
+}
+
+function describeReason(comparison: InventoryComparisonPreview | null): string | undefined {
+  if (!comparison || comparison.canEquip) {
+    return undefined;
+  }
+  if (comparison.reason && REASON_COPY[comparison.reason]) {
+    return REASON_COPY[comparison.reason];
+  }
+  return 'Unable to equip this item right now.';
+}
+
+function createTooltip(stats: readonly InventoryStatProjection[], comparison: InventoryComparisonPreview): HTMLDivElement {
+  const tooltip = document.createElement('div');
+  tooltip.className = styles.tooltip;
+  const title = document.createElement('h4');
+  if (comparison.projected) {
+    title.textContent = comparison.canEquip ? 'Projected stats' : 'Current loadout';
+  } else {
+    title.textContent = 'Stats';
+  }
+  tooltip.appendChild(title);
+  if (!comparison.canEquip) {
+    const reason = describeReason(comparison);
+    if (reason) {
+      const note = document.createElement('p');
+      note.textContent = reason;
+      note.style.margin = '0 0 0.5rem';
+      note.style.fontSize = '0.78rem';
+      tooltip.appendChild(note);
+    }
+  }
+  const list = document.createElement('ul');
+  list.className = styles.statList;
+  for (const stat of stats) {
+    const row = document.createElement('li');
+    row.className = styles.stat;
+    if (stat.delta > 0) {
+      row.dataset.delta = 'positive';
+    } else if (stat.delta < 0) {
+      row.dataset.delta = 'negative';
+    }
+    const label = document.createElement('span');
+    label.textContent = STAT_LABELS[stat.stat] ?? stat.stat;
+    const value = document.createElement('span');
+    const current = numberFormatter.format(stat.current);
+    const projected = numberFormatter.format(stat.projected);
+    const delta = stat.delta;
+    const deltaString =
+      delta === 0 ? '±0' : `${delta > 0 ? '+' : '−'}${numberFormatter.format(Math.abs(delta))}`;
+    value.textContent = `${current} → ${projected} (${deltaString})`;
+    row.append(label, value);
+    list.appendChild(row);
+  }
+  tooltip.appendChild(list);
+  return tooltip;
+}
+
+function createCompareBlock(view: InventoryListItemView): HTMLElement | null {
+  const comparison = view.comparison;
+  if (!comparison) {
+    return null;
+  }
+  const wrapper = document.createElement('div');
+  const compareButton = document.createElement('button');
+  compareButton.type = 'button';
+  compareButton.className = styles.compare;
+  compareButton.textContent = comparison.canEquip ? 'Compare stats' : 'View details';
+  const tooltipId = `${view.item.id}-compare-${view.location}-${view.index}`;
+  compareButton.setAttribute('aria-controls', tooltipId);
+  compareButton.setAttribute('aria-expanded', 'false');
+  compareButton.setAttribute('aria-describedby', tooltipId);
+  compareButton.addEventListener('focus', () => {
+    compareButton.setAttribute('aria-expanded', 'true');
+  });
+  compareButton.addEventListener('blur', () => {
+    compareButton.setAttribute('aria-expanded', 'false');
+  });
+  wrapper.appendChild(compareButton);
+  const tooltip = createTooltip(comparison.stats, comparison);
+  tooltip.id = tooltipId;
+  wrapper.appendChild(tooltip);
+  return wrapper;
+}
+
+function setActionState(button: HTMLButtonElement, comparison: InventoryComparisonPreview | null): void {
+  if (!comparison) {
+    return;
+  }
+  if (!comparison.canEquip) {
+    button.disabled = true;
+    const reason = describeReason(comparison);
+    if (reason) {
+      button.title = reason;
+    }
+  }
+}
+
+function formatTags(tags: readonly string[]): readonly string[] {
+  return tags.map((tag) => {
+    const normalized = tag.trim();
+    if (!normalized) {
+      return normalized;
+    }
+    return normalized
+      .split(/[-_\s]/g)
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(' ');
+  });
+}
+
+function renderActions(
+  container: HTMLElement,
+  view: InventoryListItemView,
+  handlers: ItemCardHandlers
+): void {
+  const actions = document.createElement('div');
+  actions.className = styles.actions;
+
+  const equip = document.createElement('button');
+  equip.type = 'button';
+  equip.className = `${styles.action} ${styles.primary}`;
+  equip.textContent = 'Equip';
+  setActionState(equip, view.comparison);
+  equip.addEventListener('click', () => {
+    handlers.onEquip?.();
+  });
+  actions.appendChild(equip);
+
+  const transfer = document.createElement('button');
+  transfer.type = 'button';
+  transfer.className = styles.action;
+  transfer.textContent = view.location === 'stash' ? 'Send to inventory' : 'Return to stash';
+  transfer.addEventListener('click', () => {
+    handlers.onTransfer?.();
+  });
+  actions.appendChild(transfer);
+
+  const trash = document.createElement('button');
+  trash.type = 'button';
+  trash.className = `${styles.action} ${styles.danger}`;
+  trash.textContent = 'Trash';
+  let pendingConfirm: number | null = null;
+  const reset = () => {
+    if (pendingConfirm !== null) {
+      window.clearTimeout(pendingConfirm);
+      pendingConfirm = null;
+    }
+    trash.dataset.confirm = 'false';
+    trash.textContent = 'Trash';
+  };
+  trash.addEventListener('click', () => {
+    if (pendingConfirm !== null) {
+      reset();
+      handlers.onTrash?.();
+      return;
+    }
+    trash.dataset.confirm = 'true';
+    trash.textContent = 'Confirm trash';
+    pendingConfirm = window.setTimeout(() => {
+      reset();
+    }, 2600);
+  });
+  actions.appendChild(trash);
+
+  container.appendChild(actions);
+}
+
+export function renderItemCard(view: InventoryListItemView, handlers: ItemCardHandlers): HTMLLIElement {
+  const root = document.createElement('li');
+  root.className = styles.card;
+  root.dataset.location = view.location;
+  root.setAttribute('role', 'listitem');
+
+  const header = document.createElement('div');
+  header.className = styles.header;
+
+  const icon = document.createElement('div');
+  icon.className = styles.icon;
+  renderIcon(icon, view);
+  header.appendChild(icon);
+
+  const details = document.createElement('div');
+  details.className = styles.details;
+
+  const titleRow = document.createElement('div');
+  titleRow.className = styles.titleRow;
+  const title = document.createElement('h4');
+  title.className = styles.title;
+  title.textContent = view.item.name;
+  titleRow.appendChild(title);
+
+  const rarity = document.createElement('span');
+  rarity.className = styles.rarity;
+  rarity.textContent = view.metadata.rarity.toUpperCase();
+  titleRow.appendChild(rarity);
+
+  details.appendChild(titleRow);
+
+  const slot = document.createElement('span');
+  slot.className = styles.slot;
+  slot.textContent = view.metadata.slot ? view.metadata.slotLabel : 'No slot';
+  details.appendChild(slot);
+
+  if (view.metadata.tags.length > 0) {
+    const tags = document.createElement('div');
+    tags.className = styles.tags;
+    for (const tag of formatTags(view.metadata.tags)) {
+      const chip = document.createElement('span');
+      chip.className = styles.tag;
+      chip.textContent = tag;
+      tags.appendChild(chip);
+    }
+    details.appendChild(tags);
+  }
+
+  const compare = createCompareBlock(view);
+  if (compare) {
+    details.appendChild(compare);
+  }
+
+  header.appendChild(details);
+  root.appendChild(header);
+
+  if (view.item.quantity > 1) {
+    const badge = document.createElement('span');
+    badge.className = styles.badge;
+    badge.textContent = `×${numberFormatter.format(view.item.quantity)}`;
+    root.appendChild(badge);
+  }
+
+  renderActions(root, view, handlers);
+  return root;
+}

--- a/src/ui/stash/StashPanel.module.css
+++ b/src/ui/stash/StashPanel.module.css
@@ -1,0 +1,232 @@
+.panel {
+  position: fixed;
+  inset: 0 0 0 auto;
+  width: min(480px, 100%);
+  max-width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(18, 22, 27, 0.95), rgba(10, 12, 16, 0.98));
+  color: #f4f8ff;
+  box-shadow: -24px 0 48px rgba(0, 0, 0, 0.45);
+  transform: translate3d(100%, 0, 0);
+  transition: transform 320ms cubic-bezier(0.32, 0.72, 0, 1), opacity 180ms ease;
+  opacity: 0;
+  z-index: 32;
+}
+
+.panel[data-open='true'] {
+  transform: translate3d(0, 0, 0);
+  opacity: 1;
+}
+
+@media (max-width: 720px) {
+  .panel {
+    width: 100%;
+    background: linear-gradient(185deg, rgba(16, 20, 26, 0.98), rgba(6, 8, 12, 0.98));
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(122, 139, 168, 0.16);
+  backdrop-filter: blur(24px);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.125rem;
+  letter-spacing: 0.02em;
+  font-weight: 600;
+}
+
+.meta {
+  font-size: 0.875rem;
+  color: rgba(244, 248, 255, 0.72);
+}
+
+.close {
+  border: none;
+  background: rgba(244, 248, 255, 0.08);
+  color: inherit;
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 180ms ease, transform 160ms ease;
+}
+
+.close:hover,
+.close:focus-visible {
+  background: rgba(244, 248, 255, 0.16);
+}
+
+.close:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.controls {
+  padding: 0.85rem 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba(122, 139, 168, 0.12);
+}
+
+.collections {
+  display: inline-flex;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.35rem;
+  border-radius: 999px;
+}
+
+.collectionButton {
+  position: relative;
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: transparent;
+  color: rgba(244, 248, 255, 0.75);
+  cursor: pointer;
+  transition: color 140ms ease, background 180ms ease, transform 160ms ease;
+}
+
+.collectionButton[data-active='true'] {
+  background: linear-gradient(120deg, rgba(102, 181, 255, 0.28), rgba(74, 120, 255, 0.52));
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(29, 85, 210, 0.28);
+}
+
+.collectionButton:hover,
+.collectionButton:focus-visible {
+  color: #ffffff;
+}
+
+.collectionButton:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.searchRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.search {
+  flex: 1;
+  position: relative;
+}
+
+.search input {
+  width: 100%;
+  border-radius: 12px;
+  border: none;
+  padding: 0.65rem 1rem 0.65rem 2.4rem;
+  background: rgba(24, 32, 44, 0.82);
+  color: #f4f8ff;
+  font-size: 0.95rem;
+  transition: box-shadow 180ms ease, background 180ms ease;
+}
+
+.search input::placeholder {
+  color: rgba(244, 248, 255, 0.52);
+}
+
+.search input:focus {
+  outline: none;
+  background: rgba(30, 40, 55, 0.92);
+  box-shadow: 0 0 0 2px rgba(94, 164, 255, 0.45);
+}
+
+.searchIcon {
+  position: absolute;
+  inset: 0 auto 0 0.85rem;
+  display: grid;
+  place-items: center;
+  color: rgba(244, 248, 255, 0.62);
+  font-size: 0.95rem;
+  pointer-events: none;
+}
+
+.sortSelect {
+  border: none;
+  border-radius: 12px;
+  background: rgba(24, 32, 44, 0.82);
+  color: inherit;
+  padding: 0.55rem 0.8rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 1.5rem 1.25rem;
+}
+
+.grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(192px, 1fr));
+}
+
+.empty {
+  margin: 2.5rem auto;
+  padding: 1.5rem;
+  max-width: 320px;
+  text-align: center;
+  border-radius: 16px;
+  background: rgba(244, 248, 255, 0.04);
+  color: rgba(244, 248, 255, 0.72);
+  line-height: 1.5;
+}
+
+.footer {
+  padding: 0.85rem 1.5rem 1.5rem;
+  border-top: 1px solid rgba(122, 139, 168, 0.12);
+}
+
+.loadMore {
+  width: 100%;
+  border: none;
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background: linear-gradient(120deg, rgba(94, 164, 255, 0.28), rgba(94, 164, 255, 0.48));
+  color: #fff;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 200ms ease;
+}
+
+.loadMore:hover,
+.loadMore:focus-visible {
+  box-shadow: 0 18px 32px rgba(30, 90, 205, 0.35);
+}
+
+.loadMore:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+@media (max-width: 560px) {
+  .controls {
+    padding-inline: 1.1rem;
+  }
+  .body {
+    padding-inline: 1.1rem;
+  }
+  .footer {
+    padding-inline: 1.1rem;
+  }
+}

--- a/src/ui/stash/StashPanel.test.tsx
+++ b/src/ui/stash/StashPanel.test.tsx
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { createStashPanel } from './StashPanel.tsx';
+import type { InventoryPanelView } from '../../state/inventory.ts';
+import type { InventoryListItemView } from '../../state/inventory.ts';
+
+const baseItem: InventoryListItemView = {
+  item: {
+    id: 'emberglass-arrow',
+    name: 'Emberglass Arrow',
+    quantity: 1,
+    rarity: 'rare',
+    acquiredAt: 1000
+  },
+  index: 0,
+  location: 'stash',
+  metadata: {
+    slot: 'weapon',
+    slotLabel: 'Primary Armament',
+    rarity: 'rare',
+    rarityRank: 3,
+    tags: ['damage'],
+    acquiredAt: 1000
+  },
+  comparison: {
+    slot: 'weapon',
+    canEquip: true,
+    equipped: null,
+    projected: {
+      id: 'emberglass-arrow',
+      name: 'Emberglass Arrow',
+      quantity: 1,
+      rarity: 'rare'
+    },
+    stats: [
+      { stat: 'attackDamage', current: 3, projected: 4, delta: 1 },
+      { stat: 'attackRange', current: 2, projected: 3, delta: 1 }
+    ]
+  }
+};
+
+function buildView(overrides: Partial<InventoryPanelView> = {}): InventoryPanelView {
+  return {
+    collection: 'stash',
+    collections: [
+      { id: 'stash', label: 'Quartermaster Stash', count: 1, active: true },
+      { id: 'inventory', label: 'Ready Inventory', count: 0, active: false }
+    ],
+    filters: {
+      slots: [{ id: 'weapon', label: 'Weapon', count: 1, active: false }],
+      rarities: [{ id: 'rare', label: 'Rare', count: 1, active: false }],
+      tags: [{ id: 'damage', label: 'Damage', count: 1, active: false }]
+    },
+    items: [baseItem],
+    total: 1,
+    filteredTotal: 1,
+    search: '',
+    sort: 'newest',
+    hasMore: false,
+    emptyMessage: 'Empty stash',
+    ...overrides
+  } satisfies InventoryPanelView;
+}
+
+describe('createStashPanel', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it('renders items, filters, and actions', () => {
+    const callbacks = {
+      onClose: vi.fn(),
+      onCollectionChange: vi.fn(),
+      onFilterToggle: vi.fn(),
+      onSearchChange: vi.fn(),
+      onSortChange: vi.fn(),
+      onLoadMore: vi.fn(),
+      onItemEquip: vi.fn(),
+      onItemTransfer: vi.fn(),
+      onItemTrash: vi.fn()
+    };
+    const panel = createStashPanel(callbacks);
+    container.appendChild(panel.element);
+
+    const view = buildView();
+    panel.render(view);
+
+    expect(panel.element.querySelectorAll('ul li[role="listitem"]')).toHaveLength(1);
+    expect(panel.element.textContent).toContain('Quartermaster Stash');
+
+    const filterButton = panel.element.querySelector('button[class*="chip"]');
+    expect(filterButton).not.toBeNull();
+    filterButton?.dispatchEvent(new Event('click'));
+    expect(callbacks.onFilterToggle).toHaveBeenCalledWith('slots', 'weapon');
+
+    const searchInput = panel.element.querySelector('input[type="search"]');
+    expect(searchInput).not.toBeNull();
+    searchInput!.value = 'arrow';
+    searchInput!.dispatchEvent(new Event('input'));
+    expect(callbacks.onSearchChange).toHaveBeenCalledWith('arrow');
+
+    const equipButton = panel.element.querySelector('button[class*="primary"]');
+    expect(equipButton).not.toBeNull();
+    equipButton?.dispatchEvent(new Event('click'));
+    expect(callbacks.onItemEquip).toHaveBeenCalledTimes(1);
+
+    const transferButton = panel.element.querySelectorAll('button[class*="action"]')[1];
+    transferButton.dispatchEvent(new Event('click'));
+    expect(callbacks.onItemTransfer).toHaveBeenCalledTimes(1);
+
+    vi.useFakeTimers();
+    const trashButton = panel.element.querySelector(`button[class*="danger"]`);
+    trashButton?.dispatchEvent(new Event('click'));
+    expect(callbacks.onItemTrash).not.toHaveBeenCalled();
+    trashButton?.dispatchEvent(new Event('click'));
+    expect(callbacks.onItemTrash).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles collection view and load more button', () => {
+    const callbacks = {
+      onClose: vi.fn(),
+      onCollectionChange: vi.fn(),
+      onFilterToggle: vi.fn(),
+      onSearchChange: vi.fn(),
+      onSortChange: vi.fn(),
+      onLoadMore: vi.fn(),
+      onItemEquip: vi.fn(),
+      onItemTransfer: vi.fn(),
+      onItemTrash: vi.fn()
+    };
+    const panel = createStashPanel(callbacks);
+    container.appendChild(panel.element);
+
+    const view = buildView({
+      hasMore: true,
+      collections: [
+        { id: 'stash', label: 'Quartermaster Stash', count: 1, active: true },
+        { id: 'inventory', label: 'Ready Inventory', count: 0, active: false }
+      ]
+    });
+    panel.render(view);
+
+    const loadMore = panel.element.querySelector('button[class*="loadMore"]');
+    expect(loadMore).not.toBeNull();
+    loadMore?.dispatchEvent(new Event('click'));
+    expect(callbacks.onLoadMore).toHaveBeenCalledTimes(1);
+
+    const readyButton = panel.element.querySelectorAll('button[data-active]')[1];
+    readyButton.dispatchEvent(new Event('click'));
+    expect(callbacks.onCollectionChange).toHaveBeenCalledWith('inventory');
+  });
+});

--- a/src/ui/stash/StashPanel.tsx
+++ b/src/ui/stash/StashPanel.tsx
@@ -1,0 +1,260 @@
+import panelStyles from './StashPanel.module.css';
+import filterStyles from './Filters.module.css';
+import { renderItemCard, type ItemCardHandlers } from './ItemCard.tsx';
+import type {
+  InventoryCollection,
+  InventoryListItemView,
+  InventoryPanelView,
+  InventorySort
+} from '../../state/inventory.ts';
+
+export interface StashPanelCallbacks {
+  readonly onClose?: () => void;
+  readonly onCollectionChange?: (collection: InventoryCollection) => void;
+  readonly onFilterToggle?: (category: 'slots' | 'rarities' | 'tags', value: string) => void;
+  readonly onSearchChange?: (value: string) => void;
+  readonly onSortChange?: (value: InventorySort) => void;
+  readonly onLoadMore?: () => void;
+  readonly onItemEquip?: (item: InventoryListItemView) => void;
+  readonly onItemTransfer?: (item: InventoryListItemView) => void;
+  readonly onItemTrash?: (item: InventoryListItemView) => void;
+}
+
+export interface StashPanelController {
+  readonly element: HTMLElement;
+  render(view: InventoryPanelView): void;
+  setOpen(open: boolean): void;
+  focus(): void;
+  destroy(): void;
+}
+
+interface FilterSlot {
+  readonly row: HTMLDivElement;
+  readonly group: HTMLDivElement;
+}
+
+const SORT_LABELS: Record<InventorySort, string> = {
+  newest: 'Newest',
+  oldest: 'Oldest',
+  rarity: 'Rarity',
+  name: 'Name A-Z'
+};
+
+function createFilterSlot(labelText: string): FilterSlot {
+  const row = document.createElement('div');
+  row.className = filterStyles.row;
+  const label = document.createElement('div');
+  label.className = filterStyles.label;
+  label.textContent = labelText;
+  const group = document.createElement('div');
+  group.className = filterStyles.group;
+  row.append(label, group);
+  return { row, group } satisfies FilterSlot;
+}
+
+export function createStashPanel(callbacks: StashPanelCallbacks): StashPanelController {
+  const element = document.createElement('section');
+  element.className = panelStyles.panel;
+  element.tabIndex = -1;
+  element.dataset.open = 'false';
+  element.setAttribute('aria-label', 'Quartermaster stash');
+
+  const header = document.createElement('header');
+  header.className = panelStyles.header;
+
+  const titleWrap = document.createElement('div');
+  const title = document.createElement('h2');
+  title.className = panelStyles.title;
+  title.textContent = 'Quartermaster Stash';
+  titleWrap.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = panelStyles.meta;
+  meta.textContent = 'Loading…';
+  titleWrap.appendChild(meta);
+
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = panelStyles.close;
+  close.textContent = 'Close';
+  close.addEventListener('click', () => callbacks.onClose?.());
+
+  header.append(titleWrap, close);
+  element.appendChild(header);
+
+  const controls = document.createElement('div');
+  controls.className = panelStyles.controls;
+
+  const collections = document.createElement('div');
+  collections.className = panelStyles.collections;
+
+  const collectionButtons: Record<InventoryCollection, HTMLButtonElement> = {
+    stash: document.createElement('button'),
+    inventory: document.createElement('button')
+  };
+
+  collectionButtons.stash.type = 'button';
+  collectionButtons.stash.className = panelStyles.collectionButton;
+  collectionButtons.stash.textContent = 'Stash';
+  collectionButtons.stash.addEventListener('click', () => callbacks.onCollectionChange?.('stash'));
+
+  collectionButtons.inventory.type = 'button';
+  collectionButtons.inventory.className = panelStyles.collectionButton;
+  collectionButtons.inventory.textContent = 'Ready';
+  collectionButtons.inventory.addEventListener('click', () =>
+    callbacks.onCollectionChange?.('inventory')
+  );
+
+  collections.append(collectionButtons.stash, collectionButtons.inventory);
+  controls.appendChild(collections);
+
+  const searchRow = document.createElement('div');
+  searchRow.className = panelStyles.searchRow;
+
+  const searchWrapper = document.createElement('div');
+  searchWrapper.className = panelStyles.search;
+  const searchInput = document.createElement('input');
+  searchInput.type = 'search';
+  searchInput.placeholder = 'Search stash…';
+  searchInput.addEventListener('input', () => callbacks.onSearchChange?.(searchInput.value));
+  const searchIcon = document.createElement('span');
+  searchIcon.className = panelStyles.searchIcon;
+  searchIcon.textContent = '🔍';
+  searchWrapper.append(searchIcon, searchInput);
+  searchRow.appendChild(searchWrapper);
+
+  const sortSelect = document.createElement('select');
+  sortSelect.className = panelStyles.sortSelect;
+  (['newest', 'oldest', 'rarity', 'name'] as InventorySort[]).forEach((value) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = SORT_LABELS[value];
+    sortSelect.appendChild(option);
+  });
+  sortSelect.addEventListener('change', () =>
+    callbacks.onSortChange?.(sortSelect.value as InventorySort)
+  );
+  searchRow.appendChild(sortSelect);
+
+  controls.appendChild(searchRow);
+
+  const filterSection = document.createElement('div');
+  const filterSlots: Record<'slots' | 'rarities' | 'tags', FilterSlot> = {
+    slots: createFilterSlot('Slots'),
+    rarities: createFilterSlot('Rarity'),
+    tags: createFilterSlot('Tags')
+  };
+  filterSection.append(
+    filterSlots.slots.row,
+    filterSlots.rarities.row,
+    filterSlots.tags.row
+  );
+  controls.appendChild(filterSection);
+
+  element.appendChild(controls);
+
+  const body = document.createElement('div');
+  body.className = panelStyles.body;
+  const list = document.createElement('ul');
+  list.className = panelStyles.grid;
+  const empty = document.createElement('div');
+  empty.className = panelStyles.empty;
+  empty.textContent = 'No items match the current filters.';
+  empty.hidden = true;
+  body.append(list, empty);
+  element.appendChild(body);
+
+  const footer = document.createElement('div');
+  footer.className = panelStyles.footer;
+  const loadMore = document.createElement('button');
+  loadMore.type = 'button';
+  loadMore.className = panelStyles.loadMore;
+  loadMore.textContent = 'Show more';
+  loadMore.addEventListener('click', () => callbacks.onLoadMore?.());
+  footer.appendChild(loadMore);
+  element.appendChild(footer);
+
+  function renderFilters(
+    slot: FilterSlot,
+    category: 'slots' | 'rarities' | 'tags',
+    chips: readonly { id: string; label: string; count: number; active: boolean }[]
+  ): void {
+    slot.group.innerHTML = '';
+    slot.row.hidden = chips.length === 0;
+    for (const chip of chips) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = filterStyles.chip;
+      button.dataset.active = chip.active ? 'true' : 'false';
+      button.textContent = chip.label;
+      if (chip.count > 0) {
+        const count = document.createElement('span');
+        count.className = filterStyles.count;
+        count.textContent = String(chip.count);
+        button.appendChild(count);
+      }
+      button.addEventListener('click', () => callbacks.onFilterToggle?.(category, chip.id));
+      slot.group.appendChild(button);
+    }
+  }
+
+  function renderItems(view: InventoryPanelView): void {
+    list.replaceChildren();
+    const fragment = document.createDocumentFragment();
+    for (const itemView of view.items) {
+      const handlers: ItemCardHandlers = {
+        onEquip: () => callbacks.onItemEquip?.(itemView),
+        onTransfer: () => callbacks.onItemTransfer?.(itemView),
+        onTrash: () => callbacks.onItemTrash?.(itemView)
+      };
+      fragment.appendChild(renderItemCard(itemView, handlers));
+    }
+    list.appendChild(fragment);
+    empty.hidden = view.filteredTotal !== 0;
+    if (!empty.hidden) {
+      empty.textContent = view.emptyMessage;
+    }
+  }
+
+  const controller: StashPanelController = {
+    element,
+    render(view: InventoryPanelView) {
+      meta.textContent =
+        view.total === 0
+          ? 'No items yet'
+          : `${view.filteredTotal} of ${view.total} item${view.total === 1 ? '' : 's'}`;
+
+      for (const [key, button] of Object.entries(collectionButtons) as [
+        InventoryCollection,
+        HTMLButtonElement
+      ][]) {
+        button.dataset.active = key === view.collection ? 'true' : 'false';
+      }
+
+      if (searchInput.value !== view.search) {
+        searchInput.value = view.search;
+      }
+      if (sortSelect.value !== view.sort) {
+        sortSelect.value = view.sort;
+      }
+
+      renderFilters(filterSlots.slots, 'slots', view.filters.slots);
+      renderFilters(filterSlots.rarities, 'rarities', view.filters.rarities);
+      renderFilters(filterSlots.tags, 'tags', view.filters.tags);
+
+      renderItems(view);
+      loadMore.hidden = !view.hasMore;
+    },
+    setOpen(open: boolean) {
+      element.dataset.open = open ? 'true' : 'false';
+    },
+    focus() {
+      element.focus({ preventScroll: true });
+    },
+    destroy() {
+      element.remove();
+    }
+  } satisfies StashPanelController;
+
+  return controller;
+}


### PR DESCRIPTION
## Summary
- add derived inventory selectors that normalize filters, search, sorting, pagination, and equip comparison previews
- build the responsive stash panel suite with item cards, filter chips, quick actions, and polished CSS modules
- extend inventory state events and HUD wiring to surface comparison data, toast messaging, and keyboard/mobile toggles, with Vitest coverage and changelog notes

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ccf6a47e9c8330ab44616905a0987a