### PR TITLE
Allow sauna beer debt to surface in HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Surface sauna beer debt in the HUD by letting negative totals render, tagging
+  the resource badge for debt styling, enriching the aria-label messaging, and
+  covering the regression with a Vitest DOM test.
 - Polish battlefield unit rendering by cataloguing sprite metadata in
   `src/render/units/sprite_map.ts`, introducing snapped placement helpers and
   zoom utilities, wiring the renderer and Saunoja portraits through them, and

--- a/src/style.css
+++ b/src/style.css
@@ -393,6 +393,25 @@ body > #game-container {
   color: var(--color-warning);
 }
 
+.topbar-badge--debt {
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-danger) 18%, transparent),
+      transparent
+    );
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-danger) 32%, transparent);
+}
+
+.topbar-badge--debt .badge-label {
+  color: color-mix(in srgb, var(--color-danger) 58%, white 18%);
+}
+
+.topbar-badge--debt .badge-value {
+  color: color-mix(in srgb, var(--color-danger) 82%, white 12%);
+  text-shadow: 0 0 18px color-mix(in srgb, var(--color-danger) 46%, transparent);
+}
+
 .badge-delta {
   position: absolute;
   top: -14px;

--- a/src/ui/topbar.test.ts
+++ b/src/ui/topbar.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTopbar } from './topbar.ts';
+import { Resource, type GameState } from '../core/GameState.ts';
+
+describe('topbar resource badges', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn()
+      }))
+    });
+  });
+
+  afterEach(() => {
+    delete (window as typeof window & { matchMedia?: unknown }).matchMedia;
+  });
+
+  it('shows sauna beer debt with accessible messaging', () => {
+    const overlay = document.createElement('div');
+    overlay.id = 'ui-overlay';
+    document.body.appendChild(overlay);
+
+    const state = {
+      getResource: (resource: Resource) =>
+        resource === Resource.SAUNA_BEER ? -7 : 0
+    } as unknown as GameState;
+
+    const controls = setupTopbar(state);
+
+    try {
+      const beerBadge = overlay.querySelector<HTMLDivElement>('.badge-sauna-beer');
+      expect(beerBadge).toBeTruthy();
+      expect(beerBadge?.querySelector('.badge-value')?.textContent).toBe('-7');
+      expect(beerBadge?.classList.contains('topbar-badge--debt')).toBe(true);
+      expect(beerBadge?.getAttribute('aria-label')).toBe(
+        'Sauna beer reserves -7 — Debt of 7 bottles'
+      );
+    } finally {
+      controls.dispose();
+      overlay.remove();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- allow sauna beer totals to normalize to true values and surface debt messaging in the HUD aria labels
- introduce a dedicated debt styling hook for sauna beer badges so negative balances stand out visually
- cover the negative sauna beer flow with a Vitest DOM test and document the change in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd02e15cb88330b424d40402a25afc