### PR TITLE
Seed starter roster with free upkeep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Ensure the seeded sauna attendant starts with zero upkeep by explicitly
+  setting the roster seed cost to free, exporting test helpers, and covering the
+  persistence plus upkeep resolution with new Vitest assertions.
 - Surface sauna beer debt in the HUD by letting negative totals render, tagging
   the resource badge for debt styling, enriching the aria-label messaging, and
   covering the regression with a Vitest DOM test.


### PR DESCRIPTION
## Summary
- ensure the roster seed path creates a free starter attendant, reloads it before fallback spawns, and treats incomplete personas as missing
- expose test helpers for retrieving the attached unit and its upkeep so the starter mapping can be verified
- cover the zero-upkeep starter flow with a new Vitest case and document the change in the changelog

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd0474a418833098bc8607c71eb6f5