### PR TITLE
Add sauna roster cap controls and NG+ aware spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Add a polished sauna roster cap control that persists player preferences,
+  respects NG+ unlock ceilings down to a zero-cap option, threads the limit
+  through the economy tick and spawn helper, and covers the behaviour with
+  new Vitest suites plus storage sanitation tests.
+- Surface sauna beer debt in the HUD by letting negative totals render, tagging
+  the resource badge for debt styling, enriching the aria-label messaging, and
 - Surface sauna beer debt in the HUD by letting negative totals render, tagging
   the resource badge for debt styling, enriching the aria-label messaging, and
   covering the regression with a Vitest DOM test.

--- a/src/economy/tick.ts
+++ b/src/economy/tick.ts
@@ -23,6 +23,8 @@ export interface EconomyTickOptions {
   spawnBaseUnit: (coord: AxialCoord) => Unit | null;
   minUpkeepReserve?: number;
   maxSpawns?: number;
+  rosterCap?: number;
+  getRosterCount?: () => number;
 }
 
 export interface EconomyTickResult {
@@ -62,7 +64,9 @@ export function runEconomyTick(options: EconomyTickOptions): EconomyTickResult {
     pickSpawnTile: options.pickSpawnTile,
     spawnUnit: options.spawnBaseUnit,
     minUpkeepReserve: options.minUpkeepReserve,
-    maxSpawns: options.maxSpawns
+    maxSpawns: options.maxSpawns,
+    rosterCap: options.rosterCap,
+    getRosterCount: options.getRosterCount
   });
 
   const cooldown = options.heat.getCooldownSeconds();

--- a/src/game/saunaSettings.test.ts
+++ b/src/game/saunaSettings.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  SAUNA_SETTINGS_STORAGE_KEY,
+  loadSaunaSettings,
+  saveSaunaSettings
+} from './saunaSettings.ts';
+
+describe('saunaSettings', () => {
+  beforeEach(() => {
+    window.localStorage?.clear?.();
+  });
+
+  it('returns the provided default when storage is empty', () => {
+    const settings = loadSaunaSettings(4);
+    expect(settings.maxRosterSize).toBe(4);
+  });
+
+  it('clamps stored values to the unlock ceiling', () => {
+    window.localStorage?.setItem(SAUNA_SETTINGS_STORAGE_KEY, JSON.stringify({ maxRosterSize: 99 }));
+    const settings = loadSaunaSettings(1);
+    expect(settings.maxRosterSize).toBe(6);
+  });
+
+  it('persists sanitized roster caps', () => {
+    saveSaunaSettings({ maxRosterSize: 7 });
+    const raw = window.localStorage?.getItem(SAUNA_SETTINGS_STORAGE_KEY);
+    expect(raw).toBeTypeOf('string');
+    const parsed = raw ? JSON.parse(raw) : null;
+    expect(parsed).toEqual({ maxRosterSize: 6 });
+  });
+
+  it('handles malformed payloads gracefully', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      window.localStorage?.setItem(SAUNA_SETTINGS_STORAGE_KEY, '{not json');
+      const settings = loadSaunaSettings(3);
+      expect(settings.maxRosterSize).toBe(3);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/src/game/saunaSettings.ts
+++ b/src/game/saunaSettings.ts
@@ -1,0 +1,61 @@
+import { MAX_UNLOCK_SLOTS } from '../progression/ngplus.ts';
+
+export interface SaunaSettings {
+  maxRosterSize: number;
+}
+
+export const SAUNA_SETTINGS_STORAGE_KEY = 'autobattles:sauna-settings';
+
+function getStorage(): Storage | null {
+  try {
+    const globalWithStorage = globalThis as typeof globalThis & { localStorage?: Storage };
+    return globalWithStorage.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeCap(value: unknown, fallback: number): number {
+  const base = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+  const cap = Math.max(0, Math.floor(base));
+  const maxUnlock = 1 + MAX_UNLOCK_SLOTS;
+  return Math.max(0, Math.min(maxUnlock, cap));
+}
+
+export function loadSaunaSettings(defaultCap: number): SaunaSettings {
+  const storage = getStorage();
+  if (!storage) {
+    return { maxRosterSize: sanitizeCap(defaultCap, defaultCap) };
+  }
+
+  try {
+    const raw = storage.getItem(SAUNA_SETTINGS_STORAGE_KEY);
+    if (!raw) {
+      return { maxRosterSize: sanitizeCap(defaultCap, defaultCap) };
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return { maxRosterSize: sanitizeCap(defaultCap, defaultCap) };
+    }
+    const record = parsed as Record<string, unknown>;
+    return { maxRosterSize: sanitizeCap(record.maxRosterSize, defaultCap) };
+  } catch (error) {
+    console.warn('Failed to load sauna settings from storage', error);
+    return { maxRosterSize: sanitizeCap(defaultCap, defaultCap) };
+  }
+}
+
+export function saveSaunaSettings(settings: SaunaSettings): void {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+  const payload: SaunaSettings = {
+    maxRosterSize: sanitizeCap(settings.maxRosterSize, settings.maxRosterSize)
+  };
+  try {
+    storage.setItem(SAUNA_SETTINGS_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Failed to persist sauna settings', error);
+  }
+}

--- a/src/progression/ngplus.ts
+++ b/src/progression/ngplus.ts
@@ -166,7 +166,7 @@ export function getAiAggressionModifier(state: NgPlusState): number {
 }
 
 export function getUnlockSpawnLimit(state: NgPlusState): number {
-  return Math.max(1, 1 + Math.max(0, state.unlockSlots));
+  return 1 + Math.max(0, state.unlockSlots);
 }
 
 export function createNgPlusRng(seed: number, salt = 0): () => number {

--- a/src/sim/sauna.ts
+++ b/src/sim/sauna.ts
@@ -40,6 +40,8 @@ export interface Sauna {
   auraRadius: number;
   regenPerSec: number;
   rallyToFront: boolean;
+  /** Player-selected maximum number of active attendants allowed on the field. */
+  maxRosterSize: number;
   heat: number;
   heatPerTick: number;
   playerSpawnThreshold: number;
@@ -48,11 +50,23 @@ export interface Sauna {
   heatTracker: SaunaHeat;
 }
 
-export function createSauna(pos: AxialCoord, heatConfig?: SaunaHeatInit): Sauna {
+export interface SaunaInitOptions {
+  /** Initial roster cap to seed onto the sauna. */
+  maxRosterSize?: number;
+}
+
+export function createSauna(
+  pos: AxialCoord,
+  heatConfig?: SaunaHeatInit,
+  options: SaunaInitOptions = {}
+): Sauna {
   const tracker = createSaunaHeat(heatConfig);
   const heatPerTick = tracker.getBuildRate();
   const cooldown = tracker.getCooldownSeconds();
   const timer = tracker.timeUntilNextTrigger();
+  const initialRosterCap = Number.isFinite(options.maxRosterSize)
+    ? Math.max(0, Math.floor(options.maxRosterSize ?? 0))
+    : 0;
 
   return {
     id: 'sauna',
@@ -60,6 +74,7 @@ export function createSauna(pos: AxialCoord, heatConfig?: SaunaHeatInit): Sauna 
     auraRadius: 2,
     regenPerSec: 1,
     rallyToFront: false,
+    maxRosterSize: initialRosterCap,
     heat: tracker.getHeat(),
     heatPerTick,
     playerSpawnThreshold: tracker.getThreshold(),

--- a/src/style.css
+++ b/src/style.css
@@ -1725,6 +1725,138 @@ body > #game-container {
   transition: width 240ms ease;
 }
 
+.sauna-roster {
+  display: grid;
+  gap: 12px;
+  padding: clamp(12px, 2.2vw, 18px);
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 18%, transparent);
+  background: linear-gradient(135deg, rgba(17, 26, 46, 0.78), rgba(11, 19, 35, 0.62));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 40px rgba(4, 14, 31, 0.45);
+}
+
+.sauna-roster__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.sauna-roster__title {
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  color: var(--color-foreground);
+}
+
+.sauna-roster__value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 56px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  background: color-mix(in srgb, var(--color-accent) 45%, rgba(15, 23, 42, 0.7));
+  color: var(--color-foreground);
+  box-shadow: 0 10px 24px rgba(6, 14, 31, 0.52);
+  transition: background 180ms ease, color 180ms ease, transform 180ms ease;
+}
+
+.sauna-roster__value[data-state='paused'] {
+  background: color-mix(in srgb, var(--color-muted) 70%, rgba(11, 19, 35, 0.9));
+  color: color-mix(in srgb, var(--color-muted) 80%, white 20%);
+}
+
+.sauna-roster__description {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: color-mix(in srgb, var(--color-muted) 86%, white 8%);
+}
+
+.sauna-roster__controls {
+  display: grid;
+  gap: 10px;
+}
+
+.sauna-roster__label {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 82%, white 6%);
+}
+
+.sauna-roster__slider {
+  width: 100%;
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--color-accent) 35%, rgba(10, 20, 36, 0.8)), rgba(9, 17, 30, 0.65));
+  outline: none;
+  transition: box-shadow 180ms ease;
+}
+
+.sauna-roster__slider:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 40%, transparent);
+}
+
+.sauna-roster__slider::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--color-accent) 35%, rgba(10, 20, 36, 0.8)), rgba(9, 17, 30, 0.65));
+}
+
+.sauna-roster__slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, white 12%, var(--color-accent));
+  border: 2px solid color-mix(in srgb, var(--color-accent) 60%, white 15%);
+  box-shadow: 0 8px 16px rgba(11, 22, 43, 0.45);
+  margin-top: -6px;
+}
+
+.sauna-roster__slider::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--color-accent) 35%, rgba(10, 20, 36, 0.8)), rgba(9, 17, 30, 0.65));
+}
+
+.sauna-roster__slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--color-accent) 60%, white 15%);
+  background: radial-gradient(circle at 30% 30%, white 12%, var(--color-accent));
+  box-shadow: 0 8px 16px rgba(11, 22, 43, 0.45);
+}
+
+.sauna-roster__number {
+  width: 100%;
+  padding: 6px 12px;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--color-muted) 70%, transparent);
+  background: rgba(12, 20, 36, 0.72);
+  color: var(--color-foreground);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  letter-spacing: 0.12em;
+  transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.sauna-roster__number:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 35%, transparent);
+  background: rgba(16, 26, 46, 0.82);
+}
+
 .sauna-option {
   display: inline-flex;
   align-items: center;

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -1,7 +1,12 @@
 import type { Sauna } from '../sim/sauna.ts';
 import { ensureHudLayout } from './layout.ts';
 
-export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
+export interface SaunaUIOptions {
+  getRosterCapLimit?: () => number;
+  updateMaxRosterSize?: (value: number, options?: { persist?: boolean }) => number;
+}
+
+export function setupSaunaUI(sauna: Sauna, options: SaunaUIOptions = {}): (dt: number) => void {
   const overlay = document.getElementById('ui-overlay');
   if (!overlay) return () => {};
 
@@ -27,6 +32,56 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
   barContainer.appendChild(barFill);
   card.appendChild(barContainer);
 
+  const rosterContainer = document.createElement('div');
+  rosterContainer.classList.add('sauna-roster');
+
+  const rosterHeader = document.createElement('div');
+  rosterHeader.classList.add('sauna-roster__header');
+  const rosterTitle = document.createElement('span');
+  rosterTitle.textContent = 'Roster Cap';
+  rosterTitle.classList.add('sauna-roster__title');
+  rosterHeader.appendChild(rosterTitle);
+
+  const rosterValue = document.createElement('span');
+  rosterValue.classList.add('sauna-roster__value');
+  rosterValue.setAttribute('aria-live', 'polite');
+  rosterHeader.appendChild(rosterValue);
+  rosterContainer.appendChild(rosterHeader);
+
+  const rosterDescription = document.createElement('p');
+  rosterDescription.classList.add('sauna-roster__description');
+  rosterDescription.textContent = 'Tune how many attendants may be active before new recruits wait in the steam.';
+  rosterContainer.appendChild(rosterDescription);
+
+  const sliderId = `sauna-roster-${Math.floor(Math.random() * 100000)}`;
+  const sliderLabel = document.createElement('label');
+  sliderLabel.classList.add('sauna-roster__label');
+  sliderLabel.htmlFor = sliderId;
+  sliderLabel.textContent = 'Active attendants';
+
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.id = sliderId;
+  slider.min = '0';
+  slider.step = '1';
+  slider.classList.add('sauna-roster__slider');
+
+  const numericInput = document.createElement('input');
+  numericInput.type = 'number';
+  numericInput.min = '0';
+  numericInput.step = '1';
+  numericInput.inputMode = 'numeric';
+  numericInput.classList.add('sauna-roster__number');
+
+  const controls = document.createElement('div');
+  controls.classList.add('sauna-roster__controls');
+  controls.appendChild(sliderLabel);
+  controls.appendChild(slider);
+  controls.appendChild(numericInput);
+  rosterContainer.appendChild(controls);
+
+  card.appendChild(rosterContainer);
+
   const label = document.createElement('label');
   label.classList.add('sauna-option');
   const checkbox = document.createElement('input');
@@ -45,6 +100,63 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
 
   container.appendChild(card);
   const { actions } = ensureHudLayout(overlay);
+
+  const resolveLimit = (): number => {
+    const limit = options.getRosterCapLimit?.();
+    if (typeof limit === 'number' && Number.isFinite(limit)) {
+      return Math.max(0, Math.floor(limit));
+    }
+    return Math.max(0, Math.floor(sauna.maxRosterSize));
+  };
+
+  const updateDisplay = (limit: number, value: number): void => {
+    const cappedValue = Math.max(0, Math.min(limit, Math.floor(value)));
+    slider.max = String(limit);
+    slider.value = String(cappedValue);
+    slider.setAttribute('aria-valuemax', slider.max);
+    slider.setAttribute('aria-valuenow', slider.value);
+    numericInput.max = String(limit);
+    numericInput.value = String(cappedValue);
+    rosterValue.textContent = cappedValue === 0 ? 'Paused' : `${cappedValue}`;
+    rosterValue.dataset.state = cappedValue === 0 ? 'paused' : 'active';
+    numericInput.setAttribute('aria-label', `Roster cap set to ${cappedValue}`);
+  };
+
+  const applyRosterCap = (raw: number, persist: boolean): number => {
+    const numeric = Number(raw);
+    const limit = resolveLimit();
+    const normalized = Number.isFinite(numeric) ? Math.max(0, Math.floor(numeric)) : 0;
+    let applied = Math.max(0, Math.min(limit, normalized));
+    if (options.updateMaxRosterSize) {
+      applied = options.updateMaxRosterSize(applied, { persist });
+    } else {
+      sauna.maxRosterSize = applied;
+    }
+    updateDisplay(limit, applied);
+    return applied;
+  };
+
+  slider.addEventListener('input', () => {
+    applyRosterCap(Number(slider.value), false);
+  });
+  slider.addEventListener('change', () => {
+    applyRosterCap(Number(slider.value), true);
+  });
+
+  const commitNumeric = (persist: boolean): void => {
+    applyRosterCap(Number(numericInput.value), persist);
+  };
+  numericInput.addEventListener('input', () => {
+    commitNumeric(false);
+  });
+  numericInput.addEventListener('change', () => {
+    commitNumeric(true);
+  });
+  numericInput.addEventListener('blur', () => {
+    commitNumeric(true);
+  });
+
+  applyRosterCap(sauna.maxRosterSize, false);
 
   const placeControl = (): boolean => {
     if (container.parentElement !== actions) {
@@ -81,6 +193,19 @@ export function setupSaunaUI(sauna: Sauna): (dt: number) => void {
     const progress = 1 - sauna.playerSpawnTimer / cooldown;
     barFill.style.width = `${Math.max(0, Math.min(progress, 1)) * 100}%`;
     checkbox.checked = sauna.rallyToFront;
+    const limit = resolveLimit();
+    const sanitized = Math.max(0, Math.min(limit, Math.floor(sauna.maxRosterSize)));
+    if (sanitized !== sauna.maxRosterSize) {
+      if (options.updateMaxRosterSize) {
+        const next = options.updateMaxRosterSize(sanitized, { persist: true });
+        updateDisplay(limit, next);
+      } else {
+        sauna.maxRosterSize = sanitized;
+        updateDisplay(limit, sanitized);
+      }
+    } else {
+      updateDisplay(limit, sanitized);
+    }
   };
 }
 

--- a/src/world/spawn/player_spawns.test.ts
+++ b/src/world/spawn/player_spawns.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSaunaHeat } from '../../sauna/heat.ts';
+import { processPlayerSpawns } from './player_spawns.ts';
+import { Unit as UnitClass } from '../../units/Unit.ts';
+import { getSoldierStats } from '../../units/Soldier.ts';
+
+describe('processPlayerSpawns', () => {
+  it('vents heat and blocks spawns when the roster cap is zero', () => {
+    const heat = createSaunaHeat({ baseThreshold: 10, initialHeat: 10, heatPerSecond: 0 });
+    const spawnUnit = vi.fn(() => new UnitClass('u-blocked', 'soldier', { q: 0, r: 0 }, 'player', getSoldierStats()));
+
+    const result = processPlayerSpawns({
+      heat,
+      availableUpkeep: 50,
+      pickSpawnTile: () => ({ q: 1, r: 0 }),
+      spawnUnit,
+      minUpkeepReserve: 0,
+      maxSpawns: 2,
+      rosterCap: 0,
+      getRosterCount: () => 0
+    });
+
+    expect(result.spawned).toBe(0);
+    expect(result.blockedByRoster).toBe(1);
+    expect(result.ventedHeat).toBeGreaterThan(0);
+    expect(heat.getHeat()).toBeLessThan(heat.getThreshold());
+    expect(spawnUnit).not.toHaveBeenCalled();
+  });
+
+  it('spawns once the roster cap allows new attendants', () => {
+    const heat = createSaunaHeat({ baseThreshold: 6, initialHeat: 6, heatPerSecond: 0 });
+    let rosterCount = 0;
+
+    const result = processPlayerSpawns({
+      heat,
+      availableUpkeep: 50,
+      pickSpawnTile: () => ({ q: 2, r: -1 }),
+      spawnUnit: (coord) => {
+        rosterCount += 1;
+        return new UnitClass(`u-${rosterCount}`, 'soldier', coord, 'player', getSoldierStats());
+      },
+      minUpkeepReserve: 0,
+      maxSpawns: 3,
+      rosterCap: 2,
+      getRosterCount: () => rosterCount
+    });
+
+    expect(result.spawned).toBe(1);
+    expect(result.blockedByRoster).toBe(0);
+    expect(heat.hasTriggerReady()).toBe(false);
+    expect(rosterCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a persistent sauna roster cap setting with a polished HUD slider
- clamp economy/player spawn helpers to the selected cap and NG+ unlocks
- cover roster cap storage and spawn limits with new vitest suites

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd05cff228833091c4475b770537c3