### PR TITLE
Gate beer upkeep to five-second intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Pace sauna beer upkeep by accumulating unit costs and draining them once
+  every five seconds so resource losses arrive in larger, less frequent bursts.
 - Ensure the seeded sauna attendant starts with zero upkeep by explicitly
   setting the roster seed cost to free, exporting test helpers, and covering the
   persistence plus upkeep resolution with new Vitest assertions.

--- a/src/sim/sauna.ts
+++ b/src/sim/sauna.ts
@@ -2,6 +2,16 @@ import type { AxialCoord } from '../hex/HexUtils.ts';
 import type { Unit } from '../units/Unit.ts';
 import { createSaunaHeat, type SaunaHeat, type SaunaHeatInit } from '../sauna/heat.ts';
 
+export interface SaunaUpkeepSegment {
+  amount: number;
+  duration: number;
+}
+
+export interface SaunaUpkeepTracker {
+  elapsed: number;
+  segments: SaunaUpkeepSegment[];
+}
+
 export function pickFreeTileAround(
   origin: AxialCoord,
   radiusOrUnits: number | Unit[],
@@ -46,6 +56,7 @@ export interface Sauna {
   playerSpawnCooldown: number;
   playerSpawnTimer: number;
   heatTracker: SaunaHeat;
+  beerUpkeep: SaunaUpkeepTracker;
 }
 
 export function createSauna(pos: AxialCoord, heatConfig?: SaunaHeatInit): Sauna {
@@ -65,6 +76,10 @@ export function createSauna(pos: AxialCoord, heatConfig?: SaunaHeatInit): Sauna 
     playerSpawnThreshold: tracker.getThreshold(),
     playerSpawnCooldown: Number.isFinite(cooldown) ? cooldown : 0,
     playerSpawnTimer: Number.isFinite(timer) ? timer : 0,
-    heatTracker: tracker
+    heatTracker: tracker,
+    beerUpkeep: {
+      elapsed: 0,
+      segments: []
+    }
   };
 }


### PR DESCRIPTION
## Summary
- accumulate unit beer upkeep between calls and only drain after five seconds have elapsed
- persist the upkeep tracker on the sauna state and update tests for multi-second and large-dt scenarios
- note the new upkeep cadence in the changelog for players

## Testing
- npm run test -- src/economy/tick.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd07ca4e9483309a2bd5bdb98c40cb