### PR TITLE
Throttle beer upkeep to five-second ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Pace unit beer upkeep so the economy only deducts reserves every five
+  seconds, matching the new simulation cadence and communicating the change to
+  players.
+
 p resolution with new Vitest assertions.
 
 - Surface sauna beer debt in the HUD by letting negative totals render, tagging

--- a/src/sim/sauna.ts
+++ b/src/sim/sauna.ts
@@ -47,6 +47,11 @@ export interface Sauna {
   playerSpawnThreshold: number;
   playerSpawnCooldown: number;
   playerSpawnTimer: number;
+  /**
+   * Accumulates elapsed seconds between upkeep drains so beer only ticks down
+   * at the intended cadence.
+   */
+  beerUpkeepAccumulator: number;
   heatTracker: SaunaHeat;
 }
 
@@ -80,6 +85,7 @@ export function createSauna(
     playerSpawnThreshold: tracker.getThreshold(),
     playerSpawnCooldown: Number.isFinite(cooldown) ? cooldown : 0,
     playerSpawnTimer: Number.isFinite(timer) ? timer : 0,
+    beerUpkeepAccumulator: 0,
     heatTracker: tracker
   };
 }


### PR DESCRIPTION
## Summary
- add a persistent beer-upkeep accumulator to the sauna state and apply the upkeep drain every five seconds
- update the economy tick tests to cover one-second cadence accumulation and larger step updates
- document the five-second beer upkeep pacing change for players in the changelog

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cd0a6bdc508330b37c6a64ffff1b24