### PR TITLE
Handle ambience storage access failures gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Guard ambience preference reads behind a resilient storage helper so startup
+  falls back to defaults when `localStorage` is unavailable, and cover the
+  regression with a Vitest stubbed-storage test.
 - Move the unit module barrel exports into `src/unit/index.ts`, refreshing
   import paths across the game and renderer to keep the public unit surface
   stable while aligning with directory conventions.

--- a/src/audio/ambience.test.ts
+++ b/src/audio/ambience.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('ambience storage resilience', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to defaults when persisted preferences are unavailable', async () => {
+    vi.resetModules();
+    const throwingStorage = {
+      getItem: vi.fn(() => {
+        throw new Error('storage disabled');
+      }),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      key: vi.fn(),
+      get length() {
+        return 0;
+      },
+    };
+
+    vi.stubGlobal('localStorage', throwingStorage as unknown as Storage);
+    vi.mock('./sfx.ts', () => ({
+      initAudioSafe: vi.fn(() => null),
+      isMuted: vi.fn(() => false),
+      onMuteChange: vi.fn(() => () => undefined),
+    }));
+
+    const ambience = await import('./ambience.ts');
+
+    expect(ambience.isEnabled()).toBe(false);
+    expect(ambience.getVolume()).toBeCloseTo(0.65, 5);
+    expect(throwingStorage.getItem).toHaveBeenCalledTimes(2);
+    expect(throwingStorage.getItem).toHaveBeenNthCalledWith(1, 'audio_enabled');
+    expect(throwingStorage.getItem).toHaveBeenNthCalledWith(2, 'audio_volume');
+  });
+});

--- a/src/audio/ambience.ts
+++ b/src/audio/ambience.ts
@@ -25,11 +25,23 @@ let bufferPromise: Promise<AudioBuffer> | null = null;
 let masterGain: GainNode | null = null;
 let nextStartTimer: ReturnType<typeof setTimeout> | null = null;
 
-const storedEnabled = typeof localStorage !== 'undefined' ? localStorage.getItem(ENABLED_KEY) : null;
+function readStoredPreference(key: string): string | null {
+  if (typeof localStorage === 'undefined') {
+    return null;
+  }
+  try {
+    return localStorage.getItem(key);
+  } catch (error) {
+    console.warn('Unable to read ambience preference', key, error);
+    return null;
+  }
+}
+
+const storedEnabled = readStoredPreference(ENABLED_KEY);
 let enabled = storedEnabled === 'true';
 let hasExplicitPreference = storedEnabled !== null;
 
-const storedVolume = typeof localStorage !== 'undefined' ? localStorage.getItem(VOLUME_KEY) : null;
+const storedVolume = readStoredPreference(VOLUME_KEY);
 let volume = clampNumber(storedVolume ? Number(storedVolume) : NaN, 0.65);
 
 let playing = false;


### PR DESCRIPTION
## Summary
- add a safe `readStoredPreference` helper so ambience preferences fall back to defaults when storage access fails
- cover the failure case with a Vitest that stubs `localStorage.getItem` to throw
- document the resilience improvement in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd18a83fb08330b64831f109a79f48