### PR TITLE
refactor: extract SISU burst module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Migrate SISU burst APIs into `src/sisu/burst.ts`, retarget the game, renderer,
+  and HUD imports, and remove the legacy `src/sim/sisu.ts` implementation after
+  the move.
 - Rebuild the GitHub Pages mirror from commit ce40f24 so the hashed Vite
   bundle, published HTML, and build badge all advertise the latest deploy.
 - Add a `verify:docs` guard that checks the docs bundle commit hash against the

--- a/src/game.ts
+++ b/src/game.ts
@@ -13,7 +13,7 @@ import { setupSaunaUI } from './ui/sauna.tsx';
 import { resetAutoFrame } from './camera/autoFrame.ts';
 import { setupTopbar } from './ui/topbar.ts';
 import { playSafe } from './audio/sfx.ts';
-import { useSisuBurst, torille, SISU_BURST_COST, TORILLE_COST } from './sim/sisu.ts';
+import { useSisuBurst, torille, SISU_BURST_COST, TORILLE_COST } from './sisu/burst.ts';
 import { setupRightPanel, type GameEvent, type RosterEntry } from './ui/rightPanel.tsx';
 import { createTutorialController, type TutorialController } from './ui/tutorial/Tutorial.tsx';
 import { draw as render } from './render/renderer.ts';

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -2,7 +2,7 @@ import type { AxialCoord, PixelCoord } from '../hex/HexUtils.ts';
 import { hexDistance } from '../hex/HexUtils.ts';
 import type { LoadedAssets } from '../loader.ts';
 import type { Unit } from '../unit/index.ts';
-import { isSisuBurstActive } from '../sim/sisu.ts';
+import { isSisuBurstActive } from '../sisu/burst.ts';
 import type { Sauna } from '../sim/sauna.ts';
 import { HexMapRenderer } from './HexMapRenderer.ts';
 import { camera } from '../camera/autoFrame.ts';

--- a/src/sim/sisu.test.ts
+++ b/src/sim/sisu.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { GameState, Resource } from '../core/GameState.ts';
-import { useSisuBurst, endSisuBurst, isSisuBurstActive } from './sisu.ts';
+import { useSisuBurst, endSisuBurst, isSisuBurstActive } from '../sisu/burst.ts';
 import { modifierRuntime } from '../mods/runtime.ts';
 import { Unit } from '../units/Unit.ts';
 import type { UnitStats } from '../unit/types.ts';

--- a/src/sisu/burst.ts
+++ b/src/sisu/burst.ts
@@ -3,7 +3,7 @@ import type { GameState } from '../core/GameState.ts';
 import { Resource } from '../core/GameState.ts';
 import type { HexMap } from '../hexmap.ts';
 import type { Unit } from '../units/Unit.ts';
-import { pickFreeTileAround } from './sauna.ts';
+import { pickFreeTileAround } from '../sim/sauna.ts';
 import { eventBus } from '../events';
 import type { CombatHookPayload } from '../combat/resolve.ts';
 import { addModifier, removeModifier } from '../mods/runtime.ts';

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -12,7 +12,7 @@ import {
   isSisuBurstActive,
   SISU_BURST_COST,
   TORILLE_COST
-} from '../sim/sisu.ts';
+} from '../sisu/burst.ts';
 import { ensureHudLayout } from './layout.ts';
 import { subscribeToIsMobile } from './hooks/useIsMobile.ts';
 


### PR DESCRIPTION
## Summary
- move the SISU burst implementation into a new `src/sisu/burst.ts` module
- update game, renderer, HUD, and test imports to use the new path and delete the legacy file
- document the migration in the changelog

## Testing
- npm test
- npm run build
- npm run check:demo
- npm run simulate

------
https://chatgpt.com/codex/tasks/task_e_68cd270997588330b69cb4cbe6242b4c