### PR TITLE
Use OS temp directory for simulator output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Teach the balance simulator to resolve its CSV output inside the active OS
+  temp directory instead of hard-coding `/tmp`, and log the resolved path so
+  contributors can spot the destination.
 - Migrate SISU burst APIs into `src/sisu/burst.ts`, retarget the game, renderer,
   and HUD imports, and remove the legacy `src/sim/sisu.ts` implementation after
   the move.

--- a/scripts/simulate.ts
+++ b/scripts/simulate.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import type { AxialCoord } from '../src/hex/HexUtils.ts';
 import { HexMap } from '../src/hexmap.ts';
@@ -243,8 +245,9 @@ async function main(): Promise<void> {
   );
   const csv = [header, ...lines].join('\n');
 
-  await fs.writeFile('/tmp/balance.csv', csv, 'utf8');
-  console.log('Balance snapshot saved to /tmp/balance.csv');
+  const balancePath = join(tmpdir(), 'balance.csv');
+  await fs.writeFile(balancePath, csv, 'utf8');
+  console.log(`Balance snapshot saved to ${balancePath}`);
 }
 
 void main().catch((error) => {


### PR DESCRIPTION
## Summary
- resolve the balance simulator's CSV output path from the operating system temp directory and log the resolved location
- document the simulator output change in the changelog

## Testing
- npm run build
- npm run simulate
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd3bad8b5c8330b4184948d9752c3b