### PR TITLE
docs: restore changelog bullet formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
   seconds, matching the new simulation cadence and communicating the change to
   players.
 
-p resolution with new Vitest assertions.
+- p resolution with new Vitest assertions.
 
 - Surface sauna beer debt in the HUD by letting negative totals render, tagging
   the resource badge for debt styling, enriching the aria-label messaging, and


### PR DESCRIPTION
## Summary
- Restore the missing bullet marker in the Unreleased section of the changelog to match list formatting.
- Regenerated a Markdown preview via marked to verify the bullet renders correctly.

## Testing
- npm run build
- npx --yes marked CHANGELOG.md > /tmp/changelog.html

------
https://chatgpt.com/codex/tasks/task_e_68cd3cb6d4b48330afb3a4146678028d