### PR TITLE
Fix remaining shield total in combat resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fix combat resolution so `remainingShield` includes both base and keyword
+  barriers, and extend the resolve tests to cover leftover keyword stacks after
+  a hit.
+
 - Restrain fog-of-war reveals from re-triggering camera auto-framing after the
   opening reveal by adding an `autoFrame` toggle to `HexMap.revealAround` and
   opting recurring gameplay calls out so manual camera adjustments stay intact.

--- a/src/combat/resolve.test.ts
+++ b/src/combat/resolve.test.ts
@@ -253,13 +253,13 @@ describe('resolveCombat', () => {
     expect(burn.stacks).toBe(3);
   });
 
-  it('grants and consumes keyword shield stacks before applying damage', () => {
+  it('reports combined shield total when barrier stacks remain after the hit', () => {
     const barrier = makeKeyword('Shield', 3);
 
     const attacker: CombatParticipant = {
       id: 'shield-attacker',
       faction: 'alpha',
-      attack: 4,
+      attack: 3,
       health: 10,
       maxHealth: 10,
       shield: 0
@@ -271,19 +271,23 @@ describe('resolveCombat', () => {
       defense: 2,
       health: 10,
       maxHealth: 10,
-      shield: 0,
+      shield: 2,
       keywords: { barrier }
     };
 
     const result = resolveCombat({ attacker, defender });
 
-    expect(result.damage).toBe(2);
+    expect(result.damage).toBe(1);
+    expect(result.shieldDamage).toBe(1);
     expect(result.hpDamage).toBe(0);
     expect(result.keywordEffects.defender.shieldGranted).toBe(3);
-    expect(result.keywordEffects.defender.shieldConsumed).toBe(2);
-    expect(result.keywordEffects.defender.keywordShieldRemaining).toBe(1);
-    expect(result.remainingShield).toBe(0);
-    expect(barrier.stacks).toBe(1);
+    expect(result.keywordEffects.defender.shieldConsumed).toBe(0);
+    expect(result.keywordEffects.defender.keywordShieldRemaining).toBe(3);
+    const expectedRemaining =
+      Math.max(0, defender.shield - result.shieldDamage) +
+      result.keywordEffects.defender.keywordShieldRemaining;
+    expect(result.remainingShield).toBe(expectedRemaining);
+    expect(barrier.stacks).toBe(3);
   });
 
   it('combines keyword and base shields while tracking remaining barrier stacks', () => {
@@ -313,7 +317,7 @@ describe('resolveCombat', () => {
     expect(result.damage).toBe(10);
     expect(result.shieldDamage).toBe(10);
     expect(result.hpDamage).toBe(0);
-    expect(result.remainingShield).toBe(0);
+    expect(result.remainingShield).toBe(1);
     expect(result.keywordEffects.defender.shieldGranted).toBe(8);
     expect(result.keywordEffects.defender.shieldConsumed).toBe(7);
     expect(result.keywordEffects.defender.keywordShieldRemaining).toBe(1);

--- a/src/combat/resolve.ts
+++ b/src/combat/resolve.ts
@@ -288,7 +288,7 @@ export function resolveCombat(args: ResolveCombatArgs): CombatResolution {
     hpDamage,
     lethal,
     remainingHealth,
-    remainingShield: remainingBaseShield,
+    remainingShield: remainingBaseShield + keywordShieldRemaining,
     attackerHealing,
     attackerRemainingHealth: attackerState?.health,
     attackerRemainingShield: attackerState?.shield,


### PR DESCRIPTION
## Summary
- ensure combat resolution reports remaining shields including keyword barriers
- extend the resolve combat tests to cover hits that leave keyword stacks intact
- document the fix in the changelog

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cd40e32448833081621185c287dbae