### PR TITLE
Enhance enemy spawn ramping and bundle scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Ramp enemy progression by tracking spawn cycles, tightening spawn cadence
+  beyond the eight-second floor, and feeding a difficulty multiplier into bundle
+  spawns so late waves deploy stronger or more numerous units.
+
 - Rebuild HUD controllers during `setupGame` so repeated `destroy()` + `init()`
   cycles refresh the top bar, inventory badge, and command console without
   duplicating DOM nodes or leaking listeners, covering the flow with a Vitest

--- a/src/sim/EnemySpawner.test.ts
+++ b/src/sim/EnemySpawner.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EnemySpawner } from './EnemySpawner.ts';
 import type { Unit } from '../units/Unit.ts';
 import { getAvantoMarauderStats } from '../units/AvantoMarauder.ts';
+import * as enemySpawns from '../world/spawn/enemy_spawns.ts';
+import * as factionBundles from '../factions/bundles.ts';
+import type { FactionBundleDefinition } from '../factions/bundles.ts';
 
 function makeRandomSource(values: number[]): () => number {
   const queue = [...values];
@@ -9,6 +12,10 @@ function makeRandomSource(values: number[]): () => number {
 }
 
 describe('EnemySpawner', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('spawns bundles according to cadence and faction identity', () => {
     const spawner = new EnemySpawner({
       factionId: 'enemy',
@@ -51,5 +58,104 @@ describe('EnemySpawner', () => {
       const levelTwoStats = getAvantoMarauderStats(2);
       expect(lastUnit.stats.health).toBe(levelTwoStats.health);
     }
+  });
+
+  it('ramps spawn cadence and requests progressively higher tiers', () => {
+    const spawner = new EnemySpawner({
+      factionId: 'enemy',
+      difficulty: 1.5,
+      eliteOdds: 0,
+      random: () => 0.99
+    });
+    const units: Unit[] = [];
+    let edgeCursor = 0;
+    const pickEdge = () => ({ q: edgeCursor++, r: 0 });
+
+    const fixedBundle: FactionBundleDefinition = {
+      id: 'enemy-ramp-test',
+      label: 'Enemy Ramp Test',
+      weight: 1,
+      units: Object.freeze([{ unit: 'avanto-marauder', level: 2, quantity: 1 }]),
+      items: Object.freeze([]),
+      modifiers: Object.freeze([])
+    };
+    const bundleSpy = vi.spyOn(factionBundles, 'pickFactionBundle').mockReturnValue(fixedBundle);
+
+    const actualSpawn = enemySpawns.spawnEnemyBundle;
+    const spawnTimes: number[] = [];
+    const multipliers: number[] = [];
+    const capturedSpawns: Unit[][] = [];
+
+    let elapsed = 0;
+    const spawnSpy = vi
+      .spyOn(enemySpawns, 'spawnEnemyBundle')
+      .mockImplementation((options) => {
+        multipliers.push(options.difficultyMultiplier ?? 1);
+        spawnTimes.push(elapsed);
+        const result = actualSpawn(options);
+        capturedSpawns.push([...result.spawned]);
+        return result;
+      });
+
+    const targetSpawns = 15;
+    for (let iterations = 0; iterations < 500 && spawnTimes.length < targetSpawns; iterations += 1) {
+      elapsed += 1;
+      spawner.update(1, units, () => undefined, pickEdge);
+    }
+
+    spawnSpy.mockRestore();
+    bundleSpy.mockRestore();
+
+    expect(spawnTimes.length).toBeGreaterThanOrEqual(targetSpawns);
+    const intervals = spawnTimes.map((time, index) =>
+      index === 0 ? time : time - spawnTimes[index - 1]
+    );
+    expect(intervals[intervals.length - 1]).toBeLessThan(8);
+    expect(Math.min(...intervals.slice(1))).toBeLessThan(intervals[1]);
+    expect(multipliers[0]).toBe(1);
+    expect(multipliers[multipliers.length - 1]).toBeGreaterThan(multipliers[0]);
+
+    const lastSpawn = capturedSpawns.at(-1) ?? [];
+    for (const unit of lastSpawn) {
+      const baseStats = getAvantoMarauderStats(2);
+      expect(unit.stats.health).toBeGreaterThan(baseStats.health);
+    }
+  });
+
+  it('scales spawn bundles with the provided difficulty multiplier', () => {
+    const bundle: FactionBundleDefinition = {
+      id: 'test-bundle',
+      label: 'Test Bundle',
+      weight: 1,
+      units: [
+        { unit: 'avanto-marauder', level: 1, quantity: 1 },
+        { unit: 'avanto-marauder', level: 2, quantity: 1 }
+      ],
+      items: Object.freeze([]),
+      modifiers: Object.freeze([])
+    };
+    const added: Unit[] = [];
+    let idCounter = 0;
+    const result = enemySpawns.spawnEnemyBundle({
+      bundle,
+      factionId: 'enemy',
+      pickEdge: () => ({ q: 0, r: 0 }),
+      addUnit: (unit: Unit) => {
+        added.push(unit);
+      },
+      makeId: () => `test-${idCounter++}`,
+      availableSlots: 6,
+      eliteOdds: 0,
+      random: () => 0.9,
+      difficultyMultiplier: 2
+    });
+
+    expect(result.spawned).toHaveLength(4);
+    expect(added).toHaveLength(4);
+    const levelTwoStats = getAvantoMarauderStats(2);
+    const levelFourStats = getAvantoMarauderStats(4);
+    const spawnedHealth = added.map((unit) => unit.stats.health);
+    expect(spawnedHealth.some((value) => value >= levelFourStats.health)).toBe(true);
+    expect(spawnedHealth.every((value) => value >= levelTwoStats.health)).toBe(true);
   });
 });

--- a/src/world/spawn/enemy_spawns.ts
+++ b/src/world/spawn/enemy_spawns.ts
@@ -12,6 +12,7 @@ export interface SpawnBundleOptions {
   readonly availableSlots: number;
   readonly eliteOdds?: number;
   readonly random?: () => number;
+  readonly difficultyMultiplier?: number;
 }
 
 export interface SpawnBundleResult {
@@ -45,13 +46,22 @@ export function spawnEnemyBundle(options: SpawnBundleOptions): SpawnBundleResult
     0,
     Math.min(0.95, typeof options.eliteOdds === 'number' ? options.eliteOdds : 0)
   );
+  const difficultyMultiplier = Math.max(
+    1,
+    Number.isFinite(options.difficultyMultiplier)
+      ? (options.difficultyMultiplier as number)
+      : 1
+  );
 
   for (const spec of options.bundle.units) {
-    const iterations = Math.min(spec.quantity, slots);
+    const scaledQuantity = Math.max(1, Math.round(spec.quantity * difficultyMultiplier));
+    const iterations = Math.min(scaledQuantity, slots);
     const unitType = spec.unit as UnitType;
+    const scaledLevel = Math.max(1, Math.round(spec.level * difficultyMultiplier));
     for (let index = 0; index < iterations; index += 1) {
       const levelBoost = random() < eliteOdds ? 1 : 0;
-      const spawnOptions = buildSpawnOptions(Math.max(1, spec.level + levelBoost));
+      const spawnLevel = Math.max(1, scaledLevel + levelBoost);
+      const spawnOptions = buildSpawnOptions(spawnLevel);
       const coord = options.pickEdge();
       if (!coord) {
         return {


### PR DESCRIPTION
## Summary
- track spawn cycles in the enemy spawner, derive a ramp factor to reduce cadence beyond the existing floor, and forward a difficulty multiplier with each bundle request
- scale spawn bundle quantities and levels off the provided multiplier so late waves deliver tougher or more numerous enemies
- extend the EnemySpawner test suite to simulate long runs, validate cadence tightening, ensure higher tiers are requested, and document the change in the changelog

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ce3d102eb08330b855e4494385ea8b