### PR TITLE
Filter player units when Saunoja overlays render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Prevent Saunoja overlays from double-rendering player combatants by omitting
+  player-faction units from battlefield draw passes whenever attendants are
+  projected on top of the map.
+
 - Ramp enemy progression by tracking spawn cycles, tightening spawn cadence
   beyond the eight-second floor, and feeding a difficulty multiplier into bundle
   spawns so late waves deploy stronger or more numerous units.

--- a/src/game.ts
+++ b/src/game.ts
@@ -1126,12 +1126,16 @@ export function draw(): void {
   const fxOptions = unitFx
     ? { getUnitAlpha: (unit: Unit) => unitFx!.getUnitAlpha(unit.id) }
     : undefined;
+  const hasSaunojaOverlays = Array.isArray(saunojas) && saunojas.length > 0;
+  const renderUnits = hasSaunojaOverlays
+    ? units.filter((unit) => unit.faction !== 'player')
+    : units;
 
   ctx.save();
   if (shakeOffset.x !== 0 || shakeOffset.y !== 0) {
     ctx.translate(shakeOffset.x, shakeOffset.y);
   }
-  render(ctx, mapRenderer, assets.images, units, selected, {
+  render(ctx, mapRenderer, assets.images, renderUnits, selected, {
     saunojas: {
       units: saunojas,
       draw: drawSaunojas


### PR DESCRIPTION
## Summary
- filter player-faction units out of the battlefield render pass whenever Saunoja overlays are active to avoid overlapping sprites
- add a renderer regression test that spies on the draw routine to verify player units are omitted when attendants are present
- document the Saunoja overlay rendering fix in the changelog

## Testing
- npm test -- --run *(fails at verify:docs because the docs bundle commit 1bde2c0 does not match HEAD ef38287; Vitest suites pass)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3faf5e8483308b038f13c1aeeb6f