### PR TITLE
Track sauna destruction defeat handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Track sauna structural health in objectives, piping combat-driven
+  `saunaDestroyed` defeat events through the tracker and combat manager so runs
+  end immediately when enemies raze the structure, with progress summaries now
+  reporting sauna durability.
 - Prevent Saunoja overlays from double-rendering player combatants by omitting
   player-faction units from battlefield draw passes whenever attendants are
   projected on top of the map.

--- a/scripts/simulate.ts
+++ b/scripts/simulate.ts
@@ -204,7 +204,7 @@ function runSeededSimulation(seed: number): SimulationRow[] {
       });
 
       enemySpawner.update(1, units, addEnemyUnit, pickEdge);
-      battleManager.tick(units, 1);
+      battleManager.tick(units, 1, sauna);
 
       const beer = state.getResource(Resource.SAUNA_BEER);
       const roster = units.filter((unit) => unit.faction === 'player' && !unit.isDead()).length;

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -17,3 +17,15 @@ export interface UnitDiedPayload {
   unitFaction: string;
   attackerFaction?: string;
 }
+
+export interface SaunaDamagedPayload {
+  attackerId?: string;
+  attackerFaction?: string;
+  amount: number;
+  remainingHealth: number;
+}
+
+export interface SaunaDestroyedPayload {
+  attackerId?: string;
+  attackerFaction?: string;
+}

--- a/src/game.ts
+++ b/src/game.ts
@@ -753,7 +753,7 @@ const clock = new GameClock(1000, (deltaMs) => {
     getRosterCount: getActiveRosterCount
   });
   enemySpawner.update(dtSeconds, units, registerUnit, pickRandomEdgeFreeTile);
-  battleManager.tick(units, dtSeconds);
+  battleManager.tick(units, dtSeconds, sauna);
   advanceModifiers(dtSeconds);
   if (syncSaunojaRosterWithUnits()) {
     updateRosterDisplay();
@@ -885,6 +885,7 @@ objectiveTracker = createObjectiveTracker({
   state,
   map,
   getRosterCount: getActiveRosterCount,
+  sauna,
   rosterWipeGraceMs: 8000,
   bankruptcyGraceMs: 12000
 });


### PR DESCRIPTION
## Summary
- add structural health to the sauna model and expose helpers for combat damage
- emit sauna defeat events from the battle manager and subscribe the objective tracker to the new cause and state
- thread the sauna reference through game/simulation setup and cover the defeat flow with a BattleManager test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce425fc5cc83308d41488495de724c