### PR TITLE
Add sauna destruction narrative to end screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Script a new end-screen epilogue for sauna destruction so defeat runs narrate
+  the collapse with bespoke copy and polished UI coverage.
+
 - Refresh the soldier and archer unit art with high-fidelity 128×128 SVGs,
   recalibrated sprite metadata, and placement tests so their battlefield
   silhouettes match the marauder's polish.

--- a/src/ui/overlays/EndScreen.test.ts
+++ b/src/ui/overlays/EndScreen.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Resource } from '../../core/GameState.ts';
+import type { ObjectiveResolution } from '../../progression/objectives.ts';
+import { showEndScreen } from './EndScreen.tsx';
+
+describe('showEndScreen', () => {
+  let container: HTMLElement;
+  let originalRaf: typeof globalThis.requestAnimationFrame | undefined;
+
+  const baseResolution: ObjectiveResolution = {
+    outcome: 'lose',
+    cause: 'saunaDestroyed',
+    timestamp: 42_000,
+    durationMs: 180_000,
+    summary: {
+      strongholds: { total: 4, destroyed: 2, remaining: 2 },
+      roster: { active: 0, totalDeaths: 7, wipeSince: null, wipeDurationMs: 0 },
+      economy: {
+        beer: 0,
+        worstBeer: -35,
+        bankruptSince: null,
+        bankruptDurationMs: 0
+      },
+      sauna: { maxHealth: 1_000, health: 0, destroyed: true, destroyedAt: 41_500 },
+      startedAt: 0
+    },
+    rewards: {
+      resources: {
+        [Resource.SAUNA_BEER]: { final: 250, delta: 50 },
+        [Resource.SAUNAKUNNIA]: { final: 80, delta: 20 },
+        [Resource.SISU]: { final: 15, delta: 5 }
+      }
+    }
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    originalRaf = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+      cb(0);
+      return 0;
+    }) as typeof globalThis.requestAnimationFrame;
+  });
+
+  afterEach(() => {
+    container.remove();
+    const globalTarget = globalThis as {
+      requestAnimationFrame?: typeof globalThis.requestAnimationFrame;
+    };
+    if (originalRaf) {
+      globalTarget.requestAnimationFrame = originalRaf;
+    } else {
+      delete globalTarget.requestAnimationFrame;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('renders a polished defeat message when the sauna falls', () => {
+    const controller = showEndScreen({
+      container,
+      resolution: baseResolution,
+      currentNgPlusLevel: 2,
+      onNewRun: vi.fn(),
+      onDismiss: vi.fn()
+    });
+
+    const subtitle = container.querySelector('.end-screen__subtitle');
+    expect(subtitle?.textContent).toBe(
+      'The sauna collapsed under relentless assault—the sacred steamline has fallen silent.'
+    );
+
+    controller.destroy();
+  });
+});
+

--- a/src/ui/overlays/EndScreen.tsx
+++ b/src/ui/overlays/EndScreen.tsx
@@ -47,6 +47,8 @@ function describeCause(resolution: ObjectiveResolution): string {
       return 'Every attendant is down—no one remains to hold the line.';
     case 'bankruptcy':
       return 'Upkeep debts have exhausted the steam reserves.';
+    case 'saunaDestroyed':
+      return 'The sauna collapsed under relentless assault—the sacred steamline has fallen silent.';
     default:
       return '';
   }


### PR DESCRIPTION
## Summary
- add bespoke sauna destruction defeat copy to the end screen overlay
- cover the new narration with a focused Vitest DOM spec and log the change in the changelog

## Testing
- npx vitest run src/ui/overlays/EndScreen.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce4811c57483308c753300d9efe9b4