### PR TITLE
Fix inventory overlay pointer events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Restore the inventory overlay's pointer interactivity only while the stash
+  panel is open so its controls respond crisply without blocking gameplay when
+  closed.
+
 - Script a new end-screen epilogue for sauna destruction so defeat runs narrate
   the collapse with bespoke copy and polished UI coverage.
 

--- a/src/style.css
+++ b/src/style.css
@@ -146,6 +146,14 @@ body > #game-container {
   gap: clamp(16px, 3vw, 28px);
 }
 
+#ui-overlay.inventory-panel-open {
+  pointer-events: auto;
+}
+
+#ui-overlay.inventory-panel-open #inventory-stash-panel {
+  pointer-events: auto;
+}
+
 .is-mobile #ui-overlay {
   gap: clamp(12px, 4vw, 18px);
 }


### PR DESCRIPTION
## Summary
- restore pointer interactivity to `#ui-overlay` whenever the inventory panel is open so stash controls remain clickable
- document the inventory overlay interaction fix in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce49221c6883308772116f056d22d3