### PR TITLE
Handle stash focus failures gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Keep the stash overlay interactive even when focus operations throw by
+  toggling the inventory panel class before focusing, guarding the panel focus
+  helper with a fallback, and covering the regression with Vitest DOM tests.
+- Add a sauna integrity HUD that tracks structure health with an animated
 - Add a sauna integrity HUD that tracks structure health with an animated
   glassmorphism bar, reacts to combat events with reduced-motion aware impact
   flashes plus destruction shockwaves, and ships with Vitest coverage for the

--- a/src/ui/inventoryHud.test.ts
+++ b/src/ui/inventoryHud.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupInventoryHud } from './inventoryHud.ts';
+import type { InventoryEvent, InventoryState } from '../inventory/state.ts';
+import type { StashPanelController } from './stash/StashPanel.tsx';
+
+const focusMock = vi.fn();
+const setOpenMock = vi.fn();
+const renderMock = vi.fn();
+const destroyMock = vi.fn();
+
+let stashPanel: StashPanelController;
+
+vi.mock('./stash/StashPanel.tsx', () => {
+  return {
+    createStashPanel: vi.fn(() => stashPanel)
+  };
+});
+
+describe('setupInventoryHud', () => {
+  let overlay: HTMLElement;
+
+  beforeEach(() => {
+    overlay = document.createElement('div');
+    overlay.id = 'ui-overlay';
+    document.body.appendChild(overlay);
+
+    focusMock.mockReset();
+    setOpenMock.mockReset();
+    renderMock.mockReset();
+    destroyMock.mockReset();
+
+    stashPanel = {
+      element: document.createElement('div'),
+      render: renderMock,
+      setOpen: setOpenMock,
+      focus: focusMock,
+      destroy: destroyMock
+    } satisfies StashPanelController;
+  });
+
+  afterEach(() => {
+    overlay.remove();
+  });
+
+  it('keeps the overlay interactive when focusing the panel throws', () => {
+    focusMock.mockImplementation(() => {
+      throw new Error('focus failed');
+    });
+
+    const listeners = new Set<(event: InventoryEvent) => void>();
+
+    const inventory = {
+      isAutoEquipEnabled: () => false,
+      getStash: () => [],
+      getInventory: () => [],
+      equipFromStash: vi.fn(),
+      equipFromInventory: vi.fn(),
+      moveToInventory: vi.fn(),
+      moveToStash: vi.fn(),
+      discardFromStash: vi.fn(),
+      discardFromInventory: vi.fn(),
+      on: (listener: (event: InventoryEvent) => void) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      }
+    } as unknown as InventoryState;
+
+    const hud = setupInventoryHud(inventory);
+
+    const badge = overlay.querySelector<HTMLButtonElement>('.inventory-badge');
+    expect(badge).not.toBeNull();
+
+    badge!.click();
+
+    expect(setOpenMock).toHaveBeenCalledWith(true);
+    expect(overlay.classList.contains('inventory-panel-open')).toBe(true);
+
+    badge!.click();
+
+    expect(setOpenMock).toHaveBeenCalledWith(false);
+    expect(overlay.classList.contains('inventory-panel-open')).toBe(false);
+
+    hud.destroy();
+  });
+});

--- a/src/ui/inventoryHud.ts
+++ b/src/ui/inventoryHud.ts
@@ -214,8 +214,12 @@ export function setupInventoryHud(
       isOpen ? 'Close quartermaster stash' : 'Open quartermaster stash'
     );
     if (isOpen) {
-      panel.focus();
       overlay.classList.add('inventory-panel-open');
+      try {
+        panel.focus();
+      } catch (error) {
+        console.warn('Unable to focus stash panel', error);
+      }
     } else {
       overlay.classList.remove('inventory-panel-open');
     }

--- a/src/ui/stash/StashPanel.test.tsx
+++ b/src/ui/stash/StashPanel.test.tsx
@@ -156,4 +156,25 @@ describe('createStashPanel', () => {
     readyButton.dispatchEvent(new Event('click'));
     expect(callbacks.onCollectionChange).toHaveBeenCalledWith('inventory');
   });
+
+  it('falls back to focusing without options when preventScroll throws', () => {
+    const panel = createStashPanel({});
+    container.appendChild(panel.element);
+
+    const focusMock = vi
+      .fn<HTMLElement['focus']>()
+      .mockImplementation((options?: FocusOptions) => {
+        if (options) {
+          throw new TypeError('preventScroll unsupported');
+        }
+      });
+
+    panel.element.focus = focusMock as typeof panel.element.focus;
+
+    panel.focus();
+
+    expect(focusMock).toHaveBeenCalledTimes(2);
+    expect(focusMock.mock.calls[0][0]).toEqual({ preventScroll: true });
+    expect(focusMock.mock.calls[1]).toEqual([]);
+  });
 });

--- a/src/ui/stash/StashPanel.tsx
+++ b/src/ui/stash/StashPanel.tsx
@@ -249,7 +249,17 @@ export function createStashPanel(callbacks: StashPanelCallbacks): StashPanelCont
       element.dataset.open = open ? 'true' : 'false';
     },
     focus() {
-      element.focus({ preventScroll: true });
+      const focusElement = element.focus.bind(element);
+      try {
+        focusElement({ preventScroll: true });
+      } catch (error) {
+        console.warn('Stash panel focus without scroll prevention fallback', error);
+        try {
+          focusElement();
+        } catch (fallbackError) {
+          console.warn('Unable to focus stash panel element', fallbackError);
+        }
+      }
     },
     destroy() {
       element.remove();


### PR DESCRIPTION
## Summary
- ensure the inventory HUD toggles its overlay class before attempting to focus the stash panel so pointer events stay enabled even if focusing fails
- guard the stash panel focus helper with a preventScroll fallback and document the regression fix in the changelog
- add focused unit HUD and stash panel tests that simulate focus errors to confirm the overlay remains interactive

## Testing
- npm test *(fails: docs bundle commit c67240a does not match HEAD 063a716)*

------
https://chatgpt.com/codex/tasks/task_e_68ce50a615f08330981a46c62d0dad92