### PR TITLE
Preserve enemy visibility under Saunoja overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Prevent Saunoja overlays from double-rendering player combatants by omitting
   player-faction units from battlefield draw passes whenever attendants are
   projected on top of the map.
+- Preserve enemy visibility when Saunoja overlays hide player sprites by
+  routing friendly vision sources through the renderer and covering the
+  regression with a focused Vitest battlefield draw test.
 
 - Ramp enemy progression by tracking spawn cycles, tightening spawn cadence
   beyond the eight-second floor, and feeding a difficulty multiplier into bundle

--- a/src/game.ts
+++ b/src/game.ts
@@ -1140,6 +1140,9 @@ export function draw(): void {
     ? { getUnitAlpha: (unit: Unit) => unitFx!.getUnitAlpha(unit.id) }
     : undefined;
   const hasSaunojaOverlays = Array.isArray(saunojas) && saunojas.length > 0;
+  const friendlyVisionSources = units.filter(
+    (unit) => unit.faction === 'player' && !unit.isDead()
+  );
   const renderUnits = hasSaunojaOverlays
     ? units.filter((unit) => unit.faction !== 'player')
     : units;
@@ -1154,7 +1157,8 @@ export function draw(): void {
       draw: drawSaunojas
     },
     sauna,
-    fx: fxOptions
+    fx: fxOptions,
+    friendlyVisionSources
   });
   ctx.restore();
 }

--- a/src/render/renderer.test.ts
+++ b/src/render/renderer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { drawUnits } from './renderer.ts';
+import type { Unit } from '../unit/index.ts';
+import type { HexMapRenderer } from './HexMapRenderer.ts';
+import type { PixelCoord } from '../hex/HexUtils.ts';
+import { camera } from '../camera/autoFrame.ts';
+
+vi.mock('../sisu/burst.ts', () => ({
+  isSisuBurstActive: () => false
+}));
+
+function createMockContext(): CanvasRenderingContext2D {
+  const canvas = {
+    width: 256,
+    height: 256
+  } as HTMLCanvasElement;
+  const ctx = {
+    canvas,
+    save: vi.fn(),
+    restore: vi.fn(),
+    drawImage: vi.fn(),
+    strokeRect: vi.fn(),
+    filter: '',
+    globalAlpha: 1,
+    strokeStyle: '',
+    lineWidth: 1
+  } as unknown as CanvasRenderingContext2D;
+  return ctx;
+}
+
+function createStubUnit(
+  id: string,
+  faction: string,
+  coord: { q: number; r: number },
+  type: string,
+  visionRange = 3
+): Unit {
+  return {
+    id,
+    faction,
+    coord,
+    type,
+    stats: {
+      health: 10,
+      attackDamage: 1,
+      attackRange: 1,
+      movementRange: 1
+    },
+    isDead: () => false,
+    getMaxHealth: () => 10,
+    getVisionRange: () => visionRange
+  } as unknown as Unit;
+}
+
+describe('drawUnits', () => {
+  beforeEach(() => {
+    camera.x = 0;
+    camera.y = 0;
+    camera.zoom = 1;
+  });
+
+  it('renders enemies within friendly vision when Saunoja overlay hides player sprites', () => {
+    const friendly = createStubUnit('friendly', 'player', { q: 0, r: 0 }, 'soldier');
+    const enemy = createStubUnit('enemy', 'enemy', { q: 1, r: 0 }, 'marauder');
+    const mapRenderer = { hexSize: 32 } as unknown as HexMapRenderer;
+    const origin: PixelCoord = { x: 0, y: 0 };
+    const ctx = createMockContext();
+    const makeImage = () => document.createElement('img') as HTMLImageElement;
+    const assets = {
+      'unit-soldier': makeImage(),
+      'unit-marauder': makeImage(),
+      placeholder: makeImage()
+    };
+
+    drawUnits(ctx, mapRenderer, assets, [enemy], origin, undefined, [friendly]);
+
+    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    expect(ctx.drawImage).toHaveBeenCalledWith(
+      assets['unit-marauder'],
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number)
+    );
+  });
+});

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -28,6 +28,7 @@ export interface DrawOptions {
   };
   sauna?: Sauna | null;
   fx?: FxLayerOptions;
+  friendlyVisionSources?: readonly Unit[];
 }
 
 export function draw(
@@ -66,7 +67,15 @@ export function draw(
       zoom: camera.zoom
     });
   }
-  drawUnits(ctx, mapRenderer, assets, units, origin, options?.fx);
+  drawUnits(
+    ctx,
+    mapRenderer,
+    assets,
+    units,
+    origin,
+    options?.fx,
+    options?.friendlyVisionSources
+  );
   if (options?.sauna) {
     drawSaunaOverlay(ctx, options.sauna, {
       origin,
@@ -82,9 +91,11 @@ export function drawUnits(
   assets: LoadedAssets['images'],
   units: Unit[],
   origin: PixelCoord,
-  fx?: FxLayerOptions
+  fx?: FxLayerOptions,
+  visionSources?: readonly Unit[]
 ): void {
-  const friendlyVisionSources = units
+  const visionUnits = visionSources ?? units;
+  const friendlyVisionSources = visionUnits
     .filter((unit) => unit.faction === 'player' && !unit.isDead())
     .map((unit) => ({ coord: unit.coord, range: unit.getVisionRange() }));
   for (const unit of units) {


### PR DESCRIPTION
## Summary
- surface the living player unit list to renderer draws so Saunoja overlays can hide duplicate sprites without losing vision
- accept explicit friendly vision sources in `drawUnits` and cover the regression with a focused renderer test
- document the fix in the changelog

## Testing
- npx vitest run src/render/renderer.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce52658a04833096ebf9b295c47f40