### PR TITLE
Include sauna aura in fog-of-war vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
 - Preserve enemy visibility when Saunoja overlays hide player sprites by
   routing friendly vision sources through the renderer and covering the
   regression with a focused Vitest battlefield draw test.
+- Extend the sauna's aura as a vision source so overlapping enemies stay
+  visible even without active scouts, wiring the renderer through the game
+  draw loop and locking the behaviour down with a Vitest regression.
 
 - Ramp enemy progression by tracking spawn cycles, tightening spawn cadence
   beyond the eight-second floor, and feeding a difficulty multiplier into bundle

--- a/src/game.ts
+++ b/src/game.ts
@@ -17,7 +17,7 @@ import { playSafe } from './audio/sfx.ts';
 import { useSisuBurst, torille, SISU_BURST_COST, TORILLE_COST } from './sisu/burst.ts';
 import { setupRightPanel, type GameEvent, type RosterEntry } from './ui/rightPanel.tsx';
 import { createTutorialController, type TutorialController } from './ui/tutorial/Tutorial.tsx';
-import { draw as render } from './render/renderer.ts';
+import { draw as render, type VisionSource } from './render/renderer.ts';
 import { createUnitFxManager, type UnitFxManager } from './render/unit_fx.ts';
 import { HexMapRenderer } from './render/HexMapRenderer.ts';
 import type { Saunoja, SaunojaItem, SaunojaStatBlock } from './units/saunoja.ts';
@@ -1143,6 +1143,12 @@ export function draw(): void {
   const friendlyVisionSources = units.filter(
     (unit) => unit.faction === 'player' && !unit.isDead()
   );
+  const saunaVision: VisionSource | null = sauna
+    ? {
+        coord: sauna.pos,
+        range: sauna.auraRadius
+      }
+    : null;
   const renderUnits = hasSaunojaOverlays
     ? units.filter((unit) => unit.faction !== 'player')
     : units;
@@ -1157,6 +1163,7 @@ export function draw(): void {
       draw: drawSaunojas
     },
     sauna,
+    saunaVision,
     fx: fxOptions,
     friendlyVisionSources
   });

--- a/src/render/renderer.test.ts
+++ b/src/render/renderer.test.ts
@@ -3,6 +3,7 @@ import { drawUnits } from './renderer.ts';
 import type { Unit } from '../unit/index.ts';
 import type { HexMapRenderer } from './HexMapRenderer.ts';
 import type { PixelCoord } from '../hex/HexUtils.ts';
+import type { Sauna } from '../sim/sauna.ts';
 import { camera } from '../camera/autoFrame.ts';
 
 vi.mock('../sisu/burst.ts', () => ({
@@ -73,6 +74,33 @@ describe('drawUnits', () => {
     };
 
     drawUnits(ctx, mapRenderer, assets, [enemy], origin, undefined, [friendly]);
+
+    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    expect(ctx.drawImage).toHaveBeenCalledWith(
+      assets['unit-marauder'],
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number)
+    );
+  });
+
+  it('renders enemies overlapping the sauna when only sauna vision is supplied', () => {
+    const enemy = createStubUnit('enemy', 'enemy', { q: 0, r: 0 }, 'marauder');
+    const sauna = {
+      pos: enemy.coord,
+      auraRadius: 2
+    } as unknown as Sauna;
+    const mapRenderer = { hexSize: 32 } as unknown as HexMapRenderer;
+    const origin: PixelCoord = { x: 0, y: 0 };
+    const ctx = createMockContext();
+    const makeImage = () => document.createElement('img') as HTMLImageElement;
+    const assets = {
+      'unit-marauder': makeImage(),
+      placeholder: makeImage()
+    };
+
+    drawUnits(ctx, mapRenderer, assets, [enemy], origin, undefined, [], sauna);
 
     expect(ctx.drawImage).toHaveBeenCalledTimes(1);
     expect(ctx.drawImage).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- treat sauna data as a vision source inside the renderer so fog-of-war checks include its aura radius
- propagate a typed sauna vision payload from the game draw loop into the renderer
- cover the regression with a Vitest that renders an enemy with only sauna vision and update the changelog entry

## Testing
- npm run test -- renderer

------
https://chatgpt.com/codex/tasks/task_e_68ce597fee8883308a5a920b9946283b