### PR TITLE
Overhaul enemy scaling with ramp curves and telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,9 @@
   visible even without active scouts, wiring the renderer through the game
   draw loop and locking the behaviour down with a Vitest regression.
 
-- Ramp enemy progression by tracking spawn cycles, tightening spawn cadence
-  beyond the eight-second floor, and feeding a difficulty multiplier into bundle
-  spawns so late waves deploy stronger or more numerous units.
+- Overhaul enemy scaling with configurable difficulty curves, ramp-tier bundle
+  unlocks, telemetry snapshots, and long-run simulations so cadence keeps
+  tightening and marauders escalate in strength for balance tuning.
 
 - Rebuild the GitHub Pages mirror from commit ef38287 so the hashed Vite
   bundle, published HTML, and build badge all advertise the latest deploy.

--- a/src/content/factions/enemy.json
+++ b/src/content/factions/enemy.json
@@ -7,6 +7,7 @@
       "id": "iceblade-scouts",
       "label": "Iceblade Scouts",
       "weight": 3,
+      "minRampTier": 0,
       "units": [
         { "unit": "avanto-marauder", "level": 1, "quantity": 1 }
       ],
@@ -17,6 +18,7 @@
       "id": "raiding-party",
       "label": "Raiding Party",
       "weight": 2,
+      "minRampTier": 0,
       "units": [
         { "unit": "avanto-marauder", "level": 1, "quantity": 2 }
       ],
@@ -27,11 +29,48 @@
       "id": "frost-champion",
       "label": "Frost Champion",
       "weight": 1,
+      "minRampTier": 0,
       "units": [
         { "unit": "avanto-marauder", "level": 2, "quantity": 1 }
       ],
       "items": ["glacier-brand"],
       "modifiers": ["glacial-ward"]
+    },
+    {
+      "id": "icebreaker-vanguard",
+      "label": "Icebreaker Vanguard",
+      "weight": 2.5,
+      "minRampTier": 1,
+      "units": [
+        { "unit": "avanto-marauder", "level": 2, "quantity": 2 },
+        { "unit": "avanto-marauder", "level": 1, "quantity": 1 }
+      ],
+      "items": ["stormglass-pendant"],
+      "modifiers": ["frost-resilience", "berserker-drift"]
+    },
+    {
+      "id": "glacial-phalanx",
+      "label": "Glacial Phalanx",
+      "weight": 2,
+      "minRampTier": 2,
+      "units": [
+        { "unit": "avanto-marauder", "level": 3, "quantity": 3 },
+        { "unit": "avanto-marauder", "level": 2, "quantity": 1 }
+      ],
+      "items": ["glacier-brand", "frostshard-relic"],
+      "modifiers": ["glacial-ward", "polar-endurance"]
+    },
+    {
+      "id": "avalanche-warhost",
+      "label": "Avalanche Warhost",
+      "weight": 1.25,
+      "minRampTier": 3,
+      "units": [
+        { "unit": "avanto-marauder", "level": 4, "quantity": 3 },
+        { "unit": "avanto-marauder", "level": 3, "quantity": 2 }
+      ],
+      "items": ["avalanche-totem"],
+      "modifiers": ["glacial-ward", "polar-endurance", "berserker-drift"]
     }
   ]
 }

--- a/src/data/difficultyCurves.ts
+++ b/src/data/difficultyCurves.ts
@@ -1,0 +1,149 @@
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+export interface EnemyRampMetrics {
+  readonly runSeconds: number;
+  readonly clears: number;
+  readonly spawnCycles: number;
+}
+
+export interface EnemyRampStageDefinition {
+  readonly id: string;
+  readonly label: string;
+  readonly minRunSeconds: number;
+  readonly minClears: number;
+  readonly cadence: number;
+  readonly multiplier: number;
+  readonly bundleTier: number;
+}
+
+export interface EnemyRampEvaluation {
+  readonly stage: EnemyRampStageDefinition;
+  readonly stageIndex: number;
+  readonly cadenceTarget: number;
+  readonly multiplierBase: number;
+}
+
+const ENEMY_RAMP_STAGES: readonly EnemyRampStageDefinition[] = Object.freeze([
+  {
+    id: 'skirmish',
+    label: 'Skirmish Patrols',
+    minRunSeconds: 0,
+    minClears: 0,
+    cadence: 26,
+    multiplier: 1,
+    bundleTier: 0
+  },
+  {
+    id: 'raids',
+    label: 'Raid Pressure',
+    minRunSeconds: 90,
+    minClears: 2,
+    cadence: 19,
+    multiplier: 1.35,
+    bundleTier: 1
+  },
+  {
+    id: 'siege',
+    label: 'Siege Lines',
+    minRunSeconds: 210,
+    minClears: 5,
+    cadence: 13,
+    multiplier: 1.8,
+    bundleTier: 2
+  },
+  {
+    id: 'onslaught',
+    label: 'Winter Onslaught',
+    minRunSeconds: 360,
+    minClears: 9,
+    cadence: 8.5,
+    multiplier: 2.45,
+    bundleTier: 3
+  },
+  {
+    id: 'maelstrom',
+    label: 'Glacier Maelstrom',
+    minRunSeconds: 540,
+    minClears: 14,
+    cadence: 6.2,
+    multiplier: 3.25,
+    bundleTier: 4
+  }
+]);
+
+function cadenceScaleForDifficulty(difficulty: number): number {
+  if (difficulty >= 1) {
+    const normalized = difficulty - 1;
+    return 1 / (1 + normalized * 0.45);
+  }
+  const deficit = 1 - difficulty;
+  return 1 + deficit * 0.35;
+}
+
+function multiplierScaleForDifficulty(difficulty: number): number {
+  if (difficulty >= 1) {
+    const normalized = difficulty - 1;
+    return 1 + normalized * 0.85;
+  }
+  const deficit = 1 - difficulty;
+  return clamp(1 - deficit * 0.4, 0.45, 1);
+}
+
+function sanitizeMetrics(metrics: EnemyRampMetrics): EnemyRampMetrics {
+  return {
+    runSeconds: Math.max(0, Number.isFinite(metrics.runSeconds) ? metrics.runSeconds : 0),
+    clears: Math.max(0, Number.isFinite(metrics.clears) ? metrics.clears : 0),
+    spawnCycles: Math.max(0, Number.isFinite(metrics.spawnCycles) ? metrics.spawnCycles : 0)
+  } satisfies EnemyRampMetrics;
+}
+
+export function evaluateEnemyRamp(
+  difficulty: number,
+  metrics: EnemyRampMetrics
+): EnemyRampEvaluation {
+  const sanitized = sanitizeMetrics(metrics);
+  let stageIndex = 0;
+  for (let index = 0; index < ENEMY_RAMP_STAGES.length; index += 1) {
+    const stage = ENEMY_RAMP_STAGES[index];
+    if (sanitized.runSeconds < stage.minRunSeconds || sanitized.clears < stage.minClears) {
+      break;
+    }
+    stageIndex = index;
+  }
+  const stage = ENEMY_RAMP_STAGES[stageIndex];
+  const cadenceScale = cadenceScaleForDifficulty(difficulty);
+  const multiplierScale = multiplierScaleForDifficulty(difficulty);
+  const cadenceTarget = Math.max(0.75, stage.cadence * cadenceScale);
+  const multiplierBase = stage.multiplier * multiplierScale;
+  return { stage, stageIndex, cadenceTarget, multiplierBase } satisfies EnemyRampEvaluation;
+}
+
+export function getEnemyCadenceDecay(difficulty: number): number {
+  if (difficulty >= 1) {
+    const normalized = Math.min(3, difficulty - 1);
+    return clamp(0.93 - normalized * 0.035, 0.82, 0.93);
+  }
+  const deficit = Math.min(1, 1 - difficulty);
+  return clamp(0.93 + deficit * 0.03, 0.9, 0.97);
+}
+
+export function getEnemyMultiplierGrowth(difficulty: number): number {
+  if (difficulty >= 1) {
+    const normalized = Math.min(3, difficulty - 1);
+    return 0.024 + normalized * 0.012;
+  }
+  const deficit = Math.min(1, 1 - difficulty);
+  return Math.max(0.012, 0.024 - deficit * 0.01);
+}
+
+export function getEnemyRampStages(): readonly EnemyRampStageDefinition[] {
+  return ENEMY_RAMP_STAGES;
+}

--- a/src/factions/bundles.test.ts
+++ b/src/factions/bundles.test.ts
@@ -19,8 +19,9 @@ describe('faction bundles', () => {
   });
 
   it('respects bundle weights during selection', () => {
+    const bundles = getFactionBundles('enemy');
     const bundle = pickFactionBundle('enemy', () => 0.99);
-    expect(bundle.id).toBe('frost-champion');
+    expect(bundle.id).toBe(bundles[bundles.length - 1]?.id ?? '');
   });
 
   it('falls back to Math.random when a provided source is invalid', () => {

--- a/src/factions/bundles.ts
+++ b/src/factions/bundles.ts
@@ -15,6 +15,7 @@ export interface FactionBundleDefinition {
   readonly units: readonly FactionBundleUnitDefinition[];
   readonly items: readonly string[];
   readonly modifiers: readonly string[];
+  readonly minRampTier?: number;
 }
 
 export interface FactionDefinition {
@@ -118,6 +119,18 @@ function parseUnitDefinition(
   return Object.freeze({ unit, level, quantity });
 }
 
+function toOptionalNonNegativeInteger(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return undefined;
+  }
+  const truncated = Math.floor(numeric);
+  return truncated >= 0 ? truncated : undefined;
+}
+
 function parseBundleDefinition(
   value: unknown,
   context: string,
@@ -138,13 +151,15 @@ function parseBundleDefinition(
   );
   const items = toStringArray(value.items, `${context}.items`);
   const modifiers = toStringArray(value.modifiers, `${context}.modifiers`);
+  const minRampTier = toOptionalNonNegativeInteger(value.minRampTier);
   return Object.freeze({
     id,
     label,
     weight,
     units: Object.freeze(units),
     items,
-    modifiers
+    modifiers,
+    minRampTier
   });
 }
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -10,6 +10,7 @@ import { eventBus } from './events';
 import type { SaunaDamagedPayload, SaunaDestroyedPayload } from './events/types.ts';
 import { createSauna, pickFreeTileAround } from './sim/sauna.ts';
 import { EnemySpawner } from './sim/EnemySpawner.ts';
+import { recordEnemyScalingTelemetry } from './state/telemetry/enemyScaling.ts';
 import { setupSaunaUI, type SaunaUIController } from './ui/sauna.tsx';
 import { resetAutoFrame } from './camera/autoFrame.ts';
 import { setupTopbar, type TopbarControls } from './ui/topbar.ts';
@@ -765,6 +766,12 @@ const clock = new GameClock(1000, (deltaMs) => {
     getRosterCount: getActiveRosterCount
   });
   enemySpawner.update(dtSeconds, units, registerUnit, pickRandomEdgeFreeTile);
+  const scalingSnapshot = enemySpawner.getSnapshot();
+  const rosterProgress = objectiveTracker?.getProgress().roster;
+  recordEnemyScalingTelemetry(scalingSnapshot, {
+    wipeSince: rosterProgress?.wipeSince ?? null,
+    wipeDurationMs: rosterProgress?.wipeDurationMs ?? 0
+  });
   battleManager.tick(units, dtSeconds, sauna);
   advanceModifiers(dtSeconds);
   if (syncSaunojaRosterWithUnits()) {

--- a/src/sim/EnemySpawner.ts
+++ b/src/sim/EnemySpawner.ts
@@ -1,8 +1,13 @@
 import type { Unit } from '../units/Unit.ts';
 import type { AxialCoord } from '../hex/HexUtils.ts';
 import { MAX_ENEMIES } from '../battle/BattleManager.ts';
-import { pickFactionBundle } from '../factions/bundles.ts';
-import { spawnEnemyBundle } from '../world/spawn/enemy_spawns.ts';
+import {
+  evaluateEnemyRamp,
+  getEnemyCadenceDecay,
+  getEnemyMultiplierGrowth,
+  type EnemyRampEvaluation
+} from '../data/difficultyCurves.ts';
+import { pickRampBundle, spawnEnemyBundle } from '../world/spawn/enemy_spawns.ts';
 
 export interface EnemySpawnerOptions {
   readonly factionId?: string;
@@ -11,6 +16,23 @@ export interface EnemySpawnerOptions {
   readonly difficulty?: number;
   readonly eliteOdds?: number;
 }
+
+export interface EnemySpawnerSnapshot {
+  readonly runSeconds: number;
+  readonly clears: number;
+  readonly spawnCycles: number;
+  readonly rampStageIndex: number;
+  readonly rampStageId: string;
+  readonly rampStageLabel: string;
+  readonly bundleTier: number;
+  readonly cadence: number;
+  readonly lastCadence: number;
+  readonly lastSpawnAt: number | null;
+  readonly lastClearAt: number | null;
+  readonly difficultyMultiplier: number;
+}
+
+const MAX_SPAWNS_PER_UPDATE = 6;
 
 export class EnemySpawner {
   private timer: number;
@@ -21,6 +43,17 @@ export class EnemySpawner {
   private readonly makeId: () => string;
   private readonly difficulty: number;
   private readonly eliteOdds: number;
+  private readonly cadenceDecay: number;
+  private readonly multiplierGrowth: number;
+  private runSeconds = 0;
+  private clearCount = 0;
+  private boardEmpty = true;
+  private lastClearAt: number | null = null;
+  private lastSpawnAt: number | null = null;
+  private lastCadence: number;
+  private lastMultiplier: number;
+  private rampEvaluation: EnemyRampEvaluation;
+  private rampStageIndex: number;
 
   constructor(options: EnemySpawnerOptions = {}) {
     this.factionId = options.factionId ?? 'enemy';
@@ -29,10 +62,19 @@ export class EnemySpawner {
     this.difficulty = Math.max(0.5, difficulty);
     const odds = typeof options.eliteOdds === 'number' ? options.eliteOdds : 0;
     this.eliteOdds = Math.max(0, Math.min(0.95, odds));
-    const initialCadence = Math.max(10, 30 / this.difficulty);
-    this.interval = initialCadence;
-    this.timer = initialCadence;
+    this.cadenceDecay = getEnemyCadenceDecay(this.difficulty);
+    this.multiplierGrowth = getEnemyMultiplierGrowth(this.difficulty);
     this.spawnCycles = 0;
+    this.rampEvaluation = evaluateEnemyRamp(this.difficulty, {
+      runSeconds: 0,
+      clears: 0,
+      spawnCycles: 0
+    });
+    this.rampStageIndex = this.rampEvaluation.stageIndex;
+    this.interval = this.rampEvaluation.cadenceTarget;
+    this.timer = this.interval;
+    this.lastCadence = this.interval;
+    this.lastMultiplier = this.rampEvaluation.multiplierBase;
     const fallbackIdFactory = (() => {
       let counter = 0;
       return () => `e${Date.now()}-${(counter += 1)}`;
@@ -46,17 +88,29 @@ export class EnemySpawner {
     addUnit: (u: Unit) => void,
     pickEdge: () => AxialCoord | undefined
   ): void {
-    this.timer -= dt;
-    if (this.timer > 0) {
+    if (!Number.isFinite(dt) || dt <= 0) {
       return;
     }
 
-    const enemyCount = units.filter((u) => u.faction === this.factionId && !u.isDead()).length;
-    const availableSlots = MAX_ENEMIES - enemyCount;
-    if (availableSlots > 0) {
-      const bundle = pickFactionBundle(this.factionId, this.random);
-      const rampMultiplier = this.computeRampFactor(this.spawnCycles);
-      spawnEnemyBundle({
+    this.runSeconds += dt;
+    this.resolveRampState();
+
+    const enemyCount = this.countActiveEnemies(units);
+    this.trackClears(enemyCount);
+
+    this.timer -= dt;
+    let spawnsThisTick = 0;
+    while (this.timer <= 0 && spawnsThisTick < MAX_SPAWNS_PER_UPDATE) {
+      const availableSlots = this.getAvailableSlots(units);
+      if (availableSlots <= 0) {
+        this.timer = Math.max(this.timer, 0.5);
+        break;
+      }
+
+      const evaluation = this.resolveRampState();
+      const bundle = pickRampBundle(this.factionId, evaluation.stage.bundleTier, this.random);
+      const multiplier = this.computeMultiplier(evaluation);
+      const result = spawnEnemyBundle({
         bundle,
         factionId: this.factionId,
         pickEdge,
@@ -65,23 +119,94 @@ export class EnemySpawner {
         availableSlots,
         eliteOdds: this.eliteOdds,
         random: this.random,
-        difficultyMultiplier: rampMultiplier
+        difficultyMultiplier: multiplier,
+        rampTier: evaluation.stage.bundleTier
       });
+
+      if (result.spawned.length === 0) {
+        this.timer = Math.max(this.timer, 0.5);
+        break;
+      }
+
+      const spawnTimestamp = this.runSeconds + this.timer;
+      this.lastCadence = this.lastSpawnAt === null ? this.interval : Math.max(0.01, spawnTimestamp - this.lastSpawnAt);
+      this.lastSpawnAt = spawnTimestamp;
+      this.lastMultiplier = multiplier;
+
       this.spawnCycles += 1;
+      spawnsThisTick += 1;
+
+      const nextEvaluation = this.resolveRampState();
+      this.interval = this.computeNextInterval(nextEvaluation);
+      this.timer += this.interval;
     }
 
-    const decay = Math.pow(0.95, this.difficulty);
-    this.interval = Math.max(8, this.interval * decay); // escalate faster with higher difficulty
-    const nextRamp = this.computeRampFactor(this.spawnCycles);
-    const tightenedInterval = Math.max(2, this.interval / nextRamp);
-    this.timer = tightenedInterval;
+    if (spawnsThisTick === MAX_SPAWNS_PER_UPDATE && this.timer <= 0) {
+      this.timer = this.interval;
+    }
   }
 
-  private computeRampFactor(cycles: number): number {
-    if (cycles <= 0) {
-      return 1;
+  getSnapshot(): EnemySpawnerSnapshot {
+    const stage = this.rampEvaluation.stage;
+    return {
+      runSeconds: this.runSeconds,
+      clears: this.clearCount,
+      spawnCycles: this.spawnCycles,
+      rampStageIndex: this.rampStageIndex,
+      rampStageId: stage.id,
+      rampStageLabel: stage.label,
+      bundleTier: stage.bundleTier,
+      cadence: this.interval,
+      lastCadence: this.lastCadence,
+      lastSpawnAt: this.lastSpawnAt,
+      lastClearAt: this.lastClearAt,
+      difficultyMultiplier: this.lastMultiplier
+    } satisfies EnemySpawnerSnapshot;
+  }
+
+  private resolveRampState(): EnemyRampEvaluation {
+    this.rampEvaluation = evaluateEnemyRamp(this.difficulty, {
+      runSeconds: this.runSeconds,
+      clears: this.clearCount,
+      spawnCycles: this.spawnCycles
+    });
+    this.rampStageIndex = this.rampEvaluation.stageIndex;
+    return this.rampEvaluation;
+  }
+
+  private computeNextInterval(evaluation: EnemyRampEvaluation): number {
+    const baseTarget = evaluation.cadenceTarget;
+    const pressure = 1 + Math.min(4, Math.pow(this.spawnCycles + 1, 0.6) * 0.018);
+    const dynamicTarget = baseTarget / pressure;
+    const decayed = this.interval * this.cadenceDecay;
+    const tightened = Math.min(decayed, dynamicTarget);
+    return Math.max(0.3, tightened);
+  }
+
+  private computeMultiplier(evaluation: EnemyRampEvaluation): number {
+    const pressure = 1 + this.spawnCycles * this.multiplierGrowth;
+    const stageBonus = 1 + evaluation.stageIndex * 0.15;
+    const multiplier = evaluation.multiplierBase * pressure * stageBonus;
+    return Math.min(16, Math.max(1, multiplier));
+  }
+
+  private countActiveEnemies(units: Unit[]): number {
+    return units.filter((unit) => unit.faction === this.factionId && !unit.isDead()).length;
+  }
+
+  private getAvailableSlots(units: Unit[]): number {
+    return MAX_ENEMIES - this.countActiveEnemies(units);
+  }
+
+  private trackClears(enemyCount: number): void {
+    if (enemyCount <= 0) {
+      if (!this.boardEmpty) {
+        this.clearCount += 1;
+        this.lastClearAt = this.runSeconds;
+      }
+      this.boardEmpty = true;
+      return;
     }
-    const growth = 1 + cycles * 0.05 * Math.max(1, this.difficulty);
-    return Math.max(1, growth);
+    this.boardEmpty = false;
   }
 }

--- a/src/state/telemetry/enemyScaling.ts
+++ b/src/state/telemetry/enemyScaling.ts
@@ -1,0 +1,53 @@
+import type { EnemySpawnerSnapshot } from '../../sim/EnemySpawner.ts';
+
+export interface EnemyScalingTelemetryOptions {
+  readonly wipeSince?: number | null;
+  readonly wipeDurationMs?: number;
+}
+
+let lastStageIndex = -1;
+let lastLoggedSpawnCycles = -1;
+let lastLoggedClearAt: number | null = null;
+
+export function recordEnemyScalingTelemetry(
+  snapshot: EnemySpawnerSnapshot,
+  options: EnemyScalingTelemetryOptions = {}
+): void {
+  const stageChanged = snapshot.rampStageIndex !== lastStageIndex;
+  const spawnAdvanced = snapshot.spawnCycles >= lastLoggedSpawnCycles + 10;
+  const clearChanged = snapshot.lastClearAt !== null && snapshot.lastClearAt !== lastLoggedClearAt;
+
+  if (!stageChanged && !spawnAdvanced && !clearChanged) {
+    return;
+  }
+
+  lastStageIndex = snapshot.rampStageIndex;
+  lastLoggedSpawnCycles = snapshot.spawnCycles;
+  lastLoggedClearAt = snapshot.lastClearAt ?? lastLoggedClearAt;
+
+  const payload = {
+    stage: snapshot.rampStageLabel,
+    stageIndex: snapshot.rampStageIndex,
+    bundleTier: snapshot.bundleTier,
+    cadenceSeconds: Number(snapshot.cadence.toFixed(2)),
+    lastCadenceSeconds: Number(snapshot.lastCadence.toFixed(2)),
+    multiplier: Number(snapshot.difficultyMultiplier.toFixed(2)),
+    runSeconds: Math.round(snapshot.runSeconds),
+    spawnCycles: snapshot.spawnCycles,
+    clears: snapshot.clears,
+    wipeSince: options.wipeSince ?? null,
+    longestWipeMs: options.wipeDurationMs ?? 0
+  };
+
+  if (import.meta.env.PROD) {
+    console.info('enemy-scaling', payload);
+  } else {
+    console.debug('Enemy scaling telemetry', payload);
+  }
+}
+
+export function resetEnemyScalingTelemetry(): void {
+  lastStageIndex = -1;
+  lastLoggedSpawnCycles = -1;
+  lastLoggedClearAt = null;
+}


### PR DESCRIPTION
## Summary
- replace the enemy spawner ramp logic with configurable difficulty curves, snapshot reporting, and cadence tracking
- gate tougher enemy bundles behind ramp tiers, scale bundle quantities, and expose ramp metadata through faction parsing
- add a telemetry helper invoked by the game loop to log ramp state, and expand Vitest coverage for long-run scaling behaviour

## Testing
- `npm run build`
- `npm run test` *(fails: docs bundle commit mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5b634b548330be1ae5e0b0f7e05c