### PR TITLE
Refresh inventory badge icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Refresh the inventory stash badge with an inline SVG bag icon, centered
+  styling, and updated palette treatments for a crisper HUD affordance.
+
 - Introduce a combat audio loudness workflow by adding a reusable WAV analysis
   utility, a `vite-node` QA script with auto-normalisation support, runtime
   metadata for cue gain, a Vitest regression that decodes each payload, and

--- a/src/ui/inventoryHud.ts
+++ b/src/ui/inventoryHud.ts
@@ -116,6 +116,27 @@ function createBadge(): {
   const icon = document.createElement('span');
   icon.classList.add('inventory-badge__icon');
   icon.setAttribute('aria-hidden', 'true');
+
+  const svgNs = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNs, 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.setAttribute('focusable', 'false');
+  svg.classList.add('inventory-badge__svg');
+
+  const bagOutline = document.createElementNS(svgNs, 'path');
+  bagOutline.setAttribute(
+    'd',
+    'M8.25 7V6a3.75 3.75 0 0 1 7.5 0v1m3 0h-14.25a1.5 1.5 0 0 0-1.485 1.342l-.75 9a3 3 0 0 0 2.985 3.158h9.78a3 3 0 0 0 2.985-3.158l-.75-9A1.5 1.5 0 0 0 18.75 7Z'
+  );
+  bagOutline.classList.add('inventory-badge__icon-outline');
+
+  const bagDetail = document.createElementNS(svgNs, 'path');
+  bagDetail.setAttribute('d', 'M9.75 12.25h4.5');
+  bagDetail.classList.add('inventory-badge__icon-detail');
+
+  svg.append(bagOutline, bagDetail);
+  icon.appendChild(svg);
   button.appendChild(icon);
 
   const label = document.createElement('span');

--- a/src/ui/style/atoms.css
+++ b/src/ui/style/atoms.css
@@ -152,11 +152,39 @@
 }
 
 .inventory-badge__icon {
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.65rem;
+  height: 1.65rem;
+  flex-shrink: 0;
+  border-radius: 0.825rem;
   background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(225, 235, 255, 0.2));
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+  color: #f4f8ff;
+}
+
+.inventory-badge__icon svg {
+  display: block;
+  width: 76%;
+  height: 76%;
+}
+
+.inventory-badge__icon-outline {
+  fill: rgba(194, 216, 255, 0.32);
+  stroke: rgba(255, 255, 255, 0.92);
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.inventory-badge__icon-detail {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.85);
+  stroke-width: 1.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.9;
 }
 
 .inventory-badge__text {


### PR DESCRIPTION
## Summary
- embed a decorative inline SVG bag icon inside the inventory badge for a polished control affordance
- center and scale the badge glyph while updating stroke and fill treatments to match the HUD palette
- note the refreshed stash badge styling in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce60c380448330bf55e532456f5787