### PR TITLE
Add sauna tier registry and HUD upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 
+- Introduce a curated sauna tier registry with persistent selections, premium
+  badge art, unlock progress cues, and tier-aware roster caps, backed by new
+  serialization and HUD DOM regression tests.
+
+
 - Wire the CI workflow to run `npm test` after builds so the docs mirror guard
   executes on every push, regenerate `docs/` with the current bundle commit, and
   document the enforced check for contributors.

--- a/src/game/saunaSettings.test.ts
+++ b/src/game/saunaSettings.test.ts
@@ -4,6 +4,7 @@ import {
   loadSaunaSettings,
   saveSaunaSettings
 } from './saunaSettings.ts';
+import { DEFAULT_SAUNA_TIER_ID, SAUNA_TIERS } from '../sauna/tiers.ts';
 
 describe('saunaSettings', () => {
   beforeEach(() => {
@@ -12,21 +13,26 @@ describe('saunaSettings', () => {
 
   it('returns the provided default when storage is empty', () => {
     const settings = loadSaunaSettings(4);
-    expect(settings.maxRosterSize).toBe(4);
+    expect(settings.maxRosterSize).toBe(3);
+    expect(settings.activeTierId).toBe(DEFAULT_SAUNA_TIER_ID);
   });
 
   it('clamps stored values to the unlock ceiling', () => {
-    window.localStorage?.setItem(SAUNA_SETTINGS_STORAGE_KEY, JSON.stringify({ maxRosterSize: 99 }));
+    window.localStorage?.setItem(
+      SAUNA_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ maxRosterSize: 99, activeTierId: 'mythic-conclave' })
+    );
     const settings = loadSaunaSettings(1);
-    expect(settings.maxRosterSize).toBe(6);
+    expect(settings.maxRosterSize).toBe(1);
+    expect(settings.activeTierId).toBe('mythic-conclave');
   });
 
   it('persists sanitized roster caps', () => {
-    saveSaunaSettings({ maxRosterSize: 7 });
+    saveSaunaSettings({ maxRosterSize: 7, activeTierId: 'mythic-conclave' });
     const raw = window.localStorage?.getItem(SAUNA_SETTINGS_STORAGE_KEY);
     expect(raw).toBeTypeOf('string');
     const parsed = raw ? JSON.parse(raw) : null;
-    expect(parsed).toEqual({ maxRosterSize: 6 });
+    expect(parsed).toEqual({ maxRosterSize: 6, activeTierId: 'mythic-conclave' });
   });
 
   it('handles malformed payloads gracefully', () => {
@@ -35,9 +41,31 @@ describe('saunaSettings', () => {
       window.localStorage?.setItem(SAUNA_SETTINGS_STORAGE_KEY, '{not json');
       const settings = loadSaunaSettings(3);
       expect(settings.maxRosterSize).toBe(3);
+      expect(settings.activeTierId).toBe(DEFAULT_SAUNA_TIER_ID);
       expect(warn).toHaveBeenCalled();
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it('falls back to the default tier when an unknown id is stored', () => {
+    window.localStorage?.setItem(
+      SAUNA_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ maxRosterSize: 3, activeTierId: 'unknown-tier' })
+    );
+    const settings = loadSaunaSettings(4);
+    expect(settings.activeTierId).toBe(DEFAULT_SAUNA_TIER_ID);
+    expect(settings.maxRosterSize).toBe(3);
+  });
+
+  it('respects tier roster caps when loading', () => {
+    const premium = SAUNA_TIERS.find((tier) => tier.id === 'aurora-ward');
+    expect(premium).toBeDefined();
+    window.localStorage?.setItem(
+      SAUNA_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ maxRosterSize: 99, activeTierId: premium?.id })
+    );
+    const settings = loadSaunaSettings(10);
+    expect(settings.maxRosterSize).toBe(premium?.rosterCap ?? 4);
   });
 });

--- a/src/game/saunaSettings.ts
+++ b/src/game/saunaSettings.ts
@@ -1,7 +1,13 @@
 import { MAX_UNLOCK_SLOTS } from '../progression/ngplus.ts';
+import {
+  DEFAULT_SAUNA_TIER_ID,
+  getSaunaTier,
+  type SaunaTierId
+} from '../sauna/tiers.ts';
 
 export interface SaunaSettings {
   maxRosterSize: number;
+  activeTierId: SaunaTierId;
 }
 
 export const SAUNA_SETTINGS_STORAGE_KEY = 'autobattles:sauna-settings';
@@ -15,33 +21,67 @@ function getStorage(): Storage | null {
   }
 }
 
-function sanitizeCap(value: unknown, fallback: number): number {
+function sanitizeTierId(value: unknown): SaunaTierId {
+  if (typeof value === 'string') {
+    return getSaunaTier(value).id;
+  }
+  return DEFAULT_SAUNA_TIER_ID;
+}
+
+function sanitizeLimit(limit: number): number {
+  if (!Number.isFinite(limit)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(limit));
+}
+
+function resolveEffectiveLimit(tierCap: number, defaultCap: number): number {
+  const sanitizedTierCap = sanitizeLimit(tierCap);
+  const sanitizedDefault = sanitizeLimit(defaultCap);
+  const maxUnlock = 1 + MAX_UNLOCK_SLOTS;
+  return Math.max(0, Math.min(maxUnlock, sanitizedTierCap, sanitizedDefault));
+}
+
+function sanitizeCap(value: unknown, fallback: number, limit: number): number {
+  const safeLimit = resolveEffectiveLimit(limit, limit);
   const base = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
   const cap = Math.max(0, Math.floor(base));
-  const maxUnlock = 1 + MAX_UNLOCK_SLOTS;
-  return Math.max(0, Math.min(maxUnlock, cap));
+  return Math.max(0, Math.min(safeLimit, cap));
+}
+
+function sanitizeSettings(
+  record: Partial<Record<keyof SaunaSettings, unknown>> | null,
+  defaultCap: number
+): SaunaSettings {
+  const tierId = sanitizeTierId(record?.activeTierId);
+  const tier = getSaunaTier(tierId);
+  const limit = resolveEffectiveLimit(tier.rosterCap, defaultCap);
+  return {
+    activeTierId: tier.id,
+    maxRosterSize: sanitizeCap(record?.maxRosterSize, limit, limit)
+  } satisfies SaunaSettings;
 }
 
 export function loadSaunaSettings(defaultCap: number): SaunaSettings {
   const storage = getStorage();
   if (!storage) {
-    return { maxRosterSize: sanitizeCap(defaultCap, defaultCap) };
+    return sanitizeSettings(null, defaultCap);
   }
 
   try {
     const raw = storage.getItem(SAUNA_SETTINGS_STORAGE_KEY);
     if (!raw) {
-      return { maxRosterSize: sanitizeCap(defaultCap, defaultCap) };
+      return sanitizeSettings(null, defaultCap);
     }
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') {
-      return { maxRosterSize: sanitizeCap(defaultCap, defaultCap) };
+      return sanitizeSettings(null, defaultCap);
     }
     const record = parsed as Record<string, unknown>;
-    return { maxRosterSize: sanitizeCap(record.maxRosterSize, defaultCap) };
+    return sanitizeSettings(record, defaultCap);
   } catch (error) {
     console.warn('Failed to load sauna settings from storage', error);
-    return { maxRosterSize: sanitizeCap(defaultCap, defaultCap) };
+    return sanitizeSettings(null, defaultCap);
   }
 }
 
@@ -50,9 +90,12 @@ export function saveSaunaSettings(settings: SaunaSettings): void {
   if (!storage) {
     return;
   }
+  const tier = getSaunaTier(settings.activeTierId);
+  const tierLimit = resolveEffectiveLimit(tier.rosterCap, tier.rosterCap);
   const payload: SaunaSettings = {
-    maxRosterSize: sanitizeCap(settings.maxRosterSize, settings.maxRosterSize)
-  };
+    activeTierId: tier.id,
+    maxRosterSize: sanitizeCap(settings.maxRosterSize, tierLimit, tierLimit)
+  } satisfies SaunaSettings;
   try {
     storage.setItem(SAUNA_SETTINGS_STORAGE_KEY, JSON.stringify(payload));
   } catch (error) {

--- a/src/sauna/tiers.ts
+++ b/src/sauna/tiers.ts
@@ -1,0 +1,185 @@
+import rosterBadgeUrl from '../../assets/ui/saunoja-roster.svg';
+import saunaBeerUrl from '../../assets/ui/sauna-beer.svg';
+import resourceBadgeUrl from '../../assets/ui/resource.svg';
+
+export type SaunaTierId = 'ember-circuit' | 'aurora-ward' | 'mythic-conclave';
+
+export interface SaunaTierArt {
+  /** Inline badge art for the tier chip. */
+  badge: string;
+  /** Optional background glow for accenting the badge. */
+  glow?: string;
+}
+
+export type SaunaTierUnlock =
+  | { type: 'default'; label: string }
+  | { type: 'ngPlusLevel'; level: number; label?: string }
+  | { type: 'unlockSlots'; slots: number; label?: string };
+
+export interface SaunaTier {
+  id: SaunaTierId;
+  name: string;
+  rosterCap: number;
+  description: string;
+  art: SaunaTierArt;
+  unlock: SaunaTierUnlock;
+}
+
+export interface SaunaTierContext {
+  ngPlusLevel: number;
+  unlockSlots: number;
+}
+
+export interface SaunaTierStatus {
+  tier: SaunaTier;
+  unlocked: boolean;
+  progress: number;
+  requirementLabel: string;
+}
+
+const DEFAULT_CONTEXT: SaunaTierContext = Object.freeze({
+  ngPlusLevel: 0,
+  unlockSlots: 0
+});
+
+const DEFAULT_UNLOCK_LABELS: Record<SaunaTierUnlock['type'], string> = {
+  default: 'Included with the sauna key',
+  ngPlusLevel: 'Reach NG+ level',
+  unlockSlots: 'Earn roster unlocks'
+};
+
+export const SAUNA_TIERS: readonly SaunaTier[] = Object.freeze([
+  {
+    id: 'ember-circuit',
+    name: 'Ember Circuit',
+    rosterCap: 3,
+    description: 'Classic cedar benches with a loyal trio of attendants.',
+    art: {
+      badge: rosterBadgeUrl,
+      glow: 'linear-gradient(145deg, rgba(255,161,76,0.65), rgba(255,226,173,0.18))'
+    },
+    unlock: {
+      type: 'default',
+      label: 'Available from the first steam session'
+    }
+  },
+  {
+    id: 'aurora-ward',
+    name: 'Aurora Ward',
+    rosterCap: 4,
+    description: 'Glacial glass benches and a quartet ready to repel sieges.',
+    art: {
+      badge: saunaBeerUrl,
+      glow: 'linear-gradient(140deg, rgba(128,208,255,0.7), rgba(61,184,255,0.2))'
+    },
+    unlock: {
+      type: 'unlockSlots',
+      slots: 2,
+      label: 'Secure 2 roster unlocks'
+    }
+  },
+  {
+    id: 'mythic-conclave',
+    name: 'Mythic Conclave',
+    rosterCap: 6,
+    description: 'Runic obsidian tiers where six legends guard the löyly.',
+    art: {
+      badge: resourceBadgeUrl,
+      glow: 'linear-gradient(135deg, rgba(176,106,255,0.72), rgba(245,199,255,0.2))'
+    },
+    unlock: {
+      type: 'ngPlusLevel',
+      level: 3,
+      label: 'Prestige to NG+ level 3'
+    }
+  }
+] satisfies readonly SaunaTier[]);
+
+export const DEFAULT_SAUNA_TIER_ID: SaunaTierId = SAUNA_TIERS[0]!.id;
+
+const TIERS_BY_ID = new Map<SaunaTierId, SaunaTier>(SAUNA_TIERS.map((tier) => [tier.id, tier]));
+
+export function listSaunaTiers(): readonly SaunaTier[] {
+  return SAUNA_TIERS;
+}
+
+export function getSaunaTier(id: SaunaTierId | string | null | undefined): SaunaTier {
+  if (id && TIERS_BY_ID.has(id as SaunaTierId)) {
+    return TIERS_BY_ID.get(id as SaunaTierId)!;
+  }
+  return TIERS_BY_ID.get(DEFAULT_SAUNA_TIER_ID)!;
+}
+
+function clampUnit(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (min === max) {
+    return min;
+  }
+  const clamped = Math.max(min, Math.min(max, value));
+  if (Number.isNaN(clamped)) {
+    return min;
+  }
+  return clamped;
+}
+
+function resolveUnlockLabel(unlock: SaunaTierUnlock): string {
+  if (unlock.label) {
+    return unlock.label;
+  }
+  const base = DEFAULT_UNLOCK_LABELS[unlock.type];
+  if (!base) {
+    return '';
+  }
+  switch (unlock.type) {
+    case 'ngPlusLevel':
+      return `${base} ${unlock.level}`;
+    case 'unlockSlots':
+      return `${base} ${unlock.slots}`;
+    default:
+      return base;
+  }
+}
+
+export function evaluateSaunaTier(
+  tier: SaunaTier,
+  context: SaunaTierContext | null | undefined
+): SaunaTierStatus {
+  const safeContext = context ?? DEFAULT_CONTEXT;
+  if (tier.unlock.type === 'default') {
+    return {
+      tier,
+      unlocked: true,
+      progress: 1,
+      requirementLabel: resolveUnlockLabel(tier.unlock)
+    } satisfies SaunaTierStatus;
+  }
+
+  if (tier.unlock.type === 'ngPlusLevel') {
+    const progress = clampUnit(safeContext.ngPlusLevel / tier.unlock.level, 0, 1);
+    return {
+      tier,
+      unlocked: safeContext.ngPlusLevel >= tier.unlock.level,
+      progress,
+      requirementLabel: resolveUnlockLabel(tier.unlock)
+    } satisfies SaunaTierStatus;
+  }
+
+  if (tier.unlock.type === 'unlockSlots') {
+    const progress = clampUnit(safeContext.unlockSlots / tier.unlock.slots, 0, 1);
+    return {
+      tier,
+      unlocked: safeContext.unlockSlots >= tier.unlock.slots,
+      progress,
+      requirementLabel: resolveUnlockLabel(tier.unlock)
+    } satisfies SaunaTierStatus;
+  }
+
+  return {
+    tier,
+    unlocked: false,
+    progress: 0,
+    requirementLabel: resolveUnlockLabel(tier.unlock)
+  } satisfies SaunaTierStatus;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -2113,6 +2113,200 @@ body > #game-container {
   transition: width 240ms ease;
 }
 
+.sauna-tier {
+  display: grid;
+  gap: clamp(14px, 2vw, 20px);
+  margin-top: clamp(12px, 2vw, 20px);
+  padding: clamp(14px, 2.4vw, 22px);
+  border-radius: 22px;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 20%, transparent);
+  background: linear-gradient(145deg, rgba(13, 23, 40, 0.86), rgba(9, 16, 30, 0.68));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 20px 44px rgba(5, 12, 26, 0.55);
+}
+
+.sauna-tier__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sauna-tier__title {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.28em;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--color-muted) 68%, white 8%);
+}
+
+.sauna-tier__subtitle {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--color-muted) 80%, white 12%);
+}
+
+.sauna-tier__grid {
+  display: grid;
+  gap: clamp(12px, 2vw, 18px);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.sauna-tier__option {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 16px;
+  padding: clamp(12px, 1.8vw, 18px);
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--color-muted) 70%, transparent);
+  background: linear-gradient(150deg, rgba(12, 22, 39, 0.88), rgba(14, 26, 46, 0.74));
+  box-shadow: 0 16px 32px rgba(5, 15, 30, 0.55);
+  color: var(--color-foreground);
+  cursor: pointer;
+  text-align: left;
+  transition: transform 200ms ease, border-color 200ms ease, box-shadow 200ms ease;
+  overflow: hidden;
+}
+
+.sauna-tier__option::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(
+    --sauna-tier-glow,
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18), transparent 60%)
+  );
+  opacity: 0.45;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  transition: opacity 220ms ease;
+}
+
+.sauna-tier__option:hover,
+.sauna-tier__option:focus-visible {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
+  box-shadow: 0 24px 40px rgba(6, 14, 31, 0.65);
+}
+
+.sauna-tier__option:hover::before,
+.sauna-tier__option:focus-visible::before {
+  opacity: 0.72;
+}
+
+.sauna-tier__option[data-state='active'] {
+  border-color: color-mix(in srgb, var(--color-accent) 70%, transparent);
+  box-shadow: 0 26px 44px rgba(9, 18, 36, 0.72);
+}
+
+.sauna-tier__option[data-state='locked'] {
+  cursor: not-allowed;
+  border-color: color-mix(in srgb, var(--color-muted) 60%, transparent);
+  opacity: 0.7;
+}
+
+.sauna-tier__badge {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.28), transparent 65%),
+    color-mix(in srgb, var(--color-accent) 22%, rgba(10, 19, 34, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 18px 30px rgba(4, 12, 26, 0.45);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.sauna-tier__badge::after {
+  content: '';
+  width: 42px;
+  height: 42px;
+  background: var(--sauna-tier-badge-image) center/contain no-repeat;
+  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.45));
+}
+
+.sauna-tier__copy {
+  display: grid;
+  gap: 8px;
+}
+
+.sauna-tier__name {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sauna-tier__cap {
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 70%, white 10%);
+}
+
+.sauna-tier__description {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--color-muted) 82%, white 12%);
+}
+
+.sauna-tier__progress {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-muted) 35%, rgba(10, 19, 34, 0.8));
+  overflow: hidden;
+}
+
+.sauna-tier__progress-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(255, 189, 111, 0.92), rgba(255, 91, 159, 0.9));
+  transition: width 240ms ease;
+}
+
+.sauna-tier__progress-label {
+  margin-top: 6px;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 74%, white 18%);
+}
+
+.sauna-tier__requirement {
+  font-size: 11px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--color-muted) 88%, white 8%);
+}
+
+.sauna-tier__option--denied {
+  animation: sauna-tier-denied 320ms ease;
+}
+
+@keyframes sauna-tier-denied {
+  0% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-6px);
+  }
+  50% {
+    transform: translateX(5px);
+  }
+  75% {
+    transform: translateX(-4px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
 .sauna-roster {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## Summary
- introduce a structured sauna tier registry with unlock metadata and art references
- persist the active tier alongside sauna settings and clamp roster controls to tier caps
- refresh the sauna HUD with premium tier cards, progress feedback, and accompanying tests

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce907e27a08330b8718396c0a09af0