### PR TITLE
Raise stash panel overlay priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 
+- Elevate the stash drawer layering so it sits above the command console, gating
+  pointer interactivity to the open state and keeping the right rail fully
+  covered on desktop and mobile layouts.
+
 - Enforce sauna tier roster ceilings during player spawns with heat-aware queueing,
   auto-advancing NG+ tier unlocks, and expanded coverage for tier transitions and
   blocked reinforcements.

--- a/src/ui/stash/StashPanel.module.css
+++ b/src/ui/stash/StashPanel.module.css
@@ -12,12 +12,14 @@
   transform: translate3d(100%, 0, 0);
   transition: transform 320ms cubic-bezier(0.32, 0.72, 0, 1), opacity 180ms ease;
   opacity: 0;
-  z-index: 32;
+  z-index: 960;
+  pointer-events: none;
 }
 
 .panel[data-open='true'] {
   transform: translate3d(0, 0, 0);
   opacity: 1;
+  pointer-events: auto;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- raise the stash panel overlay above the right rail and gate pointer interactivity so it blocks the command console when open
- document the layering change in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce9a9ecf6c83309b659acf94ae8705