### PR TITLE
Reposition loot toasts within HUD actions column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 
+- Nest the loot toast stack inside the HUD action column, refresh its
+  glassmorphism treatment for responsive layouts, and keep loot notices from
+  covering the command console across desktop and mobile viewports.
+
 - Elevate the stash drawer layering so it sits above the command console, gating
   pointer interactivity to the open state and keeping the right rail fully
   covered on desktop and mobile layouts.

--- a/src/ui/inventoryHud.ts
+++ b/src/ui/inventoryHud.ts
@@ -40,16 +40,20 @@ const STAT_LABELS: Record<string, string> = {
   shield: 'Shield'
 };
 
-function ensureToastStack(overlay: HTMLElement): HTMLDivElement {
+function ensureToastStack(overlay: HTMLElement, target: HTMLElement): HTMLDivElement {
   const existing = overlay.querySelector<HTMLDivElement>('.loot-toast-stack');
   if (existing) {
+    if (existing.parentElement !== target) {
+      target.appendChild(existing);
+    }
     return existing;
   }
-  const stack = document.createElement('div');
+  const doc = overlay.ownerDocument ?? document;
+  const stack = doc.createElement('div');
   stack.classList.add('loot-toast-stack');
   stack.setAttribute('aria-live', 'polite');
   stack.setAttribute('role', 'status');
-  overlay.appendChild(stack);
+  target.appendChild(stack);
   return stack;
 }
 
@@ -163,7 +167,7 @@ export function setupInventoryHud(
   }
 
   const { actions } = ensureHudLayout(overlay);
-  const toastStack = ensureToastStack(overlay);
+  const toastStack = ensureToastStack(overlay, actions);
 
   overlay.querySelectorAll('.inventory-badge').forEach((el) => el.remove());
   const { button: badgeButton, count: badgeCount } = createBadge();

--- a/src/ui/style/atoms.css
+++ b/src/ui/style/atoms.css
@@ -93,28 +93,41 @@
 }
 
 .loot-toast-stack {
-  position: absolute;
-  top: var(--gap-lg);
-  right: var(--gap-lg);
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  gap: var(--gap-sm);
+  gap: clamp(6px, 1vw, 12px);
+  align-items: stretch;
+  width: min(22rem, 100%);
+  margin-left: auto;
   pointer-events: none;
-  z-index: 900;
+}
+
+.loot-toast-stack:empty {
+  display: none;
+}
+
+.is-mobile .loot-toast-stack {
+  width: 100%;
+  margin-left: 0;
 }
 
 .loot-toast {
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(215, 229, 255, 0.95));
   color: #152035;
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.22);
   padding: 0.75rem 1rem;
   font-size: 0.9rem;
   font-weight: 600;
+  line-height: 1.35;
+  display: flex;
+  align-items: center;
+  gap: clamp(4px, 0.8vw, 12px);
   pointer-events: auto;
   transition: transform 0.25s ease, opacity 0.25s ease;
-  max-width: 18rem;
+  width: 100%;
+  backdrop-filter: blur(14px) saturate(135%);
 }
 
 .loot-toast[data-variant='info'] {


### PR DESCRIPTION
## Summary
- Move the loot toast stack into the HUD actions column and rehome any existing stack instance into the new slot.
- Restyle the toast stack for responsive inline layout with glassmorphism polish so it no longer overlaps the right-hand HUD.
- Document the inventory toast relocation in the changelog.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce9b9772a48330a8929190cd183202