### PR TITLE
Revamp policy system with registry-driven UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 
+- Overhaul the policy system with a shared registry, premium HUD cards that surface
+  prerequisites, typed events, declarative effect wiring, and Vitest coverage for
+  both successful enactments and rejection flows.
+
 - Nest the loot toast stack inside the HUD action column, refresh its
   glassmorphism treatment for responsive layouts, and keep loot notices from
   covering the command console across desktop and mobile viewports.

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -1,0 +1,13 @@
+export enum Resource {
+  SAUNA_BEER = 'sauna-beer',
+  SAUNAKUNNIA = 'saunakunnia',
+  SISU = 'sisu'
+}
+
+export const PASSIVE_GENERATION: Record<Resource, number> = {
+  [Resource.SAUNA_BEER]: 1,
+  [Resource.SAUNAKUNNIA]: 0,
+  [Resource.SISU]: 0
+};
+
+export type ResourceMap<T = number> = Record<Resource, T>;

--- a/src/data/policies.ts
+++ b/src/data/policies.ts
@@ -1,0 +1,173 @@
+import type { GameState } from '../core/GameState.ts';
+import { Resource } from '../core/resources.ts';
+import saunaBeerIcon from '../../assets/ui/sauna-beer.svg';
+import resourceIcon from '../../assets/ui/resource.svg';
+import saunaRosterIcon from '../../assets/ui/saunoja-roster.svg';
+
+export const POLICY_EVENTS = {
+  APPLIED: 'policy:applied',
+  REJECTED: 'policy:rejected'
+} as const;
+
+export type PolicyEventName = (typeof POLICY_EVENTS)[keyof typeof POLICY_EVENTS];
+
+export type PolicyId = 'eco' | 'temperance' | 'steam-diplomats';
+
+export interface PolicyAppliedEvent {
+  readonly policy: PolicyDefinition;
+  readonly state: GameState;
+}
+
+export type PolicyRejectionReason =
+  | 'unknown-policy'
+  | 'already-applied'
+  | 'prerequisites-not-met'
+  | 'insufficient-resources';
+
+export interface PolicyRejectedEvent {
+  readonly policyId: string;
+  readonly policy?: PolicyDefinition;
+  readonly state: GameState;
+  readonly reason: PolicyRejectionReason;
+  readonly missingPrerequisites?: PolicyPrerequisite[];
+}
+
+export interface PolicyPrerequisite {
+  readonly description: string;
+  readonly isSatisfied: (state: GameState) => boolean;
+}
+
+export interface PolicyVisuals {
+  readonly icon: string;
+  readonly gradient: string;
+  readonly accentColor: string;
+  readonly badges?: readonly string[];
+  readonly flair?: string;
+}
+
+export interface PolicyEffectHook {
+  readonly event: typeof POLICY_EVENTS.APPLIED;
+  readonly once?: boolean;
+  readonly invoke: (payload: PolicyAppliedEvent) => void;
+}
+
+export interface PolicyDefinition {
+  readonly id: PolicyId;
+  readonly name: string;
+  readonly description: string;
+  readonly cost: number;
+  readonly resource: Resource;
+  readonly prerequisites: readonly PolicyPrerequisite[];
+  readonly visuals: PolicyVisuals;
+  readonly effects: readonly PolicyEffectHook[];
+  readonly spotlight?: string;
+}
+
+const POLICY_DEFINITIONS: PolicyDefinition[] = [
+  {
+    id: 'eco',
+    name: 'Evergreen Eco Mandate',
+    description: 'Increase passive sauna beer brewing by one bottle each production tick.',
+    cost: 15,
+    resource: Resource.SAUNAKUNNIA,
+    prerequisites: [],
+    visuals: {
+      icon: resourceIcon,
+      gradient: 'linear-gradient(135deg, rgba(66, 240, 155, 0.9), rgba(13, 114, 234, 0.85))',
+      accentColor: '#34d399',
+      badges: ['Economy', 'Sustainability'],
+      flair: 'Green-lit by the council of whisked sauna masters.'
+    },
+    effects: [
+      {
+        event: POLICY_EVENTS.APPLIED,
+        once: true,
+        invoke: ({ state }) => {
+          state.modifyPassiveGeneration(Resource.SAUNA_BEER, 1);
+        }
+      }
+    ],
+    spotlight: 'Sustainably expand your brewing line with solar-heated mash tuns.'
+  },
+  {
+    id: 'temperance',
+    name: 'Aurora Temperance Treaty',
+    description: 'Boost night shift work speed by 5% once the eco initiative is live.',
+    cost: 25,
+    resource: Resource.SAUNAKUNNIA,
+    prerequisites: [
+      {
+        description: 'Enact the Evergreen Eco Mandate.',
+        isSatisfied: (state) => state.hasPolicy('eco')
+      },
+      {
+        description: 'Stockpile at least 30 Sauna Beer bottles to brief the midnight crews.',
+        isSatisfied: (state) => state.getResource(Resource.SAUNA_BEER) >= 30
+      }
+    ],
+    visuals: {
+      icon: saunaRosterIcon,
+      gradient: 'linear-gradient(140deg, rgba(46, 51, 227, 0.9), rgba(118, 75, 162, 0.85))',
+      accentColor: '#6366f1',
+      badges: ['Discipline', 'Night Ops'],
+      flair: 'Whispers of aurora spirits keep the crew laser-focused after dusk.'
+    },
+    effects: [
+      {
+        event: POLICY_EVENTS.APPLIED,
+        once: true,
+        invoke: ({ state }) => {
+          state.nightWorkSpeedMultiplier = Number((state.nightWorkSpeedMultiplier * 1.05).toFixed(4));
+        }
+      }
+    ],
+    spotlight: 'Glow-lit helmets and synchronized chants keep the late shift on tempo.'
+  },
+  {
+    id: 'steam-diplomats',
+    name: 'Steam Diplomats Accord',
+    description: 'Import two additional sauna beer bottles per tick via gilded trade routes.',
+    cost: 35,
+    resource: Resource.SAUNAKUNNIA,
+    prerequisites: [
+      {
+        description: 'Secure the Aurora Temperance Treaty for your envoys.',
+        isSatisfied: (state) => state.hasPolicy('temperance')
+      },
+      {
+        description: 'Hold a reserve of 50 Sauna Beer bottles to fund the embassy festivities.',
+        isSatisfied: (state) => state.getResource(Resource.SAUNA_BEER) >= 50
+      }
+    ],
+    visuals: {
+      icon: saunaBeerIcon,
+      gradient: 'linear-gradient(150deg, rgba(255, 173, 94, 0.92), rgba(255, 99, 71, 0.85))',
+      accentColor: '#fb923c',
+      badges: ['Diplomacy', 'Logistics'],
+      flair: 'Silver samovars arrive with diplomatic steam-born delights.'
+    },
+    effects: [
+      {
+        event: POLICY_EVENTS.APPLIED,
+        once: true,
+        invoke: ({ state }) => {
+          state.modifyPassiveGeneration(Resource.SAUNA_BEER, 2);
+        }
+      }
+    ],
+    spotlight: 'Trade envoys pipe artisanal steam through every new supply line.'
+  }
+];
+
+const POLICY_REGISTRY = new Map<PolicyId, PolicyDefinition>();
+for (const definition of POLICY_DEFINITIONS) {
+  POLICY_REGISTRY.set(definition.id, definition);
+}
+
+export function listPolicies(): readonly PolicyDefinition[] {
+  return POLICY_DEFINITIONS;
+}
+
+export function getPolicyDefinition(id: string): PolicyDefinition | undefined {
+  return POLICY_REGISTRY.get(id as PolicyId);
+}

--- a/src/game.ts
+++ b/src/game.ts
@@ -7,6 +7,7 @@ import type { AxialCoord, PixelCoord } from './hex/HexUtils.ts';
 import { Unit, spawnUnit } from './unit/index.ts';
 import type { UnitStats, UnitType } from './unit/index.ts';
 import { eventBus } from './events';
+import { POLICY_EVENTS, type PolicyAppliedEvent } from './data/policies.ts';
 import type { SaunaDamagedPayload, SaunaDestroyedPayload } from './events/types.ts';
 import { createSauna, pickFreeTileAround } from './sim/sauna.ts';
 import { EnemySpawner, type EnemySpawnerRuntimeModifiers } from './sim/EnemySpawner.ts';
@@ -1542,10 +1543,10 @@ export function draw(): void {
   ctx.restore();
 }
 
-const onPolicyApplied = ({ policy }) => {
-  log(`Sauna council toasts a fresh keg for policy: ${policy}.`);
+const onPolicyApplied = ({ policy }: PolicyAppliedEvent): void => {
+  log(`Sauna council toasts a fresh keg for policy: ${policy.name}.`);
 };
-eventBus.on('policyApplied', onPolicyApplied);
+eventBus.on(POLICY_EVENTS.APPLIED, onPolicyApplied);
 
 const onUnitDied = ({
   unitId,
@@ -1681,7 +1682,7 @@ export function cleanup(): void {
     unitFx = null;
   }
 
-  eventBus.off('policyApplied', onPolicyApplied);
+  eventBus.off(POLICY_EVENTS.APPLIED, onPolicyApplied);
   eventBus.off('unitDied', onUnitDied);
   eventBus.off('unitSpawned', onUnitSpawned);
   eventBus.off('inventoryChanged', onInventoryChanged);

--- a/src/style.css
+++ b/src/style.css
@@ -1351,6 +1351,262 @@ body > #game-container {
   transform: none;
 }
 
+.policy-grid {
+  display: grid;
+  gap: 1.5rem;
+  padding-block: 0.5rem;
+}
+
+.policy-card {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: rgba(8, 13, 24, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.45);
+  overflow: hidden;
+  isolation: isolate;
+  transition: transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease;
+}
+
+.policy-card::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  background: var(
+    --policy-gradient,
+    linear-gradient(135deg, rgba(59, 130, 246, 0.55), rgba(236, 72, 153, 0.55))
+  );
+  opacity: 0.7;
+  filter: saturate(1.2);
+  z-index: -2;
+  transition: opacity 220ms ease, filter 220ms ease;
+}
+
+.policy-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% -10%, rgba(255, 255, 255, 0.35), transparent 55%);
+  opacity: 0.45;
+  mix-blend-mode: screen;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.policy-card[data-status='ready']:hover,
+.policy-card[data-status='ready']:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 40px 70px rgba(15, 23, 42, 0.6);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.policy-card[data-status='applied']::before {
+  opacity: 0.85;
+  filter: saturate(1.4);
+}
+
+.policy-card[data-status='locked']::before,
+.policy-card[data-status='budget']::before {
+  opacity: 0.55;
+  filter: saturate(0.8);
+}
+
+.policy-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+}
+
+.policy-card__icon-frame {
+  width: 54px;
+  height: 54px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--policy-accent, #38bdf8) 22%, rgba(255, 255, 255, 0.12));
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.policy-card__icon {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.35));
+}
+
+.policy-card__heading {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.policy-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #f8fafc;
+}
+
+.policy-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.policy-card__badge {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.9);
+  background: color-mix(in srgb, var(--policy-accent, #38bdf8) 75%, white 30%);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.35);
+}
+
+.policy-card__state {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #0b1220;
+  background: color-mix(in srgb, var(--policy-accent, #38bdf8) 85%, white 15%);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.4);
+}
+
+.policy-card__description,
+.policy-card__flair,
+.policy-card__status {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.policy-card__flair {
+  font-style: italic;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.policy-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.policy-card__cost {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid color-mix(in srgb, rgba(255, 255, 255, 0.65) 18%, transparent);
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: border-color 200ms ease, color 200ms ease, background 200ms ease;
+}
+
+.policy-card__cost-label {
+  font-size: 0.65rem;
+  color: rgba(148, 163, 184, 0.85);
+  letter-spacing: 0.1em;
+}
+
+.policy-card__cost-value {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.policy-card__cost--warning {
+  border-color: color-mix(in srgb, #f97316 55%, transparent);
+  color: #fed7aa;
+  background: rgba(254, 215, 170, 0.12);
+}
+
+.policy-card__action {
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(
+    135deg,
+    var(--policy-accent, #38bdf8),
+    color-mix(in srgb, var(--policy-accent, #38bdf8) 45%, #f97316 55%)
+  );
+  color: #0b1220;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 200ms ease, box-shadow 200ms ease, filter 200ms ease;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.45);
+}
+
+.policy-card__action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  filter: saturate(0.5);
+  box-shadow: none;
+}
+
+.policy-card__action:not(:disabled):hover,
+.policy-card__action:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 42px rgba(15, 23, 42, 0.55);
+  outline: none;
+}
+
+.policy-card__requirements {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.policy-card__requirements li {
+  line-height: 1.4;
+}
+
+.policy-card[data-status='applied'] .policy-card__action {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--policy-accent, #38bdf8) 65%, #34d399 35%),
+    color-mix(in srgb, var(--policy-accent, #38bdf8) 45%, #22c55e 55%)
+  );
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.policy-card[data-status='locked'] .policy-card__action,
+.policy-card[data-status='budget'] .policy-card__action {
+  background: linear-gradient(135deg, rgba(71, 85, 105, 0.65), rgba(15, 23, 42, 0.75));
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.policy-card__status {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.policy-card[data-status='locked'] .policy-card__status {
+  color: #f9a8d4;
+}
+
+.policy-card[data-status='budget'] .policy-card__status {
+  color: #fbbf24;
+}
+
 .panel-log-entry {
   padding: 10px 14px;
   border-radius: 16px;

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -5,6 +5,13 @@ import { subscribeToIsMobile } from './hooks/useIsMobile.ts';
 import { createRosterPanel } from './panels/RosterPanel.tsx';
 import type { RosterEntry } from './panels/RosterPanel.tsx';
 import type { EquipmentSlotId } from '../items/types.ts';
+import {
+  listPolicies,
+  POLICY_EVENTS,
+  type PolicyDefinition,
+  type PolicyAppliedEvent,
+  type PolicyRejectedEvent
+} from '../data/policies.ts';
 
 export type {
   RosterEntry,
@@ -456,92 +463,214 @@ export function setupRightPanel(
   }
 
   // --- Policies ---
-  type PolicyDef = {
-    id: string;
-    name: string;
-    description: string;
-    cost: number;
-    resource: Resource;
-    prerequisite: (s: GameState) => boolean;
-  };
-
   const resourceLabel: Record<Resource, string> = {
     [Resource.SAUNA_BEER]: 'Sauna Beer Bottles',
-    [Resource.SAUNAKUNNIA]: 'Saunakunnia'
+    [Resource.SAUNAKUNNIA]: 'Saunakunnia',
+    [Resource.SISU]: 'Sisu'
   };
 
-  const policyDefs: PolicyDef[] = [
-    {
-      id: 'eco',
-      name: 'Eco Policy',
-      description: 'Increase passive sauna beer brewing by 1 bottle per tick',
-      cost: 15,
-      resource: Resource.SAUNAKUNNIA,
-      prerequisite: () => true
-    },
-    {
-      id: 'temperance',
-      name: 'Temperance',
-      description: '+5% work speed at night',
-      cost: 25,
-      resource: Resource.SAUNAKUNNIA,
-      prerequisite: () => true
-    },
-    {
-      id: 'steam-diplomats',
-      name: 'Steam Diplomats',
-      description: 'Import +2 sauna beer bottles per tick through diplomatic envoys',
-      cost: 8,
-      resource: Resource.SAUNAKUNNIA,
-      prerequisite: () => true
-    }
-  ];
+  type PolicyUiElements = {
+    card: HTMLElement;
+    action: HTMLButtonElement;
+    stateBadge: HTMLSpanElement;
+    statusCopy: HTMLParagraphElement;
+    requirements: HTMLUListElement;
+    costChip: HTMLSpanElement;
+  };
 
-  const policyButtons: Record<string, HTMLButtonElement> = {};
+  const policies = listPolicies();
+  const policyElements = new Map<PolicyDefinition['id'], PolicyUiElements>();
+
+  function createBadge(text: string): HTMLSpanElement {
+    const badge = document.createElement('span');
+    badge.className = 'policy-card__badge';
+    badge.textContent = text;
+    return badge;
+  }
+
+  function createPolicyCard(def: PolicyDefinition): HTMLElement {
+    const card = document.createElement('article');
+    card.className = 'policy-card';
+    card.style.setProperty('--policy-gradient', def.visuals.gradient);
+    card.style.setProperty('--policy-accent', def.visuals.accentColor);
+
+    const header = document.createElement('div');
+    header.className = 'policy-card__header';
+
+    const iconFrame = document.createElement('div');
+    iconFrame.className = 'policy-card__icon-frame';
+
+    const icon = document.createElement('img');
+    icon.className = 'policy-card__icon';
+    icon.src = def.visuals.icon;
+    icon.alt = `${def.name} icon`;
+    iconFrame.appendChild(icon);
+
+    const heading = document.createElement('div');
+    heading.className = 'policy-card__heading';
+
+    const title = document.createElement('h4');
+    title.className = 'policy-card__title';
+    title.textContent = def.name;
+    heading.appendChild(title);
+
+    if (def.visuals.badges?.length) {
+      const badgeStrip = document.createElement('div');
+      badgeStrip.className = 'policy-card__badges';
+      def.visuals.badges.forEach((text) => badgeStrip.appendChild(createBadge(text)));
+      heading.appendChild(badgeStrip);
+    }
+
+    const stateBadge = document.createElement('span');
+    stateBadge.className = 'policy-card__state';
+    stateBadge.textContent = 'Ready';
+
+    header.append(iconFrame, heading, stateBadge);
+
+    const description = document.createElement('p');
+    description.className = 'policy-card__description';
+    description.textContent = def.description;
+
+    const flair = def.visuals.flair
+      ? (() => {
+          const flairLine = document.createElement('p');
+          flairLine.className = 'policy-card__flair';
+          flairLine.textContent = def.visuals.flair ?? '';
+          return flairLine;
+        })()
+      : null;
+
+    const actions = document.createElement('div');
+    actions.className = 'policy-card__actions';
+
+    const costChip = document.createElement('span');
+    costChip.className = 'policy-card__cost';
+
+    const costLabel = document.createElement('span');
+    costLabel.className = 'policy-card__cost-label';
+    costLabel.textContent = 'Cost';
+    const costValue = document.createElement('span');
+    costValue.className = 'policy-card__cost-value';
+    costValue.textContent = `${numberFormatter.format(def.cost)} ${resourceLabel[def.resource]}`;
+    costChip.append(costLabel, costValue);
+
+    const action = document.createElement('button');
+    action.type = 'button';
+    action.className = 'policy-card__action';
+    action.textContent = 'Enact Policy';
+
+    const statusCopy = document.createElement('p');
+    statusCopy.className = 'policy-card__status';
+
+    const requirements = document.createElement('ul');
+    requirements.className = 'policy-card__requirements';
+    requirements.hidden = true;
+
+    actions.append(costChip, action);
+
+    const handleClick = (): void => {
+      if (state.applyPolicy(def.id)) {
+        updatePolicyCard(def);
+      }
+    };
+    action.addEventListener('click', handleClick);
+    disposers.push(() => action.removeEventListener('click', handleClick));
+
+    card.append(header, description);
+    if (flair) {
+      card.appendChild(flair);
+    }
+    card.append(actions, statusCopy, requirements);
+
+    policyElements.set(def.id, {
+      card,
+      action,
+      stateBadge,
+      statusCopy,
+      requirements,
+      costChip
+    });
+
+    return card;
+  }
 
   function renderPolicies(): void {
     policiesTab.innerHTML = '';
-    for (const def of policyDefs) {
-      const btn = document.createElement('button');
-      const resource = def.resource;
-      btn.textContent = `${def.name} (${numberFormatter.format(def.cost)} ${resourceLabel[resource]})`;
-      btn.title = `${def.description}. Costs ${numberFormatter.format(def.cost)} ${resourceLabel[resource]}.`;
-      btn.classList.add('panel-action');
-      btn.disabled =
-        !def.prerequisite(state) ||
-        state.hasPolicy(def.id) ||
-        !state.canAfford(def.cost, resource);
-      const handleClick = (): void => {
-        if (state.applyPolicy(def.id, def.cost, resource)) {
-          updatePolicyButtons();
-        }
-      };
-      btn.addEventListener('click', handleClick);
-      disposers.push(() => btn.removeEventListener('click', handleClick));
-      policiesTab.appendChild(btn);
-      policyButtons[def.id] = btn;
-    }
+    policyElements.clear();
+    const grid = document.createElement('div');
+    grid.className = 'policy-grid';
+    policies.forEach((policy) => {
+      const card = createPolicyCard(policy);
+      grid.appendChild(card);
+    });
+    policiesTab.appendChild(grid);
+    updatePolicyCards();
   }
 
-  function updatePolicyButtons(): void {
-    for (const def of policyDefs) {
-      const btn = policyButtons[def.id];
-      if (btn) {
-        const resource = def.resource;
-        btn.disabled =
-          !def.prerequisite(state) ||
-          state.hasPolicy(def.id) ||
-          !state.canAfford(def.cost, resource);
-      }
+  function updatePolicyCard(def: PolicyDefinition): void {
+    const elements = policyElements.get(def.id);
+    if (!elements) {
+      return;
     }
+
+    const applied = state.hasPolicy(def.id);
+    const missing = def.prerequisites.filter((req) => !req.isSatisfied(state));
+    const affordable = state.canAfford(def.cost, def.resource);
+
+    elements.action.disabled = applied || missing.length > 0 || !affordable;
+    elements.action.textContent = applied ? 'Enacted' : 'Enact Policy';
+
+    let status = 'ready';
+    let badgeText = 'Ready';
+    let statusLine = def.spotlight ?? 'All signals point to go.';
+
+    elements.requirements.innerHTML = '';
+    elements.requirements.hidden = true;
+
+    if (applied) {
+      status = 'applied';
+      badgeText = 'Enacted';
+      statusLine = def.visuals.flair ?? 'Policy active.';
+    } else if (missing.length > 0) {
+      status = 'locked';
+      badgeText = 'Locked';
+      statusLine = 'Awaiting requirements:';
+      elements.requirements.hidden = false;
+      missing.forEach((req) => {
+        const item = document.createElement('li');
+        item.textContent = req.description;
+        elements.requirements.appendChild(item);
+      });
+    } else if (!affordable) {
+      status = 'budget';
+      badgeText = 'Needs Resources';
+      statusLine = `Earn ${numberFormatter.format(def.cost)} ${resourceLabel[def.resource]} to enact this edict.`;
+    }
+
+    elements.card.dataset.status = status;
+    elements.stateBadge.textContent = badgeText;
+    elements.statusCopy.textContent = statusLine;
+    const emphasizeCost = !applied && missing.length === 0 && !affordable;
+    elements.costChip.classList.toggle('policy-card__cost--warning', emphasizeCost);
+  }
+
+  function updatePolicyCards(): void {
+    policies.forEach((policy) => updatePolicyCard(policy));
   }
 
   renderPolicies();
-  eventBus.on('resourceChanged', updatePolicyButtons);
-  eventBus.on('policyApplied', updatePolicyButtons);
+
+  const handleResourceChanged = (_payload: unknown): void => updatePolicyCards();
+  const handlePolicyApplied = (_event: PolicyAppliedEvent): void => updatePolicyCards();
+  const handlePolicyRejected = (_event: PolicyRejectedEvent): void => updatePolicyCards();
+
+  eventBus.on('resourceChanged', handleResourceChanged);
+  eventBus.on(POLICY_EVENTS.APPLIED, handlePolicyApplied);
+  eventBus.on(POLICY_EVENTS.REJECTED, handlePolicyRejected);
   disposers.push(() => {
-    eventBus.off('resourceChanged', updatePolicyButtons);
-    eventBus.off('policyApplied', updatePolicyButtons);
+    eventBus.off('resourceChanged', handleResourceChanged);
+    eventBus.off(POLICY_EVENTS.APPLIED, handlePolicyApplied);
+    eventBus.off(POLICY_EVENTS.REJECTED, handlePolicyRejected);
   });
 
   // --- Events ---


### PR DESCRIPTION
## Summary
- Introduce a data-driven policy registry with typed events, visuals, and declarative effect hooks
- Update GameState and listeners to validate policy prerequisites and emit structured policy events
- Rebuild the right-panel policy cards with premium styling and status messaging sourced from the registry, and document the overhaul
- Extend Vitest coverage for policy successes and rejection flows

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce9d554d748330ae7c7651efdf9c2a