### PR TITLE
Refactor HUD layout for UI v2 grid regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,3 +520,8 @@
 - Defer game initialization until DOMContentLoaded via exported `init()`
 - Add workflow to deploy docs from `dist/` on pushes to `main`
 - Switch deployment workflow to Node.js 18
+- Introduce a five-region HUD grid scaffold for the experimental UI v2, teach
+  `ensureHudLayout` to emit explicit top/left/content/right/bottom anchors, move
+  the v2 bootstrapper into the centered content well, and apply Tailwind-style
+  grid utilities so the overlay honors safe margins from 1280×720 through
+  1920×1080.

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,17 +15,26 @@
     <div id="game-container">
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">
-        <div id="resource-bar">Saunoja Roster: 0</div>
-        <footer
-          id="build-id"
-          aria-live="polite"
-          aria-label="Development build"
-          data-build-state="development"
-          title="Unversioned development build"
-        >
-          <span class="build-id__label">Build</span>
-          <span class="build-id__value" data-build-commit data-state="dev">—</span>
-        </footer>
+        <div class="hud-layout-root" data-hud-root>
+          <div class="hud-region hud-top-row" data-hud-region="top"></div>
+          <div class="hud-region hud-actions" data-hud-region="left"></div>
+          <div class="hud-region hud-content" data-hud-region="content"></div>
+          <div class="hud-region hud-right-column" data-hud-region="right">
+            <div id="resource-bar">Saunoja Roster: 0</div>
+          </div>
+          <div class="hud-region hud-bottom-row" data-hud-region="bottom">
+            <footer
+              id="build-id"
+              aria-live="polite"
+              aria-label="Development build"
+              data-build-state="development"
+              title="Unversioned development build"
+            >
+              <span class="build-id__label">Build</span>
+              <span class="build-id__value" data-build-commit data-state="dev">—</span>
+            </footer>
+          </div>
+        </div>
       </div>
     </div>
   </body>

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -14,7 +14,15 @@ const renderGameShell = () => {
     <div id="game-container">
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">
-        <div id="resource-bar"></div>
+        <div class="hud-layout-root" data-hud-root>
+          <div class="hud-region hud-top-row" data-hud-region="top"></div>
+          <div class="hud-region hud-actions" data-hud-region="left"></div>
+          <div class="hud-region hud-content" data-hud-region="content"></div>
+          <div class="hud-region hud-right-column" data-hud-region="right">
+            <div id="resource-bar"></div>
+          </div>
+          <div class="hud-region hud-bottom-row" data-hud-region="bottom"></div>
+        </div>
       </div>
     </div>
   `;

--- a/src/game.ts
+++ b/src/game.ts
@@ -579,6 +579,7 @@ export function setupGame(
 ): void {
   const hudVariant = options.hudVariant ?? 'classic';
   const useClassicHud = hudVariant === 'classic';
+  overlayEl.dataset.hudVariant = hudVariant;
   canvas = canvasEl;
   if (unitFx) {
     unitFx.dispose();

--- a/src/index.html
+++ b/src/index.html
@@ -13,17 +13,26 @@
     <div id="game-container">
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">
-        <div id="resource-bar">Saunoja Roster: 0</div>
-        <footer
-          id="build-id"
-          aria-live="polite"
-          aria-label="Development build"
-          data-build-state="development"
-          title="Unversioned development build"
-        >
-          <span class="build-id__label">Build</span>
-          <span class="build-id__value" data-build-commit data-state="dev">—</span>
-        </footer>
+        <div class="hud-layout-root" data-hud-root>
+          <div class="hud-region hud-top-row" data-hud-region="top"></div>
+          <div class="hud-region hud-actions" data-hud-region="left"></div>
+          <div class="hud-region hud-content" data-hud-region="content"></div>
+          <div class="hud-region hud-right-column" data-hud-region="right">
+            <div id="resource-bar">Saunoja Roster: 0</div>
+          </div>
+          <div class="hud-region hud-bottom-row" data-hud-region="bottom">
+            <footer
+              id="build-id"
+              aria-live="polite"
+              aria-label="Development build"
+              data-build-state="development"
+              title="Unversioned development build"
+            >
+              <span class="build-id__label">Build</span>
+              <span class="build-id__value" data-build-commit data-state="dev">—</span>
+            </footer>
+          </div>
+        </div>
       </div>
     </div>
     <script type="module" src="./main.ts"></script>

--- a/src/main.hud.test.ts
+++ b/src/main.hud.test.ts
@@ -5,7 +5,15 @@ const renderShell = () => {
     <div id="game-container">
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">
-        <div id="resource-bar"></div>
+        <div class="hud-layout-root" data-hud-root>
+          <div class="hud-region hud-top-row" data-hud-region="top"></div>
+          <div class="hud-region hud-actions" data-hud-region="left"></div>
+          <div class="hud-region hud-content" data-hud-region="content"></div>
+          <div class="hud-region hud-right-column" data-hud-region="right">
+            <div id="resource-bar"></div>
+          </div>
+          <div class="hud-region hud-bottom-row" data-hud-region="bottom"></div>
+        </div>
       </div>
     </div>
   `;

--- a/src/style.css
+++ b/src/style.css
@@ -140,10 +140,77 @@ body > #game-container {
   inset: 0;
   padding: var(--hud-padding);
   padding-bottom: calc(var(--hud-padding) + env(safe-area-inset-bottom, 0px));
+}
+
+#ui-overlay:not(.hud-grid) {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   gap: clamp(16px, 3vw, 28px);
+}
+
+#ui-overlay.hud-grid {
+  align-content: start;
+}
+
+.grid {
+  display: grid;
+}
+
+.grid-rows-\[64px_1fr_80px\] {
+  grid-template-rows: 64px 1fr 80px;
+}
+
+.grid-cols-\[280px_1fr_340px\] {
+  grid-template-columns: 280px 1fr 340px;
+}
+
+.gap-\[clamp\(16px\,3vw\,28px\)\] {
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.col-span-3 {
+  grid-column: span 3 / span 3;
+}
+
+.col-start-1 {
+  grid-column-start: 1;
+}
+
+.col-start-2 {
+  grid-column-start: 2;
+}
+
+.col-start-3 {
+  grid-column-start: 3;
+}
+
+.row-start-1 {
+  grid-row-start: 1;
+}
+
+.row-start-2 {
+  grid-row-start: 2;
+}
+
+.row-start-3 {
+  grid-row-start: 3;
+}
+
+.row-span-1 {
+  grid-row: span 1 / span 1;
+}
+
+.hud-layout-root {
+  display: contents;
+}
+
+.hud-region {
+  pointer-events: none;
+}
+
+.hud-region > * {
+  pointer-events: auto;
 }
 
 #ui-overlay.inventory-panel-open {
@@ -154,7 +221,7 @@ body > #game-container {
   pointer-events: auto;
 }
 
-.is-mobile #ui-overlay {
+.is-mobile #ui-overlay:not(.hud-grid) {
   gap: clamp(12px, 4vw, 18px);
 }
 
@@ -190,7 +257,7 @@ body > #game-container {
   gap: clamp(16px, 2vw, 28px);
 }
 
-.hud-top-row {
+#ui-overlay:not(.hud-grid) .hud-top-row {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -199,24 +266,41 @@ body > #game-container {
 }
 
 .hud-actions {
+  max-width: min(620px, 58vw);
+}
+
+#ui-overlay:not(.hud-grid) .hud-actions {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: clamp(16px, 2.4vw, 24px);
-  max-width: min(620px, 58vw);
-}
-
-.hud-actions > * {
-  pointer-events: auto;
 }
 
 .hud-right-column {
+  width: fit-content;
+  max-width: min(360px, 32vw);
+}
+
+#ui-overlay:not(.hud-grid) .hud-right-column {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: clamp(18px, 2vw, 24px);
-  width: fit-content;
-  max-width: min(360px, 32vw);
+}
+
+.hud-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 2vw, 28px);
+  min-height: 0;
+}
+
+.hud-bottom-row {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  gap: clamp(12px, 2.4vw, 20px);
 }
 
 .hud-mobile-bar {
@@ -259,20 +343,20 @@ body > #game-container {
   flex: 1 1 0;
 }
 
-.is-mobile .hud-top-row {
+.is-mobile #ui-overlay:not(.hud-grid) .hud-top-row {
   flex-direction: column;
   align-items: stretch;
   gap: clamp(12px, 4vw, 18px);
 }
 
-.is-mobile .hud-actions {
+.is-mobile #ui-overlay:not(.hud-grid) .hud-actions {
   width: 100%;
   max-width: none;
   align-items: stretch;
   gap: clamp(12px, 4vw, 16px);
 }
 
-.is-mobile .hud-right-column {
+.is-mobile #ui-overlay:not(.hud-grid) .hud-right-column {
   width: 100%;
   max-width: none;
   align-items: stretch;

--- a/src/ui/inventoryHud.ts
+++ b/src/ui/inventoryHud.ts
@@ -168,13 +168,14 @@ export function setupInventoryHud(
     return { destroy: () => {} };
   }
 
-  const { actions } = ensureHudLayout(overlay);
-  const toastStack = ensureToastStack(overlay, actions);
+  const { regions } = ensureHudLayout(overlay);
+  const topRegion = regions.top;
+  const toastStack = ensureToastStack(overlay, topRegion);
 
   overlay.querySelectorAll('.inventory-badge').forEach((el) => el.remove());
   const { button: badgeButton, count: badgeCount } = createBadge();
   badgeButton.dataset.autoequip = inventory.isAutoEquipEnabled() ? 'on' : 'off';
-  actions.appendChild(badgeButton);
+  topRegion.appendChild(badgeButton);
 
   overlay.querySelector('#inventory-stash-panel')?.remove();
 

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -1,51 +1,149 @@
+export type HudLayoutRegions = {
+  top: HTMLDivElement;
+  left: HTMLDivElement;
+  content: HTMLDivElement;
+  right: HTMLDivElement;
+  bottom: HTMLDivElement;
+};
+
 export type HudLayout = {
-  container: HTMLDivElement;
+  root: HTMLDivElement;
+  regions: HudLayoutRegions;
+  /**
+   * @deprecated Prefer {@link regions.left}. Maintained for backwards compatibility.
+   */
   actions: HTMLDivElement;
+  /**
+   * @deprecated Prefer {@link regions.right}. Maintained for backwards compatibility.
+   */
   side: HTMLDivElement;
   mobileBar: HTMLDivElement;
 };
 
+const OVERLAY_GRID_CLASSES = [
+  'hud-grid',
+  'grid',
+  'grid-rows-[64px_1fr_80px]',
+  'grid-cols-[280px_1fr_340px]',
+  'gap-[clamp(16px,3vw,28px)]',
+];
+
+const REGION_GRID_CLASSES: Record<keyof HudLayoutRegions, string[]> = {
+  top: ['col-span-3', 'row-span-1', 'row-start-1'],
+  left: ['col-start-1', 'row-start-2', 'row-span-1'],
+  content: ['col-start-2', 'row-start-2', 'row-span-1'],
+  right: ['col-start-3', 'row-start-2', 'row-span-1'],
+  bottom: ['col-span-3', 'row-start-3', 'row-span-1'],
+};
+
+function ensureRoot(overlay: HTMLElement, doc: Document): HTMLDivElement {
+  let root = overlay.querySelector<HTMLDivElement>('[data-hud-root]');
+  if (!root) {
+    root = doc.createElement('div');
+    root.dataset.hudRoot = 'true';
+    root.className = 'hud-layout-root';
+    overlay.prepend(root);
+  }
+  return root;
+}
+
+function ensureRegion(
+  root: HTMLDivElement,
+  doc: Document,
+  name: keyof HudLayoutRegions,
+  classNames: string[]
+): HTMLDivElement {
+  let region = root.querySelector<HTMLDivElement>(`[data-hud-region="${name}"]`);
+  if (!region) {
+    region = doc.createElement('div');
+    region.dataset.hudRegion = name;
+    root.appendChild(region);
+  }
+  region.classList.add('hud-region', ...classNames);
+  if (region.parentElement !== root) {
+    root.appendChild(region);
+  }
+  return region;
+}
+
+function applyVariantClasses(
+  overlay: HTMLElement,
+  regions: HudLayoutRegions,
+  isUiV2: boolean
+): void {
+  if (isUiV2) {
+    overlay.classList.add(...OVERLAY_GRID_CLASSES);
+    for (const [name, classes] of Object.entries(REGION_GRID_CLASSES) as Array<[
+      keyof HudLayoutRegions,
+      string[]
+    ]>) {
+      regions[name].classList.add(...classes);
+    }
+  } else {
+    overlay.classList.remove(...OVERLAY_GRID_CLASSES);
+    for (const [name, classes] of Object.entries(REGION_GRID_CLASSES) as Array<[
+      keyof HudLayoutRegions,
+      string[]
+    ]>) {
+      regions[name].classList.remove(...classes);
+    }
+  }
+}
+
 export function ensureHudLayout(overlay: HTMLElement): HudLayout {
-  let container = overlay.querySelector<HTMLDivElement>('.hud-top-row');
-  if (!container) {
-    container = document.createElement('div');
-    container.className = 'hud-top-row';
-    overlay.prepend(container);
-  }
+  const doc = overlay.ownerDocument ?? document;
+  const root = ensureRoot(overlay, doc);
 
-  let actions = container.querySelector<HTMLDivElement>('.hud-actions');
-  if (!actions) {
-    actions = document.createElement('div');
-    actions.className = 'hud-actions';
-    container.appendChild(actions);
-  }
+  const regions = {
+    top: ensureRegion(root, doc, 'top', ['hud-top-row']),
+    left: ensureRegion(root, doc, 'left', ['hud-actions']),
+    content: ensureRegion(root, doc, 'content', ['hud-content']),
+    right: ensureRegion(root, doc, 'right', ['hud-right-column']),
+    bottom: ensureRegion(root, doc, 'bottom', ['hud-bottom-row']),
+  } satisfies HudLayoutRegions;
 
-  let side = container.querySelector<HTMLDivElement>('.hud-right-column');
-  if (!side) {
-    side = document.createElement('div');
-    side.className = 'hud-right-column';
-    container.appendChild(side);
+  // Guarantee consistent DOM order for the layout regions.
+  root.append(regions.top, regions.left, regions.content, regions.right, regions.bottom);
 
+  const isUiV2 = overlay.dataset.hudVariant === 'v2';
+  applyVariantClasses(overlay, regions, isUiV2);
+
+  if (!isUiV2) {
     const resourceBar = overlay.querySelector<HTMLElement>('#resource-bar');
-    if (resourceBar) {
-      side.prepend(resourceBar);
+    if (resourceBar && resourceBar.parentElement !== regions.right) {
+      regions.right.prepend(resourceBar);
     }
   }
 
   const buildMenu = overlay.querySelector<HTMLElement>('#build-menu');
-  if (buildMenu && buildMenu.parentElement !== actions) {
-    actions.appendChild(buildMenu);
+  if (buildMenu && buildMenu.parentElement !== regions.left) {
+    regions.left.appendChild(buildMenu);
+  }
+
+  const buildId = overlay.querySelector<HTMLElement>('#build-id');
+  if (buildId && buildId.parentElement !== regions.bottom) {
+    regions.bottom.appendChild(buildId);
   }
 
   let mobileBar = overlay.querySelector<HTMLDivElement>('.hud-mobile-bar__tray');
-  if (!mobileBar) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'hud-mobile-bar';
-    mobileBar = document.createElement('div');
+  let mobileWrapper = mobileBar?.closest<HTMLDivElement>('.hud-mobile-bar') ?? null;
+  if (!mobileBar || !mobileWrapper) {
+    mobileWrapper = doc.createElement('div');
+    mobileWrapper.className = 'hud-mobile-bar';
+    mobileBar = doc.createElement('div');
     mobileBar.className = 'hud-mobile-bar__tray';
-    wrapper.appendChild(mobileBar);
-    overlay.appendChild(wrapper);
+    mobileWrapper.appendChild(mobileBar);
   }
 
-  return { container, actions, side, mobileBar };
+  if (mobileWrapper.parentElement !== regions.bottom) {
+    regions.bottom.appendChild(mobileWrapper);
+  }
+
+  return {
+    root,
+    regions,
+    actions: regions.left,
+    side: regions.right,
+    mobileBar,
+  } satisfies HudLayout;
 }

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -51,7 +51,9 @@ export function setupRightPanel(
     return { log: () => {}, addEvent: () => {}, renderRoster: () => {}, dispose: () => {} };
   }
 
-  const { actions, side, mobileBar } = ensureHudLayout(overlay);
+  const { regions, mobileBar } = ensureHudLayout(overlay);
+  const topRegion = regions.top;
+  const rightRegion = regions.right;
 
   const existingPanel = overlay.querySelector<HTMLDivElement>('#right-panel');
   if (existingPanel) {
@@ -115,11 +117,11 @@ export function setupRightPanel(
   toggle.append(toggleIcon, toggleText);
 
   const insertToggle = (): void => {
-    const topbar = actions.querySelector<HTMLElement>('#topbar');
-    if (topbar && topbar.parentElement === actions) {
+    const topbar = topRegion.querySelector<HTMLElement>('#topbar');
+    if (topbar && topbar.parentElement === topRegion) {
       topbar.insertAdjacentElement('afterend', toggle);
     } else {
-      actions.prepend(toggle);
+      topRegion.prepend(toggle);
     }
   };
 
@@ -369,7 +371,7 @@ export function setupRightPanel(
       closeMobilePanel({ skipFocus: true });
       slideOver.style.setProperty('--panel-drag-progress', '1');
       slideOver.remove();
-      side.appendChild(panel);
+  rightRegion.appendChild(panel);
       insertToggle();
       toggle.classList.remove('hud-panel-toggle--mobile');
       toggle.hidden = !smallViewportQuery.matches;

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -269,7 +269,8 @@ export function setupSaunaUI(
   card.appendChild(label);
 
   container.appendChild(card);
-  const { actions } = ensureHudLayout(overlay);
+  const { regions } = ensureHudLayout(overlay);
+  const topRegion = regions.top;
 
   const reduceMotionQuery =
     typeof matchMedia === 'function' ? matchMedia('(prefers-reduced-motion: reduce)') : null;
@@ -411,13 +412,13 @@ export function setupSaunaUI(
   applyRosterCap(sauna.maxRosterSize, false);
 
   const placeControl = (): boolean => {
-    if (container.parentElement !== actions) {
-      actions.appendChild(container);
+    if (container.parentElement !== topRegion) {
+      topRegion.appendChild(container);
     }
-    const topbar = actions.querySelector<HTMLDivElement>('#topbar');
-    if (topbar && topbar.parentElement === actions) {
+    const topbar = topRegion.querySelector<HTMLDivElement>('#topbar');
+    if (topbar && topbar.parentElement === topRegion) {
       if (topbar.nextSibling !== container) {
-        actions.insertBefore(container, topbar.nextSibling);
+        topRegion.insertBefore(container, topbar.nextSibling);
       }
       return true;
     }
@@ -431,7 +432,7 @@ export function setupSaunaUI(
         placementObserver?.disconnect();
       }
     });
-    placementObserver.observe(actions, { childList: true });
+    placementObserver.observe(topRegion, { childList: true });
   }
 
   const handleToggle = () => {

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -125,11 +125,12 @@ export function setupTopbar(
     };
   }
 
-  const { actions, mobileBar } = ensureHudLayout(overlay);
+  const { regions, mobileBar } = ensureHudLayout(overlay);
+  const topRegion = regions.top;
 
   const bar = document.createElement('div');
   bar.id = 'topbar';
-  actions.prepend(bar);
+  topRegion.prepend(bar);
 
   const badgeRow = document.createElement('div');
   badgeRow.className = 'topbar-badge-row';

--- a/src/uiV2/bootstrap.ts
+++ b/src/uiV2/bootstrap.ts
@@ -1,4 +1,5 @@
 import '../ui/style/atoms.css';
+import { ensureHudLayout } from '../ui/layout.ts';
 
 export interface UiV2Handle {
   destroy(): void;
@@ -12,6 +13,9 @@ export interface UiV2BootstrapOptions {
 
 export function bootstrapUiV2(options: UiV2BootstrapOptions): UiV2Handle {
   const { overlay, resourceBar } = options;
+  const layout = ensureHudLayout(overlay);
+  const { regions } = layout;
+
   const root = document.createElement('div');
   root.className = 'ui-v2-overlay';
 
@@ -46,7 +50,7 @@ export function bootstrapUiV2(options: UiV2BootstrapOptions): UiV2Handle {
   card.appendChild(resourceDock);
 
   root.appendChild(card);
-  overlay.appendChild(root);
+  regions.content.appendChild(root);
 
   return {
     destroy() {


### PR DESCRIPTION
## Summary
- refactor the HUD scaffolding to create explicit top/left/content/right/bottom regions and apply Tailwind-style grid utilities when the experimental UI v2 is active
- update HUD controllers and the UI v2 bootstrapper to mount their elements inside the new regions while keeping the markup in sync for runtime and tests
- tag the overlay with the current HUD variant so classic mode and tests continue to receive the expected structure

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cea781e92c8330ac4d299cf954c05e