### PR TITLE
Align Saunoja overlays with render coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Sync Saunoja overlay icons with animated render coordinates so attendant
+  badges glide alongside their battlefield units, threading the callback through
+  the draw pipeline and extending Vitest coverage for both the renderer and
+  roster synchronization.
+
 - Keep NG+ roster unlock spawn limits from dropping below the base sauna tier
   capacity so fresh profiles can queue three attendants while higher unlocks
   continue to respect the active tier ceiling.

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -441,6 +441,7 @@ describe('rendering', () => {
     const playerUnit = new Unit('render-player', 'soldier', { q: 0, r: 0 }, 'player', {
       ...baseStats
     });
+    playerUnit.renderCoord = { q: 3, r: -2 };
     const enemyUnit = new Unit('render-enemy', 'soldier', { q: 1, r: 0 }, 'enemy', {
       ...baseStats
     });
@@ -456,7 +457,17 @@ describe('rendering', () => {
       const [, , , unitsArg, , drawOptions] = renderSpy.mock.calls[0]!;
       expect(unitsArg.some((unit) => unit.faction === 'player')).toBe(false);
       expect(unitsArg.some((unit) => unit.id === enemyUnit.id)).toBe(true);
-      expect(drawOptions?.saunojas?.units?.length ?? 0).toBeGreaterThan(0);
+      const saunojaOverlay = drawOptions?.saunojas;
+      expect(saunojaOverlay?.units?.length ?? 0).toBeGreaterThan(0);
+      expect(typeof saunojaOverlay?.resolveRenderCoord).toBe('function');
+      const resolvedCoords = saunojaOverlay?.units
+        ?.map((attendant) => saunojaOverlay.resolveRenderCoord?.(attendant) ?? null)
+        .filter((coord): coord is { q: number; r: number } => !!coord);
+      expect(
+        resolvedCoords?.some(
+          (coord) => coord.q === playerUnit.renderCoord?.q && coord.r === playerUnit.renderCoord?.r
+        )
+      ).toBe(true);
     } finally {
       renderSpy.mockRestore();
       assetsModule.resetAssetsForTest();

--- a/src/game.ts
+++ b/src/game.ts
@@ -1657,7 +1657,14 @@ export function draw(): void {
   render(ctx, mapRenderer, assets.images, renderUnits, selected, {
     saunojas: {
       units: saunojas,
-      draw: drawSaunojas
+      draw: drawSaunojas,
+      resolveRenderCoord: (attendant) => {
+        const unit = getAttachedUnitFor(attendant);
+        if (!unit) {
+          return null;
+        }
+        return unit.renderCoord ?? unit.coord;
+      }
     },
     sauna,
     saunaVision,

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -64,6 +64,7 @@ export interface DrawOptions {
   saunojas?: {
     units: Saunoja[];
     draw: DrawSaunojaFn;
+    resolveRenderCoord?: DrawSaunojasOptions['resolveRenderCoord'];
   };
   sauna?: Sauna | null;
   saunaVision?: VisionSource | null;
@@ -104,7 +105,8 @@ export function draw(
       originX: origin.x,
       originY: origin.y,
       hexRadius: mapRenderer.hexSize,
-      zoom: camera.zoom
+      zoom: camera.zoom,
+      resolveRenderCoord: saunojaLayer.resolveRenderCoord
     });
   }
   drawUnits(


### PR DESCRIPTION
## Summary
- allow Saunoja overlays to resolve optional render coordinates when drawing attendants
- pass the attached unit render coordinates through the game renderer so overlays follow animations
- cover the new rendering path with focused Vitest updates and document the behaviour change

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef554e0a08330af6e62ecc2bea4a1