### PR TITLE
Refactor roster cap controls into roster panel

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2124,6 +2124,140 @@ body > #game-container {
   color: var(--color-muted);
 }
 
+.panel-roster__cap {
+  display: grid;
+  gap: 12px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 24%, transparent);
+  background:
+    radial-gradient(circle at -20% 0%, rgba(56, 189, 248, 0.18), transparent 60%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.62));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12), 0 18px 36px rgba(10, 20, 36, 0.45);
+}
+
+.panel-roster__cap-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.panel-roster__cap-title {
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  color: var(--color-foreground);
+}
+
+.panel-roster__cap-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 56px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-accent) 45%, rgba(15, 23, 42, 0.65));
+  color: color-mix(in srgb, var(--color-foreground) 88%, white 12%);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  box-shadow: 0 12px 28px rgba(8, 17, 35, 0.48);
+  transition: background 200ms ease, color 200ms ease;
+}
+
+.panel-roster__cap-value[data-state='paused'] {
+  background: color-mix(in srgb, var(--color-muted) 72%, rgba(11, 19, 35, 0.88));
+  color: color-mix(in srgb, var(--color-muted) 82%, white 18%);
+}
+
+.panel-roster__cap-description {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: color-mix(in srgb, var(--color-muted) 86%, white 8%);
+}
+
+.panel-roster__cap-controls {
+  display: grid;
+  gap: 10px;
+}
+
+.panel-roster__cap-label {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 82%, white 6%);
+}
+
+.panel-roster__cap-slider {
+  width: 100%;
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--color-accent) 40%, rgba(10, 20, 36, 0.8)), rgba(9, 17, 30, 0.65));
+  outline: none;
+  transition: box-shadow 180ms ease;
+}
+
+.panel-roster__cap-slider:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 45%, transparent);
+}
+
+.panel-roster__cap-slider::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--color-accent) 40%, rgba(10, 20, 36, 0.8)), rgba(9, 17, 30, 0.65));
+}
+
+.panel-roster__cap-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, white 12%, var(--color-accent));
+  border: 2px solid color-mix(in srgb, var(--color-accent) 60%, white 15%);
+  box-shadow: 0 8px 16px rgba(11, 22, 43, 0.45);
+  margin-top: -6px;
+}
+
+.panel-roster__cap-slider::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--color-accent) 40%, rgba(10, 20, 36, 0.8)), rgba(9, 17, 30, 0.65));
+}
+
+.panel-roster__cap-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--color-accent) 60%, white 15%);
+  background: radial-gradient(circle at 30% 30%, white 12%, var(--color-accent));
+  box-shadow: 0 8px 16px rgba(11, 22, 43, 0.45);
+}
+
+.panel-roster__cap-number {
+  width: 100%;
+  padding: 6px 12px;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--color-muted) 70%, transparent);
+  background: rgba(12, 20, 36, 0.72);
+  color: var(--color-foreground);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  letter-spacing: 0.12em;
+  transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.panel-roster__cap-number:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 35%, transparent);
+  background: rgba(16, 26, 46, 0.82);
+}
+
 .panel-roster__metrics {
   display: flex;
   flex-wrap: wrap;

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -50,6 +50,9 @@ type RightPanelOptions = {
   onRosterRendererReady?: (renderer: (entries: RosterEntry[]) => void) => void;
   onRosterEquipSlot?: (unitId: string, slot: EquipmentSlotId) => void;
   onRosterUnequipSlot?: (unitId: string, slot: EquipmentSlotId) => void;
+  getRosterCap?: () => number;
+  getRosterCapLimit?: () => number;
+  updateMaxRosterSize?: (value: number, options?: { persist?: boolean }) => number;
 };
 
 export function setupRightPanel(
@@ -493,7 +496,10 @@ export function setupRightPanel(
   const rosterPanel = createRosterPanel(rosterTab, {
     onSelect: onRosterSelect,
     onEquipSlot: onRosterEquipSlot,
-    onUnequipSlot: onRosterUnequipSlot
+    onUnequipSlot: onRosterUnequipSlot,
+    getRosterCap: options.getRosterCap,
+    getRosterCapLimit: options.getRosterCapLimit,
+    updateMaxRosterSize: options.updateMaxRosterSize
   });
 
   const renderRoster = (entries: RosterEntry[]): void => {

--- a/src/ui/sauna.test.ts
+++ b/src/ui/sauna.test.ts
@@ -123,8 +123,6 @@ describe('setupSaunaUI', () => {
     const sauna = createTestSauna();
     let activeTierId: SaunaTierId = DEFAULT_SAUNA_TIER_ID;
     const controller = setupSaunaUI(sauna, {
-      getRosterCapLimit: () => 6,
-      updateMaxRosterSize: (value) => value,
       getActiveTierId: () => activeTierId,
       setActiveTierId: (tierId) => {
         activeTierId = tierId;
@@ -176,60 +174,6 @@ describe('setupSaunaUI', () => {
       expect(lockedTier?.dataset.state).toBe('locked');
       lockedTier?.click();
       expect(lockedTier?.classList.contains('sauna-tier__option--denied')).toBe(true);
-    } finally {
-      controller.dispose();
-      overlay.remove();
-    }
-  });
-
-  it('limits roster controls to the baseline unlock allowance for new profiles', () => {
-    const overlay = createOverlay();
-    const sauna = createTestSauna();
-    sauna.maxRosterSize = 0;
-    const controller = setupSaunaUI(sauna, {
-      getRosterCapLimit: () => 3,
-      getActiveTierId: () => DEFAULT_SAUNA_TIER_ID,
-      getTierContext: () => ({ ngPlusLevel: 0, unlockSlots: 0 })
-    });
-
-    try {
-      controller.update();
-      const slider = overlay.querySelector<HTMLInputElement>('.sauna-roster__slider');
-      expect(slider?.max).toBe('3');
-      const numeric = overlay.querySelector<HTMLInputElement>('.sauna-roster__number');
-      expect(numeric?.max).toBe('3');
-    } finally {
-      controller.dispose();
-      overlay.remove();
-    }
-  });
-
-  it('caps roster controls by the active tier even with excess unlocks', () => {
-    const overlay = createOverlay();
-    const sauna = createTestSauna();
-    sauna.maxRosterSize = 4;
-    let activeTierId: SaunaTierId = 'aurora-ward';
-    const controller = setupSaunaUI(sauna, {
-      getRosterCapLimit: () => 6,
-      getActiveTierId: () => activeTierId,
-      setActiveTierId: (tierId) => {
-        activeTierId = tierId;
-        return true;
-      },
-      getTierContext: () => ({ ngPlusLevel: 5, unlockSlots: 5 })
-    });
-
-    try {
-      controller.update();
-      const slider = overlay.querySelector<HTMLInputElement>('.sauna-roster__slider');
-      const numeric = overlay.querySelector<HTMLInputElement>('.sauna-roster__number');
-      expect(slider?.max).toBe('4');
-      expect(numeric?.max).toBe('4');
-
-      activeTierId = DEFAULT_SAUNA_TIER_ID;
-      controller.update();
-      expect(slider?.max).toBe('3');
-      expect(numeric?.max).toBe('3');
     } finally {
       controller.dispose();
       overlay.remove();

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -12,8 +12,6 @@ import {
 import { ensureHudLayout } from './layout.ts';
 
 export interface SaunaUIOptions {
-  getRosterCapLimit?: () => number;
-  updateMaxRosterSize?: (value: number, options?: { persist?: boolean }) => number;
   getActiveTierId?: () => SaunaTierId;
   setActiveTierId?: (value: SaunaTierId, options?: { persist?: boolean }) => boolean;
   getTierContext?: () => SaunaTierContext;
@@ -202,56 +200,6 @@ export function setupSaunaUI(
   card.appendChild(tierSection);
   refreshTierDisplay();
 
-  const rosterContainer = document.createElement('div');
-  rosterContainer.classList.add('sauna-roster');
-
-  const rosterHeader = document.createElement('div');
-  rosterHeader.classList.add('sauna-roster__header');
-  const rosterTitle = document.createElement('span');
-  rosterTitle.textContent = 'Roster Cap';
-  rosterTitle.classList.add('sauna-roster__title');
-  rosterHeader.appendChild(rosterTitle);
-
-  const rosterValue = document.createElement('span');
-  rosterValue.classList.add('sauna-roster__value');
-  rosterValue.setAttribute('aria-live', 'polite');
-  rosterHeader.appendChild(rosterValue);
-  rosterContainer.appendChild(rosterHeader);
-
-  const rosterDescription = document.createElement('p');
-  rosterDescription.classList.add('sauna-roster__description');
-  rosterDescription.textContent = 'Tune how many attendants may be active before new recruits wait in the steam.';
-  rosterContainer.appendChild(rosterDescription);
-
-  const sliderId = `sauna-roster-${Math.floor(Math.random() * 100000)}`;
-  const sliderLabel = document.createElement('label');
-  sliderLabel.classList.add('sauna-roster__label');
-  sliderLabel.htmlFor = sliderId;
-  sliderLabel.textContent = 'Active attendants';
-
-  const slider = document.createElement('input');
-  slider.type = 'range';
-  slider.id = sliderId;
-  slider.min = '0';
-  slider.step = '1';
-  slider.classList.add('sauna-roster__slider');
-
-  const numericInput = document.createElement('input');
-  numericInput.type = 'number';
-  numericInput.min = '0';
-  numericInput.step = '1';
-  numericInput.inputMode = 'numeric';
-  numericInput.classList.add('sauna-roster__number');
-
-  const controls = document.createElement('div');
-  controls.classList.add('sauna-roster__controls');
-  controls.appendChild(sliderLabel);
-  controls.appendChild(slider);
-  controls.appendChild(numericInput);
-  rosterContainer.appendChild(controls);
-
-  card.appendChild(rosterContainer);
-
   const label = document.createElement('label');
   label.classList.add('sauna-option');
   const checkbox = document.createElement('input');
@@ -308,17 +256,6 @@ export function setupSaunaUI(
     attachMqListener(reduceMotionQuery, handleMotionChange);
   }
 
-  const resolveLimit = (): number => {
-    const activeTier = getSaunaTier(resolveActiveTierId());
-    const tierCap = Math.max(0, Math.floor(activeTier.rosterCap));
-    const limit = options.getRosterCapLimit?.();
-    if (typeof limit === 'number' && Number.isFinite(limit)) {
-      const sanitized = Math.max(0, Math.floor(limit));
-      return Math.max(0, Math.min(tierCap, sanitized));
-    }
-    return tierCap;
-  };
-
   function refreshTierDisplay(): void {
     const activeId = resolveActiveTierId();
     const context = resolveTierContext();
@@ -350,66 +287,9 @@ export function setupSaunaUI(
       entry.button.classList.add('sauna-tier__option--denied');
       return;
     }
-    const success = options.setActiveTierId?.(tier.id, { persist: true }) ?? false;
-    if (success) {
-      applyRosterCap(sauna.maxRosterSize, true);
-    }
+    options.setActiveTierId?.(tier.id, { persist: true });
     refreshTierDisplay();
   }
-
-  const updateDisplay = (limit: number, value: number): void => {
-    const cappedValue = Math.max(0, Math.min(limit, Math.floor(value)));
-    slider.max = String(limit);
-    slider.value = String(cappedValue);
-    slider.setAttribute('aria-valuemax', slider.max);
-    slider.setAttribute('aria-valuenow', slider.value);
-    numericInput.max = String(limit);
-    numericInput.value = String(cappedValue);
-    rosterValue.textContent = cappedValue === 0 ? 'Paused' : `${cappedValue}`;
-    rosterValue.dataset.state = cappedValue === 0 ? 'paused' : 'active';
-    numericInput.setAttribute('aria-label', `Roster cap set to ${cappedValue}`);
-  };
-
-  function applyRosterCap(raw: number, persist: boolean): number {
-    const numeric = Number(raw);
-    const limit = resolveLimit();
-    const normalized = Number.isFinite(numeric) ? Math.max(0, Math.floor(numeric)) : 0;
-    let applied = Math.max(0, Math.min(limit, normalized));
-    if (options.updateMaxRosterSize) {
-      applied = options.updateMaxRosterSize(applied, { persist });
-    } else {
-      sauna.maxRosterSize = applied;
-    }
-    updateDisplay(limit, applied);
-    return applied;
-  }
-
-  const handleSliderInput = () => {
-    applyRosterCap(Number(slider.value), false);
-  };
-  const handleSliderCommit = () => {
-    applyRosterCap(Number(slider.value), true);
-  };
-  slider.addEventListener('input', handleSliderInput);
-  slider.addEventListener('change', handleSliderCommit);
-
-  const commitNumeric = (persist: boolean): void => {
-    applyRosterCap(Number(numericInput.value), persist);
-  };
-  const handleNumericInput = () => {
-    commitNumeric(false);
-  };
-  const handleNumericCommit = () => {
-    commitNumeric(true);
-  };
-  const handleNumericBlur = () => {
-    commitNumeric(true);
-  };
-  numericInput.addEventListener('input', handleNumericInput);
-  numericInput.addEventListener('change', handleNumericCommit);
-  numericInput.addEventListener('blur', handleNumericBlur);
-
-  applyRosterCap(sauna.maxRosterSize, false);
 
   const placeControl = (): boolean => {
     if (container.parentElement !== topRegion) {
@@ -531,19 +411,6 @@ export function setupSaunaUI(
     const progress = 1 - sauna.playerSpawnTimer / cooldown;
     barFill.style.width = `${Math.max(0, Math.min(progress, 1)) * 100}%`;
     checkbox.checked = sauna.rallyToFront;
-    const limit = resolveLimit();
-    const sanitized = Math.max(0, Math.min(limit, Math.floor(sauna.maxRosterSize)));
-    if (sanitized !== sauna.maxRosterSize) {
-      if (options.updateMaxRosterSize) {
-        const next = options.updateMaxRosterSize(sanitized, { persist: true });
-        updateDisplay(limit, next);
-      } else {
-        sauna.maxRosterSize = sanitized;
-        updateDisplay(limit, sanitized);
-      }
-    } else {
-      updateDisplay(limit, sanitized);
-    }
     refreshTierDisplay();
   };
 
@@ -566,11 +433,6 @@ export function setupSaunaUI(
     placementObserver?.disconnect();
     placementObserver = null;
     btn.removeEventListener('click', handleToggle);
-    slider.removeEventListener('input', handleSliderInput);
-    slider.removeEventListener('change', handleSliderCommit);
-    numericInput.removeEventListener('input', handleNumericInput);
-    numericInput.removeEventListener('change', handleNumericCommit);
-    numericInput.removeEventListener('blur', handleNumericBlur);
     if (reduceMotionQuery) {
       detachMqListener(reduceMotionQuery, handleMotionChange);
     }


### PR DESCRIPTION
## Summary
- move the roster cap slider into the roster panel with callbacks for reading and updating the cap
- wire the right panel and game setup to supply roster-cap helpers and refresh summaries when the cap changes
- streamline the sauna UI by removing the old roster-cap block and update tests to cover the new control

## Testing
- pnpm test *(fails: docs bundle commit 1d99b2e does not match HEAD 1cbb7c9)*

------
https://chatgpt.com/codex/tasks/task_e_68cf84b077bc8330aeeb500a29e55202