### PR TITLE
docs: align onboarding onboarding tutorial copy with HUD cues

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,18 +1,20 @@
 # Onboarding Experience
 
-The onboarding flow introduces the core HUD rhythms for new leaders through a guided tutorial. It automatically launches on fresh saves unless the local `tutorial_done` flag is set in `localStorage`.
+The onboarding flow introduces the polished HUD rhythms for new leaders through a guided tutorial. It automatically launches on fresh saves unless the local `tutorial_done` flag is set in `localStorage`.
 
 ## Flow overview
 
 | Step | Anchor | Purpose |
 | --- | --- | --- |
-| Heat | `data-tutorial-target="heat"` on the sauna control | Highlights the sauna heat controls so players understand how reinforcements arrive. |
-| Upkeep | `data-tutorial-target="upkeep"` on the roster HUD | Emphasises upkeep pressure and introduces the featured attendant card. |
-| SISU | `data-tutorial-target="sisu"` on the SISU meter | Shows how grit accumulates and fuels abilities. |
-| Combat | `data-tutorial-target="combat"` on the action tray | Demonstrates the burst and rally buttons that shape battles. |
-| Victory | `data-tutorial-target="victory"` on the Saunakunnia badge | Frames long-term success through renown tracking. |
+| Heat the Sauna | `data-tutorial-target="heat"` on the sauna control | Keep the sauna fires roaring. This control shows when the next warrior emerges from the steam. |
+| Mind Your Upkeep | `data-tutorial-target="upkeep"` on the roster HUD | Every attendant draws upkeep. Track totals and see a featured roster member to balance your economy. |
+| Stockpile SISU | `data-tutorial-target="sisu"` on the SISU meter | SISU fuels heroic bursts. Watch this meter to know when your grit reserves can power signature moves. |
+| Command the Fight | `data-tutorial-target="combat"` on the action tray | Trigger a Sisu Burst to supercharge allied attacks or rally everyone home with a Torille call. |
+| Claim Victory | `data-tutorial-target="victory"` on the Saunakunnia badge | Saunakunnia measures renown. Push it ever higher to unlock triumphs and close the campaign in glory. |
 
 Each tooltip card is fully keyboard navigable (`←`, `→`, `Esc`, or the on-screen controls) and can be dismissed at any time.
+
+The refreshed sauna HUD now anchors the opening step with the Sauna Integrity meter and animated progress bar introduced in `src/ui/sauna.tsx`. The Premium Tiers grid showcased later in the tutorial reinforces how leaders unlock expanded roster capacity, while updated SISU and combat cues echo their in-game meters and rally buttons.
 
 ## Skip and reset
 
@@ -20,4 +22,4 @@ Selecting **Skip tutorial** or finishing the final step marks the `tutorial_done
 
 ## Visual polish
 
-The tooltip overlay uses blurred glass cards, accent lighting around anchors, and responsive positioning to maintain a premium presentation on both desktop and handheld layouts.
+The tooltip overlay uses blurred glass cards, accent lighting around anchors, and responsive positioning to maintain a premium presentation on both desktop and handheld layouts. Those cards mirror the sauna HUD styling, complete with badge-forward Premium Tier options, realtime progress labels, and the destruction FX woven into the Sauna Integrity meter.


### PR DESCRIPTION
## Summary
- refresh onboarding flow table to match the latest tutorial step titles and descriptions
- call out the Sauna Integrity meter, Premium Tier grid, and updated combat/SISU cues highlighted in the HUD
- adjust visual polish notes to reference the current sauna HUD styling and effects

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf9cce97b48330acf35989ae307309