### PR TITLE
Restore action bar tutorial anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Restore the action tray tutorial anchor so **Command the Fight** hugs the combat
+  controls again, exercise the regression with a HUD Vitest suite, and document
+  the premium highlight behaviour in the onboarding guide.
+
 - Tighten Saunoja upkeep rolls to the 1–4 window with a simplified sampler,
   refreshed vitest coverage, and documentation of the corrected distribution.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -14,6 +14,8 @@ The onboarding flow introduces the polished HUD rhythms for new leaders through 
 
 Each tooltip card is fully keyboard navigable (`←`, `→`, `Esc`, or the on-screen controls) and can be dismissed at any time.
 
+With the combat anchor restored on the action tray, the **Command the Fight** spotlight now locks to the tray chrome instead of floating, immersing leaders in the premium rally controls during that beat of the tour.
+
 The refreshed sauna HUD now anchors the opening step with the Sauna Integrity meter and animated progress bar introduced in `src/ui/sauna.tsx`. The Premium Tiers grid showcased later in the tutorial reinforces how leaders unlock expanded roster capacity, while updated SISU and combat cues echo their in-game meters and rally buttons.
 
 ## Skip and reset

--- a/src/ui/action-bar/index.tsx
+++ b/src/ui/action-bar/index.tsx
@@ -15,6 +15,7 @@ export function setupActionBar(
   const layout = ensureHudLayout(overlay);
   const container = overlay.ownerDocument.createElement('div');
   container.dataset.component = 'action-bar';
+  container.dataset.tutorialTarget = 'combat';
   container.className = 'flex w-full justify-center';
 
   const bottomRegion = layout.regions.bottom;

--- a/tests/ui/action-bar.test.ts
+++ b/tests/ui/action-bar.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupActionBar } from '../../src/ui/action-bar/index.tsx';
+import { GameState } from '../../src/core/GameState.ts';
+
+function renderOverlay(): HTMLElement {
+  document.body.innerHTML = `
+    <div id="ui-overlay">
+      <div class="hud-layout-root" data-hud-root>
+        <div class="hud-region hud-top-row" data-hud-region="top"></div>
+        <div class="hud-region hud-actions" data-hud-region="left"></div>
+        <div class="hud-region hud-content" data-hud-region="content"></div>
+        <div class="hud-region hud-right-column" data-hud-region="right">
+          <div id="resource-bar"></div>
+        </div>
+        <div class="hud-region hud-bottom-row" data-hud-region="bottom"></div>
+      </div>
+    </div>
+  `;
+
+  const overlay = document.querySelector<HTMLElement>('#ui-overlay');
+  if (!overlay) {
+    throw new Error('Failed to render UI overlay shell for the action bar test.');
+  }
+  return overlay;
+}
+
+describe('action bar tutorial anchor', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('exposes the combat tutorial target so onboarding can anchor correctly', () => {
+    const overlay = renderOverlay();
+    const state = new GameState(1000);
+    const controller = setupActionBar(state, overlay);
+
+    const tray = overlay.querySelector('[data-component="action-bar"]');
+    expect(tray).toBeTruthy();
+    expect(tray?.dataset.tutorialTarget).toBe('combat');
+
+    controller.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- reinstate the combat tutorial target on the action bar wrapper so onboarding can lock onto the tray
- cover the anchor with a Vitest DOM regression and describe the renewed behaviour in the onboarding guide
- log the change in the changelog for visibility

## Testing
- npm run build
- npx vitest run tests/ui/action-bar.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf9d6622d48330bb16a5c25712065f