### PR TITLE
Guard tutorial pause state transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Pause the game when the onboarding tutorial boots, resume only when the
+  walkthrough owned the pause toggle, and guard dispose flows so teardown no
+  longer leaves the battlefield frozen.
+
 - Extend the onboarding walkthrough with an Enemy Ramp badge spotlight and
   document the top-bar anchor alongside the flow overview.
 


### PR DESCRIPTION
## Summary
- pause the game when starting the tutorial only when it is not already paused and record ownership
- resume tutorial-owned pauses when completing, skipping, or disposing the walkthrough
- document the pause guardrails in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfa7d4a2708330b714b9ced7a971eb