### PR TITLE
Clarify onboarding victory and defeat guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Clarify onboarding win and loss conditions with refreshed tutorial copy, a
+  defeat spotlight on the Sauna Integrity meter, and updated flow docs.
+
 - Pause the game when the onboarding tutorial boots, resume only when the
   walkthrough owned the pause toggle, and guard dispose flows so teardown no
   longer leaves the battlefield frozen.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -11,7 +11,8 @@ The onboarding flow introduces the polished HUD rhythms for new leaders through 
 | Stockpile SISU | `data-tutorial-target="sisu"` on the SISU meter | SISU fuels heroic bursts. Watch this meter to know when your grit reserves can power signature moves. |
 | Read the Enemy Ramp | `data-tutorial-target="enemy-ramp"` on the top-bar badge | The badge shows current stage markers, multiplier spikes, and calm windows before the next enemy wave. |
 | Command the Fight | `data-tutorial-target="combat"` on the action tray | Trigger a Sisu Burst to supercharge allied attacks or rally everyone home with a Torille call. |
-| Claim Victory | `data-tutorial-target="victory"` on the Saunakunnia badge | Saunakunnia measures renown. Push it ever higher to unlock triumphs and close the campaign in glory. |
+| Claim Victory | `data-tutorial-target="victory"` on the Saunakunnia badge | Destroy every enemy stronghold to win the campaign. The badge tracks your march toward total conquest. |
+| Avert Defeat | `data-tutorial-target="sauna-integrity"` on the Sauna Integrity meter | Defeat strikes if the sauna is razed, every attendant is downed for 8 seconds, or upkeep bankruptcy lingers for 12 seconds. Guard the meter and steady your roster. |
 
 Each tooltip card is fully keyboard navigable (`←`, `→`, `Esc`, or the on-screen controls) and can be dismissed at any time.
 

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -65,6 +65,7 @@ export function setupSaunaUI(
 
   const integritySection = document.createElement('section');
   integritySection.classList.add('sauna-health');
+  integritySection.dataset.tutorialTarget = 'sauna-integrity';
   const healthLabelId = `sauna-health-label-${Math.floor(Math.random() * 100000)}`;
   const healthHeader = document.createElement('div');
   healthHeader.classList.add('sauna-health__header');

--- a/src/ui/tutorial/Tutorial.tsx
+++ b/src/ui/tutorial/Tutorial.tsx
@@ -66,7 +66,14 @@ const defaultSteps: readonly TutorialStep[] = [
     target: 'victory',
     title: 'Claim Victory',
     description:
-      'Saunakunnia measures renown. Push it ever higher to unlock triumphs and close the campaign in glory.'
+      'Destroy every enemy stronghold to win the campaign. The Saunakunnia badge tracks your march toward total conquest.'
+  },
+  {
+    id: 'defeat',
+    target: 'sauna-integrity',
+    title: 'Avert Defeat',
+    description:
+      'Defeat strikes if the sauna is razed, every attendant is downed for 8 seconds, or upkeep bankruptcy lingers for 12 seconds. Guard the integrity meter and keep your roster on its feet.'
   }
 ];
 


### PR DESCRIPTION
## Summary
- clarify the tutorial victory step to call out destroying every enemy stronghold
- add a defeat-focused tutorial step anchored to the sauna integrity meter and document the revised onboarding flow
- note the onboarding refinement in the changelog

## Testing
- `npm run build`
- `npm run test` *(fails: existing Vitest suite times out in `src/game.test.ts > rollSaunojaUpkeep > returns inclusive upkeep rolls between the configured bounds` and `src/game.test.ts > game lifecycle > stops scheduling animation frames after cleanup`)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa89253248330a98856f104d0c3de