### PR TITLE
Document artocoin payout formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Document the artocoin payout pipeline with tier baselines, difficulty
+  modifiers, defeat floors, and a companion design note so engineering can wire
+  the formula straight into the economy systems.
+
 - Collapse the HUD grid into a single-column mobile stack, stretch the left,
   right, and bottom regions to full-width trays, and ensure the command console
   toggle still slides in over the canvas alongside the mobile action bar.

--- a/docs/design/sauna-artocoin-formula.md
+++ b/docs/design/sauna-artocoin-formula.md
@@ -1,0 +1,173 @@
+# Design Note: Artocoin Payout Pipeline
+
+## Goals
+- Convert battle telemetry (run duration, kill count, tiles explored, roster
+  losses, difficulty scalar, tier) into a deterministic artocoin award.
+- Keep tier unlock pacing at ~2.5 average wins while letting high-skill clears
+  accelerate rewards and defeats still contribute.
+- Provide explicit clamps and constants so engineering can implement without
+  additional balancing passes.
+
+## Data Model
+```ts
+interface ArtocoinTierTuning {
+  tierId: SaunaTierId;
+  nextUnlockLabel: string;
+  unlockCost: number; // Artocoins required for the next milestone.
+  baselinePayout: number; // Artocoins for an average win.
+  baselineDurationMinutes: number;
+  baselineKills: number;
+  baselineTiles: number;
+}
+```
+
+Populate the table with:
+
+| tierId | nextUnlockLabel | unlockCost | baselinePayout | baselineDurationMinutes | baselineKills | baselineTiles |
+| --- | --- | --- | --- | --- | --- | --- |
+| `ember-circuit` | "Aurora Ward key engraving" | `150` | `60` | `12.5` | `150` | `85` |
+| `aurora-ward` | "Mythic Conclave rite" | `210` | `84` | `12.0` | `190` | `100` |
+| `mythic-conclave` | "Prestige cache rotation" | `275` | `110` | `11.5` | `230` | `115` |
+
+Difficulty modifiers mirror the existing difficulty scalar exposed by the enemy
+ramp system.
+
+```ts
+interface DifficultyModifier {
+  minScalar: number; // inclusive lower bound from the game difficulty value
+  maxScalar?: number; // optional exclusive upper bound
+  multiplier: number;
+  bonusPerStage?: number; // Endless bonus per ramp stage beyond maelstrom
+  maxMultiplier?: number; // cap when bonusPerStage is applied
+}
+```
+
+Use the following table:
+
+| Range | multiplier | Notes |
+| --- | --- | --- |
+| `[0, 0.95)` | `0.85` | Relaxed Heat training. |
+| `[0.95, 1.1)` | `1.0` | Standard Steam reference. |
+| `[1.1, 1.3)` | `1.18` | Veteran Sauna. |
+| `[1.3, 1.5)` | `1.32` | Mythic Heat. |
+| `[1.5, ∞)` | `1.42` base, `bonusPerStage = 0.03`, `maxMultiplier = 1.58` | Endless Onslaught; add 0.03 per ramp stage completed past Maelstrom. |
+
+The ramp stage index is available from `evaluateEnemyRamp` and should be passed
+into the payout function to apply the Endless bonus.
+
+## Win Payout Algorithm
+```ts
+interface PayoutInputs {
+  tierId: SaunaTierId;
+  runSeconds: number;
+  enemyKills: number;
+  tilesExplored: number;
+  rosterLosses: number;
+  difficultyScalar: number;
+  rampStageIndex: number; // needed for Endless bonus
+}
+
+interface PayoutResult {
+  artocoins: number;
+  breakdown: {
+    baseline: number;
+    performanceMultiplier: number;
+    lossPenalty: number;
+    difficultyMultiplier: number;
+  };
+}
+
+function calculateWinPayout(input: PayoutInputs): PayoutResult {
+  const tuning = tierTuning[input.tierId];
+  const baseline = tuning.baselinePayout;
+  const tempoTarget = tuning.baselineDurationMinutes;
+  const killsTarget = tuning.baselineKills;
+  const tileTarget = tuning.baselineTiles;
+
+  const tempoMinutes = input.runSeconds / 60;
+  const tempoFactor = clamp(
+    0.75,
+    1.2,
+    1 + ((tempoTarget - tempoMinutes) / tempoTarget) * 0.35
+  );
+  const killFactor = clamp(0.6, 1.45, input.enemyKills / killsTarget);
+  const exploreFactor = clamp(0.7, 1.25, input.tilesExplored / tileTarget);
+
+  const performanceMultiplier =
+    tempoFactor * 0.3 + killFactor * 0.45 + exploreFactor * 0.25;
+
+  const lossPenalty = Math.max(0.4, 1 - input.rosterLosses * 0.22);
+
+  const difficultyMultiplier = resolveDifficultyMultiplier(
+    input.difficultyScalar,
+    input.rampStageIndex
+  );
+
+  const artocoins = Math.round(
+    baseline * performanceMultiplier * lossPenalty * difficultyMultiplier
+  );
+
+  return {
+    artocoins,
+    breakdown: { baseline, performanceMultiplier, lossPenalty, difficultyMultiplier }
+  };
+}
+```
+
+`clamp` is the usual `min/max` helper. Implement `resolveDifficultyMultiplier`
+using the tables above and add the Endless bonus when
+`input.difficultyScalar >= 1.5` and the evaluated ramp stage index exceeds the
+Maelstrom stage (index ≥ 4). Each full stage beyond Maelstrom adds `0.03`, capped
+at `maxMultiplier`.
+
+## Defeat Payout Algorithm
+```ts
+function calculateDefeatPayout(input: PayoutInputs): PayoutResult {
+  const tuning = tierTuning[input.tierId];
+  const baseline = tuning.baselinePayout;
+  const difficultyMultiplier = resolveDifficultyMultiplier(
+    input.difficultyScalar,
+    input.rampStageIndex
+  );
+
+  const floorPayout = baseline * 0.2 * difficultyMultiplier;
+  const tempoProgress = input.runSeconds / (tuning.baselineDurationMinutes * 60);
+  const killProgress = input.enemyKills / tuning.baselineKills;
+  const progress = clamp01(0.5 * tempoProgress + 0.5 * killProgress);
+  const performanceShare = baseline * 0.45 * progress * difficultyMultiplier;
+  const lossFloor = Math.max(0.35, 1 - input.rosterLosses * 0.12);
+  const artocoins = Math.round(Math.max(floorPayout, performanceShare) * lossFloor);
+
+  return {
+    artocoins,
+    breakdown: {
+      baseline,
+      performanceMultiplier: performanceShare / baseline,
+      lossPenalty: lossFloor,
+      difficultyMultiplier
+    }
+  };
+}
+```
+
+Call the defeat branch whenever the run terminates without clearing the final
+objective.
+
+## Telemetry & UI Hooks
+- Surface the breakdown in the post-run UI so players see tempo / kill /
+  exploration influences and difficulty bonuses.
+- Log the breakdown to analytics for balancing.
+- Store the tier tuning and difficulty tables in a shared config module so both
+  the economy calculator and UI share constants.
+- Add regression tests covering:
+  - Baseline win (should return exactly the baseline payout).
+  - Perfect run cap (ensure clamps cap at expected ceilings).
+  - Multi-loss run to verify loss penalty floor.
+  - Endless Onslaught stage bonus accumulation and cap.
+  - Defeat payout floor when progress is minimal.
+
+## Open Questions
+- If additional sauna tiers ship, extend `ArtocoinTierTuning` with new entries
+  and adjust the unlock pacing targets; no formula changes required.
+- Should meta upgrades adjust the loss penalty floor? Revisit once roster revive
+  tech ships.

--- a/docs/progression/artocoin-economy.md
+++ b/docs/progression/artocoin-economy.md
@@ -1,0 +1,88 @@
+# Artocoin Payout Targets
+
+Premium rewards for sauna defense runs now flow through a single, data-backed
+artocoin target. The formula below turns run duration, enemy eliminations,
+exploration, and roster survivability into a payout that feels generous on a
+clean win while keeping unlock pacing near two to three runs per sauna tier.
+
+## Baseline Win Expectations
+
+| Active Sauna Tier | Next Unlock Target | Unlock Cost (Artocoins) | Baseline Run Duration (min) | Baseline Enemy Kills | Baseline Tiles Explored | Baseline Roster Losses | Baseline Payout (Artocoins) | Runs to Unlock (Avg) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Ember Circuit | Aurora Ward key engraving | 150 | 12.5 | 150 | 85 | 1 | 60 | 2.5 |
+| Aurora Ward | Mythic Conclave rite | 210 | 12.0 | 190 | 100 | 1 | 84 | 2.5 |
+| Mythic Conclave | Prestige cache rotation | 275 | 11.5 | 230 | 115 | 1 | 110 | 2.5 |
+
+The baselines establish the "average win" reference used in the payout formula.
+Players who exceed the targets accelerate their unlock cadence, while slower or
+costly victories still award enough artocoins to feel forward momentum.
+
+## Step-by-Step Payout Formula
+
+1. **Resolve the base payout for the active tier.** Pull the `baselinePayout`
+   from the table above for the player's current sauna tier. (`60`, `84`, or
+   `110` artocoins.)
+2. **Normalize the inputs.** With run duration reported in seconds:
+   - `tempoTargetMinutes` is the tier baseline duration.
+   - `tempoFactor = clamp(0.75, 1.20, 1 + ((tempoTargetMinutes - runSeconds / 60) / tempoTargetMinutes) * 0.35)`
+   - `killFactor = clamp(0.60, 1.45, enemyKills / tierKillBaseline)`
+   - `exploreFactor = clamp(0.70, 1.25, tilesExplored / tierTileBaseline)`
+3. **Blend the performance multipliers.**
+   - `performanceMultiplier = tempoFactor * 0.30 + killFactor * 0.45 + exploreFactor * 0.25`
+4. **Apply the roster attrition penalty.**
+   - `lossPenalty = max(0.40, 1 - rosterLosses * 0.22)`
+5. **Combine the pieces.**
+   - `rawPayout = baselinePayout * performanceMultiplier * lossPenalty`
+6. **Apply the difficulty modifier (see below) and round.**
+   - `finalPayout = round(rawPayout * difficultyModifier)` (standard banker's rounding to the nearest whole artocoin.)
+
+The clamps keep extreme values from running away while still celebrating high
+execution. A perfect, fast Mythic Conclave clear tops out near ~160 artocoins,
+while a scrappy Ember Circuit hold that lost two attendants still clears ~40.
+
+## Difficulty Modifiers
+
+Difficulty speaks to the same scalar used by the enemy ramp. Mirror that value
+inside the payout pipeline using the following table.
+
+| Difficulty Label | Internal Difficulty Scalar | Artocoin Multiplier | Notes |
+| --- | --- | --- | --- |
+| Relaxed Heat | 0.85 | 0.85× | Training mode pacing; still respects loss penalties. |
+| Standard Steam | 1.0 | 1.00× | Baseline balance reference. |
+| Veteran Sauna | 1.2 | 1.18× | Mirrors the +18% enemy multiplier curve. |
+| Mythic Heat | 1.4 | 1.32× | Aligns with late-game siege pressure. |
+| Endless Onslaught | ≥1.6 | 1.42× + 0.03× per full ramp stage cleared past Maelstrom (cap 1.58×). |
+
+Difficulty multipliers always apply after performance and loss calculations to
+keep rewards proportional to the heightened risk.
+
+## Failure Payouts
+
+Defeat runs still deliver progress while reflecting performance:
+
+1. Compute the tier base payout and difficulty multiplier as with a win.
+2. Establish a **floor payout** equal to `baselinePayout * 0.20 * difficultyModifier`.
+3. Build a **progress ratio**: `progress = clamp01(0.5 * (runSeconds / (tempoTargetMinutes * 60)) + 0.5 * (enemyKills / tierKillBaseline))`.
+4. Calculate the **performance share**: `performanceShare = baselinePayout * 0.45 * progress * difficultyModifier`.
+5. Apply a softer attrition penalty: `lossFloor = max(0.35, 1 - rosterLosses * 0.12)`.
+6. Final defeat payout is `round(max(floorPayout, performanceShare) * lossFloor)`.
+
+The result is that an early wipe still awards roughly 15–20% of a clear, while a
+boss defeat with solid stats might pay out 45–55% despite the loss.
+
+## Worked Examples
+
+- **Average Ember Circuit win** – 12.6 minute run, 152 kills, 86 tiles, one
+  roster loss on Standard Steam: `tempoFactor ≈ 0.99`, `killFactor ≈ 1.01`,
+  `exploreFactor ≈ 1.01`, `performanceMultiplier ≈ 1.00`, `lossPenalty = 0.78`,
+  payout `≈ 47 artocoins`.
+- **Fast Mythic Conclave win** – 10.8 minute run, 250 kills, 128 tiles, zero
+  losses on Mythic Heat: `tempoFactor ≈ 1.06`, `killFactor ≈ 1.09`,
+  `exploreFactor ≈ 1.11`, `performanceMultiplier ≈ 1.08`, `lossPenalty = 1.00`,
+  payout `≈ 110 * 1.08 * 1.32 ≈ 157 artocoins`.
+- **Aurora Ward defeat** – 9.5 minute wipe before the boss, 140 kills, 72 tiles,
+  two losses on Veteran Sauna: floor `≈ 20`, progress `≈ 0.67`, performance
+  share `≈ 25`, loss floor `= 0.76`, payout `≈ 19 artocoins`.
+
+These targets keep meta progression brisk without trivialising high-heat clears
+or punishing experimentation.


### PR DESCRIPTION
## Summary
- define tier baselines and payout formula for artocoin rewards in the progression docs, covering win flow, difficulty multipliers, and defeat floors
- add an implementation-focused design note that specifies tuning tables, helper interfaces, and pseudocode for both win and defeat payouts
- log the documentation update in the changelog so contributors can find the new guidance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfb542432c83309d871aab4510ae56