### PR TITLE
Track enemy kills and exploration in objective tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Track objective enemy kill and exploration tallies per run so the end screen
+  snapshot captures combat momentum and fog busting progress, backed by fresh
+  regression coverage.
+
 - Document the artocoin payout pipeline with tier baselines, difficulty
   modifiers, defeat floors, and a companion design note so engineering can wire
   the formula straight into the economy systems.

--- a/tests/progression/objectiveTracker.test.ts
+++ b/tests/progression/objectiveTracker.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { GameState } from '../../src/core/GameState.ts';
+import { HexMap } from '../../src/hexmap.ts';
+import {
+  createObjectiveTracker,
+  type ObjectiveResolution,
+  type ObjectiveTracker
+} from '../../src/progression/objectives.ts';
+import { eventBus } from '../../src/events/index.ts';
+
+describe('ObjectiveTracker run counters', () => {
+  let now = 0;
+  let rosterCount = 1;
+  const timeSource = () => now;
+
+  beforeEach(() => {
+    now = 0;
+    rosterCount = 1;
+  });
+
+  function makeTracker(map?: HexMap): ObjectiveTracker {
+    return createObjectiveTracker({
+      state: new GameState(1000),
+      map: map ?? new HexMap(3, 3),
+      getRosterCount: () => rosterCount,
+      timeSource
+    });
+  }
+
+  it('tracks enemy kills and exploration per run and resets on new tracker', () => {
+    const map = new HexMap(3, 3);
+    const tracker = makeTracker(map);
+
+    eventBus.emit('unitDied', { unitId: 'foe-1', unitFaction: 'enemy' });
+    map.revealAround({ q: 0, r: 0 }, 0, { autoFrame: false });
+
+    const progress = tracker.getProgress();
+    expect(progress.enemyKills).toBe(1);
+    expect(progress.exploration.revealedHexes).toBe(1);
+
+    tracker.dispose();
+
+    const freshTracker = makeTracker(new HexMap(3, 3));
+    const freshProgress = freshTracker.getProgress();
+    expect(freshProgress.enemyKills).toBe(0);
+    expect(freshProgress.exploration.revealedHexes).toBe(0);
+    freshTracker.dispose();
+  });
+
+  it('captures kill and exploration totals in resolution summary', async () => {
+    const map = new HexMap(4, 4);
+    const tracker = makeTracker(map);
+
+    eventBus.emit('unitDied', { unitId: 'foe-1', unitFaction: 'enemy' });
+    eventBus.emit('unitDied', { unitId: 'foe-2', unitFaction: 'enemy' });
+    map.revealAround({ q: 0, r: 0 }, 1, { autoFrame: false });
+    const expectedExploration = tracker.getProgress().exploration.revealedHexes;
+
+    const resolutionPromise = new Promise<ObjectiveResolution>((resolve) => {
+      tracker.onResolution(resolve);
+    });
+
+    eventBus.emit('saunaDestroyed', { attackerFaction: 'enemy' });
+
+    const resolution = await resolutionPromise;
+    expect(resolution.summary.enemyKills).toBe(2);
+    expect(resolution.summary.exploration.revealedHexes).toBe(expectedExploration);
+  });
+});


### PR DESCRIPTION
## Summary
- extend objective tracker progress snapshots with per-run enemy kill and exploration counts and track reveals via hex map updates
- propagate the new fields through resolution cloning and document the feature in the changelog
- add regression tests that cover counter resets between runs and snapshot persistence at game over

## Testing
- npm run test *(fails: src/game.test.ts > game lifecycle > stops scheduling animation frames after cleanup)*
- node scripts/check-demo-link.js *(warns: network request failed)*
- npm run verify:docs *(warns: docs bundle commit b6f8b59 does not match HEAD 82de518)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb805c6d4833096e5b5d87defe6d8