### PR TITLE
Refresh artocoin icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Refresh the artocoin emblem with a high-fidelity illustrated crest that
+  matches the latest Steamforge Atelier branding across the HUD and shop UI.
+
 - Refresh the published docs bundle so the build badge reflects the
   current commit metadata.
 

--- a/assets/ui/artocoin.svg
+++ b/assets/ui/artocoin.svg
@@ -1,31 +1,53 @@
-<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title" focusable="false">
-  <title>Artocoin emblem</title>
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title" focusable="false">
+  <title>Artocoin icon</title>
   <defs>
-    <radialGradient id="artocoinGlow" cx="50%" cy="35%" r="70%">
-      <stop offset="0%" stop-color="#fff4d6" stop-opacity="0.95" />
-      <stop offset="55%" stop-color="#f9d27a" stop-opacity="0.85" />
-      <stop offset="100%" stop-color="#d17b22" stop-opacity="0.9" />
+    <radialGradient id="coinCore" cx="50%" cy="40%" r="70%">
+      <stop offset="0%" stop-color="#ffde9a" />
+      <stop offset="45%" stop-color="#f8b858" />
+      <stop offset="100%" stop-color="#d87a1d" />
     </radialGradient>
-    <linearGradient id="artocoinRim" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f9f3e3" />
-      <stop offset="45%" stop-color="#f2c45e" />
-      <stop offset="100%" stop-color="#a85c19" />
+    <linearGradient id="coinRim" x1="15%" y1="0%" x2="85%" y2="100%">
+      <stop offset="0%" stop-color="#fdf1cd" />
+      <stop offset="45%" stop-color="#f3c463" />
+      <stop offset="100%" stop-color="#b16414" />
     </linearGradient>
-    <linearGradient id="artocoinHighlight" x1="25%" y1="15%" x2="85%" y2="85%">
-      <stop offset="0%" stop-color="#fffaf0" stop-opacity="0.9" />
-      <stop offset="40%" stop-color="#ffe9b8" stop-opacity="0.75" />
-      <stop offset="100%" stop-color="#f9c55a" stop-opacity="0.6" />
+    <linearGradient id="rimHighlight" x1="30%" y1="10%" x2="70%" y2="90%">
+      <stop offset="0%" stop-color="#fff4dc" stop-opacity="0.85" />
+      <stop offset="40%" stop-color="#ffdf9b" stop-opacity="0.55" />
+      <stop offset="100%" stop-color="#f4a848" stop-opacity="0.3" />
     </linearGradient>
+    <radialGradient id="faceTone" cx="55%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="#ffdca8" />
+      <stop offset="70%" stop-color="#f3a95d" />
+      <stop offset="100%" stop-color="#ea8c44" />
+    </radialGradient>
+    <path id="labelPath" d="M27 55a37 37 0 0 1 74 0" />
   </defs>
   <g fill="none">
-    <circle cx="32" cy="32" r="30" fill="url(#artocoinRim)" stroke="#fff3d1" stroke-width="1.4" />
-    <circle cx="32" cy="32" r="23" fill="url(#artocoinGlow)" stroke="#ffe4a8" stroke-width="1.2" />
-    <path d="M32 16c7.732 0 14 6.268 14 14s-6.268 14-14 14-14-6.268-14-14 6.268-14 14-14Z" fill="url(#artocoinHighlight)" opacity="0.88" />
-    <path d="M32 20c5.523 0 10 4.477 10 10s-4.477 10-10 10-10-4.477-10-10 4.477-10 10-10Z" stroke="#8d4f12" stroke-width="1.6" stroke-linejoin="round" />
-    <path d="m32 24.5 2.85 5.78 6.38.93-4.61 4.49 1.09 6.35L32 38.6l-5.71 3.45 1.09-6.35-4.61-4.49 6.38-.93L32 24.5Z" fill="#9f5e16" />
-    <path d="m32 26.8 2.11 4.3 4.75.69-3.43 3.34.81 4.71L32 36.95l-4.24 2.49.81-4.71-3.43-3.34 4.75-.69L32 26.8Z" fill="#fff6dc" />
-    <path d="M20.2 18.8c3.16-3.4 7.59-5.44 12.28-5.44" stroke="#fff4d8" stroke-width="2" stroke-linecap="round" opacity="0.75" />
-    <path d="M17 32c0-3.46.96-6.69 2.64-9.46" stroke="#fff1cc" stroke-width="1.6" stroke-linecap="round" opacity="0.5" />
-    <path d="M32 49.5c-7.5 0-14.02-4.7-16.64-11.47" stroke="#b46b1d" stroke-width="1.4" stroke-linecap="round" opacity="0.55" />
+    <circle cx="64" cy="64" r="60" fill="url(#coinRim)" stroke="#5e2c02" stroke-width="2" />
+    <circle cx="64" cy="64" r="60" fill="url(#rimHighlight)" opacity="0.35" />
+    <circle cx="64" cy="64" r="48" fill="url(#coinCore)" stroke="#5e2c02" stroke-width="1.6" />
+    <circle cx="64" cy="64" r="42" fill="url(#coinCore)" opacity="0.65" />
+    <g fill="#4b2200" font-family="'Montserrat','Inter','Gill Sans',sans-serif" font-size="14" font-weight="700" letter-spacing="0.4">
+      <text>
+        <textPath href="#labelPath" startOffset="50%" text-anchor="middle">ARTOCOIN</textPath>
+      </text>
+    </g>
+    <circle cx="40" cy="74" r="3.2" fill="#c97a23" />
+    <circle cx="88" cy="74" r="3.2" fill="#c97a23" />
+    <g transform="translate(64 74)">
+      <ellipse cx="0" cy="-2" rx="22" ry="26" fill="url(#faceTone)" stroke="#481e06" stroke-width="1.6" />
+      <path d="M -22 -6 C -16 -15 -7 -22 0 -22 C 7 -22 16 -15 22 -6 C 20 -24 9 -32 0 -32 C -9 -32 -20 -24 -22 -6 Z" fill="#6c3f23" />
+      <path d="M -13 -24 C -7 -30 1 -32 8 -28 C 6 -33 1 -36 -5 -36 C -11 -36 -16 -32 -17 -27 C -16 -25 -14.5 -24.2 -13 -24 Z" fill="#532a13" />
+      <rect x="-18" y="-9" width="14" height="9.5" rx="3.8" fill="#1c1a18" />
+      <rect x="4" y="-9" width="14" height="9.5" rx="3.8" fill="#1c1a18" />
+      <rect x="-4" y="-6.4" width="8" height="2.6" rx="1.3" fill="#1c1a18" />
+      <path d="M -8.8 -6 V -7.4 C -8.8 -8.6 -7.9 -9.4 -6.6 -9.4 H 1.4 C 2.7 -9.4 3.6 -8.6 3.6 -7.4 V -6 C 3.6 -3.1 1.5 -1.2 -1.6 -1.2 C -4.7 -1.2 -6.8 -3.1 -6.8 -6 Z" fill="#2b2724" />
+      <path d="M -11.2 -1.2 C -8.8 1.1 -4.8 2.4 0 2.4 C 4.8 2.4 8.8 1.1 11.2 -1.2 C 10.8 -3.2 9.4 -4.8 7 -5.6 C 4.7 -4.7 2.4 -4.2 0 -4.2 C -2.4 -4.2 -4.7 -4.7 -7 -5.6 C -9.4 -4.8 -10.8 -3.2 -11.2 -1.2 Z" fill="#e4834a" />
+      <path d="M -10 1.6 C -6 6.6 -2 8.2 0 8.2 C 2 8.2 6 6.6 10 1.6 V -1.6 C 6 -0.6 2 0.2 0 0.2 C -2 0.2 -6 -0.6 -10 -1.6 V 1.6 Z" fill="#6f2b19" />
+      <path d="M 0 12.2 C -4.6 12.2 -8.6 10.8 -11.8 8.2 C -10.6 13.1 -6.1 16.2 0 16.2 C 6.1 16.2 10.6 13.1 11.8 8.2 C 8.6 10.8 4.6 12.2 0 12.2 Z" fill="#f6b167" />
+    </g>
+    <path d="M64 28c-9.6 0-18.4 2.8-25.8 7.8-1.4 1-1 3.3 0.7 3.8 16.4 4.7 33.8 4.7 50.2 0 1.7-0.5 2.1-2.8 0.7-3.8C82.4 30.8 73.6 28 64 28Z" fill="#fff7e6" opacity="0.4" />
+    <path d="M64 106c-12.4 0-23.5-3.7-32.6-9.9-1.6-1.1-3.8 0.5-3 2.4 5.2 11.8 18 20.5 35.6 20.5s30.4-8.7 35.6-20.5c0.8-1.9-1.4-3.5-3-2.4-9.1 6.2-20.2 9.9-32.6 9.9Z" fill="#8d4b14" opacity="0.25" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the artocoin SVG with a larger illustrated crest that matches the new branding
- document the art refresh in the changelog for release tracking

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cffb26968883308cebd77772cd5fc1