### PR TITLE
Add return-to-classic HUD control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Ship an accessible “Return to Classic HUD” control within the experimental
+  overlay, persist the sauna settings toggle when players opt out, and reboot
+  the classic layout instantly with fresh regression coverage.
+
 - Encode the product-supplied Artocoin crest PNG as a base64 data URI so the
   HUD, shop, and build badge render the polished crest without checking a
   binary blob into the repository.

--- a/src/game.ts
+++ b/src/game.ts
@@ -1192,6 +1192,10 @@ const setUseUiV2 = (next: boolean): void => {
   persistSaunaSettings(sauna.maxRosterSize, { useUiV2: normalized });
 };
 
+export const disableUiV2 = (): void => {
+  setUseUiV2(false);
+};
+
 const spawnTierQueue = createPlayerSpawnTierQueue({
   getTier: () => getSaunaTier(currentTierId),
   getRosterLimit: () => getActiveTierLimit(),

--- a/src/main.hud.test.ts
+++ b/src/main.hud.test.ts
@@ -78,4 +78,42 @@ describe('main HUD lifecycle', () => {
     expect(document.querySelectorAll('[data-testid="inventory-badge"]')).toHaveLength(1);
     expect(document.querySelectorAll('#right-panel')).toHaveLength(1);
   });
+
+  it('restores the classic HUD and persists the flag when the V2 exit control is used', async () => {
+    const { DEFAULT_SAUNA_TIER_ID } = await import('./sauna/tiers.ts');
+    const { SAUNA_SETTINGS_STORAGE_KEY } = await import('./game/saunaSettings.ts');
+
+    window.localStorage.setItem(
+      SAUNA_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ maxRosterSize: 6, activeTierId: DEFAULT_SAUNA_TIER_ID, useUiV2: true })
+    );
+
+    const { init, destroy } = await import('./main.ts');
+
+    init();
+    await Promise.resolve();
+
+    const overlay = document.getElementById('ui-overlay');
+    expect(overlay?.dataset.hudVariant).toBe('v2');
+
+    const returnControl = document.querySelector<HTMLButtonElement>('[data-testid="return-to-classic-hud"]');
+    expect(returnControl).toBeTruthy();
+
+    returnControl?.click();
+    await Promise.resolve();
+
+    const saved = window.localStorage.getItem(SAUNA_SETTINGS_STORAGE_KEY);
+    expect(saved).toBeTruthy();
+    const parsed = saved ? (JSON.parse(saved) as { useUiV2?: boolean }) : null;
+    expect(parsed?.useUiV2).toBe(false);
+
+    expect(overlay?.dataset.hudVariant).toBe('classic');
+    expect(document.querySelector('[data-testid="return-to-classic-hud"]')).toBeNull();
+    expect(document.querySelector('#topbar')).not.toBeNull();
+    expect(document.querySelector('[data-testid="inventory-badge"]')).not.toBeNull();
+    expect(document.querySelector('#right-panel')).not.toBeNull();
+
+    destroy();
+    await Promise.resolve();
+  });
 });


### PR DESCRIPTION
## Summary
- add an accessible "Return to Classic HUD" control to the experimental overlay and wire it to a callback
- expose a main-layer handler that persists `useUiV2`, destroys the overlay, and reboots the classic HUD
- cover the opt-out flow with a HUD lifecycle regression test and document the change in the changelog

## Testing
- npm run build
- npx vitest run src/main.hud.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d021e787148330be941190d7529a36