### PR TITLE
Sanitize artocoin metrics before payout

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -89,6 +89,7 @@ import {
   onArtocoinChange,
   type ArtocoinChangeEvent
 } from './progression/artocoin.ts';
+import { coerceObjectiveMetric } from './progression/objectivePayout.ts';
 import {
   getPurchasedSaunaTiers,
   grantSaunaTier,
@@ -1420,10 +1421,13 @@ const handleObjectiveResolution = (resolution: ObjectiveResolution): void => {
   const snapshot = enemySpawner.getSnapshot();
   const payout = calculateArtocoinPayout(resolution.outcome, {
     tierId: currentTierId,
-    runSeconds: Math.max(0, resolution.durationMs / 1000),
-    enemyKills: Math.max(0, resolution.summary.enemyKills),
-    tilesExplored: Math.max(0, resolution.summary.exploration.revealedHexes),
-    rosterLosses: Math.max(0, resolution.summary.roster.totalDeaths),
+    runSeconds: Math.max(0, coerceObjectiveMetric(resolution.durationMs) / 1000),
+    enemyKills: Math.max(0, coerceObjectiveMetric(resolution.summary.enemyKills)),
+    tilesExplored: Math.max(
+      0,
+      coerceObjectiveMetric(resolution.summary.exploration.revealedHexes)
+    ),
+    rosterLosses: Math.max(0, coerceObjectiveMetric(resolution.summary.roster.totalDeaths)),
     difficultyScalar: snapshot.effectiveDifficulty,
     rampStageIndex: snapshot.rampStageIndex
   });

--- a/src/progression/objectivePayout.ts
+++ b/src/progression/objectivePayout.ts
@@ -1,0 +1,21 @@
+import type { ObjectiveResolution } from './objectives.ts';
+
+export function coerceObjectiveMetric(value: number | null | undefined): number {
+  return Number.isFinite(value) ? (value as number) : 0;
+}
+
+export interface ObjectiveArtocoinMetrics {
+  readonly runSeconds: number;
+  readonly enemyKills: number;
+  readonly tilesExplored: number;
+  readonly rosterLosses: number;
+}
+
+export function extractObjectiveMetrics(resolution: ObjectiveResolution): ObjectiveArtocoinMetrics {
+  return {
+    runSeconds: coerceObjectiveMetric(resolution.durationMs) / 1000,
+    enemyKills: coerceObjectiveMetric(resolution.summary.enemyKills),
+    tilesExplored: coerceObjectiveMetric(resolution.summary.exploration.revealedHexes),
+    rosterLosses: coerceObjectiveMetric(resolution.summary.roster.totalDeaths)
+  } satisfies ObjectiveArtocoinMetrics;
+}

--- a/tests/progression/objectivePayout.test.ts
+++ b/tests/progression/objectivePayout.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { Resource } from '../../src/core/GameState.ts';
+import { calculateArtocoinPayout } from '../../src/progression/artocoin.ts';
+import { extractObjectiveMetrics } from '../../src/progression/objectivePayout.ts';
+import type { ObjectiveResolution } from '../../src/progression/objectives.ts';
+
+function makeResolutionWithMissingMetrics(): ObjectiveResolution {
+  return {
+    outcome: 'lose',
+    cause: 'saunaDestroyed',
+    timestamp: 0,
+    durationMs: undefined as unknown as number,
+    summary: {
+      strongholds: { total: 3, destroyed: 1, remaining: 2 },
+      roster: { active: 0, totalDeaths: 0, wipeSince: null, wipeDurationMs: 0 },
+      economy: { beer: 0, worstBeer: 0, bankruptSince: null, bankruptDurationMs: 0 },
+      sauna: { maxHealth: 100, health: 0, destroyed: true, destroyedAt: 0 },
+      enemyKills: undefined as unknown as number,
+      exploration: { revealedHexes: undefined as unknown as number },
+      startedAt: 0
+    },
+    rewards: {
+      resources: {
+        [Resource.SAUNA_BEER]: { final: 0, delta: 0 },
+        [Resource.SAUNAKUNNIA]: { final: 0, delta: 0 },
+        [Resource.SISU]: { final: 0, delta: 0 }
+      }
+    }
+  } satisfies ObjectiveResolution;
+}
+
+describe('objective payout sanitization', () => {
+  it('falls back to the defeat floor when metrics are missing', () => {
+    const resolution = makeResolutionWithMissingMetrics();
+    const snapshot = { effectiveDifficulty: 1, rampStageIndex: 0 } as const;
+    const metrics = extractObjectiveMetrics(resolution);
+    const payout = calculateArtocoinPayout(resolution.outcome, {
+      tierId: 'ember-circuit',
+      runSeconds: Math.max(0, metrics.runSeconds),
+      enemyKills: Math.max(0, metrics.enemyKills),
+      tilesExplored: Math.max(0, metrics.tilesExplored),
+      rosterLosses: Math.max(0, metrics.rosterLosses),
+      difficultyScalar: snapshot.effectiveDifficulty,
+      rampStageIndex: snapshot.rampStageIndex
+    });
+    expect(payout.artocoins).toBe(12);
+    expect(Number.isNaN(payout.artocoins)).toBe(false);
+  });
+});

--- a/tests/ui/endScreenLedger.test.ts
+++ b/tests/ui/endScreenLedger.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Resource } from '../../src/core/GameState.ts';
+import { calculateArtocoinPayout } from '../../src/progression/artocoin.ts';
+import { extractObjectiveMetrics } from '../../src/progression/objectivePayout.ts';
+import type { ObjectiveResolution } from '../../src/progression/objectives.ts';
+import { showEndScreen } from '../../src/ui/overlays/EndScreen.tsx';
+
+function makeResolution(): ObjectiveResolution {
+  return {
+    outcome: 'lose',
+    cause: 'saunaDestroyed',
+    timestamp: 0,
+    durationMs: undefined as unknown as number,
+    summary: {
+      strongholds: { total: 3, destroyed: 1, remaining: 2 },
+      roster: { active: 0, totalDeaths: 0, wipeSince: null, wipeDurationMs: 0 },
+      economy: { beer: 0, worstBeer: 0, bankruptSince: null, bankruptDurationMs: 0 },
+      sauna: { maxHealth: 100, health: 0, destroyed: true, destroyedAt: 0 },
+      enemyKills: undefined as unknown as number,
+      exploration: { revealedHexes: undefined as unknown as number },
+      startedAt: 0
+    },
+    rewards: {
+      resources: {
+        [Resource.SAUNA_BEER]: { final: 0, delta: 0 },
+        [Resource.SAUNAKUNNIA]: { final: 0, delta: 0 },
+        [Resource.SISU]: { final: 0, delta: 0 }
+      }
+    }
+  } satisfies ObjectiveResolution;
+}
+
+describe('EndScreen artocoin ledger', () => {
+  let container: HTMLDivElement | null = null;
+
+  afterEach(() => {
+    container?.remove();
+    container = null;
+  });
+
+  it('shows the defeat floor payout when metrics are undefined', () => {
+    container = document.createElement('div');
+    document.body.append(container);
+
+    const resolution = makeResolution();
+    const snapshot = { effectiveDifficulty: 1, rampStageIndex: 0 } as const;
+    const metrics = extractObjectiveMetrics(resolution);
+    const payout = calculateArtocoinPayout(resolution.outcome, {
+      tierId: 'ember-circuit',
+      runSeconds: Math.max(0, metrics.runSeconds),
+      enemyKills: Math.max(0, metrics.enemyKills),
+      tilesExplored: Math.max(0, metrics.tilesExplored),
+      rosterLosses: Math.max(0, metrics.rosterLosses),
+      difficultyScalar: snapshot.effectiveDifficulty,
+      rampStageIndex: snapshot.rampStageIndex
+    });
+
+    const controller = showEndScreen({
+      container,
+      resolution,
+      artocoinSummary: {
+        balance: payout.artocoins,
+        earned: payout.artocoins,
+        spent: 0
+      },
+      onNewRun: () => {}
+    });
+
+    const labels = Array.from(container.querySelectorAll('.end-screen__artocoin-label'));
+    const values = Array.from(container.querySelectorAll('.end-screen__artocoin-value'));
+    const earnedIndex = labels.findIndex((label) => label.textContent === 'Earned');
+    expect(earnedIndex).toBeGreaterThanOrEqual(0);
+    expect(values[earnedIndex]?.textContent).toBe('12');
+
+    controller.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- guard the artocoin payout calculation against invalid objective metrics by coercing them to finite values
- share an objective metric extraction helper for reuse in tests and future integrations
- add regression tests that cover missing metrics and confirm the end-screen ledger reports the floor payout

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d025d36124833091921dea956078f5