### PR TITLE
Refine HUD layout anchors and styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Reanchor the HUD around explicit top-left, top-right, and command-dock mounts,
+  move the resource bar, topbar, action tray, and alerts into those anchors, and
+  restyle the trays with glassy gradients plus refreshed tests for the new
+  layout order.
+
 - Introduce dedicated UI v2 controllers for the roster, top bar, inventory, log,
   and sauna experiences, bootstrap them from `setupGame` alongside variant-aware
   cleanup, and extend the Vitest suite so both classic and v2 HUDs mount the

--- a/src/main.hud.test.ts
+++ b/src/main.hud.test.ts
@@ -6,13 +6,18 @@ const renderShell = () => {
       <canvas id="game-canvas"></canvas>
       <div id="ui-overlay">
         <div class="hud-layout-root" data-hud-root>
-          <div class="hud-region hud-top-row" data-hud-region="top"></div>
+          <div class="hud-region hud-top-row" data-hud-region="top">
+            <div class="hud-anchor hud-anchor--top-left" data-hud-anchor="top-left-cluster">
+              <div id="resource-bar"></div>
+            </div>
+            <div class="hud-anchor hud-anchor--top-right" data-hud-anchor="top-right-cluster"></div>
+          </div>
           <div class="hud-region hud-actions" data-hud-region="left"></div>
           <div class="hud-region hud-content" data-hud-region="content"></div>
-          <div class="hud-region hud-right-column" data-hud-region="right">
-            <div id="resource-bar"></div>
+          <div class="hud-region hud-right-column" data-hud-region="right"></div>
+          <div class="hud-region hud-bottom-row" data-hud-region="bottom">
+            <div class="hud-anchor hud-anchor--command-dock" data-hud-anchor="command-dock"></div>
           </div>
-          <div class="hud-region hud-bottom-row" data-hud-region="bottom"></div>
         </div>
       </div>
     </div>

--- a/src/style.css
+++ b/src/style.css
@@ -346,11 +346,78 @@ body > #game-container {
   gap: clamp(16px, 2vw, 28px);
 }
 
+.hud-anchor {
+  pointer-events: none;
+  display: flex;
+}
+
+.hud-anchor > * {
+  pointer-events: auto;
+}
+
+.hud-anchor--top-left {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: clamp(12px, 2vw, 20px);
+  width: min(100%, clamp(360px, 48vw, 720px));
+}
+
+.hud-anchor--top-left > * {
+  max-width: 100%;
+}
+
+.hud-anchor--top-right {
+  flex-direction: column;
+  align-items: flex-end;
+  gap: clamp(12px, 2vw, 20px);
+  width: min(100%, clamp(280px, 32vw, 420px));
+}
+
+.hud-anchor--command-dock {
+  pointer-events: auto;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: clamp(12px, 2.6vw, 20px);
+  width: min(100%, clamp(600px, 78vw, 960px));
+  margin: 0 auto;
+  padding: clamp(14px, 3.6vw, 22px) clamp(18px, 4.4vw, 30px);
+  border-radius: clamp(20px, 4vw, 32px);
+  border: 1px solid color-mix(in srgb, var(--hud-border-strong) 65%, rgba(94, 234, 212, 0.22));
+  background:
+    radial-gradient(circle at 18% -30%, rgba(59, 130, 246, 0.28), transparent 68%),
+    radial-gradient(circle at 82% 130%, rgba(253, 164, 175, 0.26), transparent 72%),
+    linear-gradient(170deg, rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0.58));
+  box-shadow:
+    0 24px 40px rgba(8, 25, 53, 0.46),
+    0 36px 72px rgba(8, 25, 53, 0.58);
+  backdrop-filter: blur(26px) saturate(155%);
+  overflow: hidden;
+}
+
+.hud-anchor--command-dock::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  background: radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.12), transparent 65%);
+  opacity: 0.3;
+  pointer-events: none;
+  transition: opacity var(--transition-snappy);
+}
+
+.hud-anchor--command-dock:hover::after,
+.hud-anchor--command-dock:focus-within::after {
+  opacity: 0.55;
+}
+
 #ui-overlay:not(.hud-grid) .hud-top-row {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: clamp(20px, 3vw, 36px);
+  flex-wrap: wrap;
+  gap: clamp(18px, 3vw, 32px);
   width: 100%;
 }
 
@@ -387,9 +454,9 @@ body > #game-container {
 
 .hud-bottom-row {
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
   align-items: flex-end;
-  gap: clamp(12px, 2.4vw, 20px);
+  gap: clamp(12px, 2.8vw, 22px);
 }
 
 .hud-mobile-bar {
@@ -402,6 +469,13 @@ body > #game-container {
   display: flex;
   justify-content: center;
   margin-top: auto;
+}
+
+.is-mobile #ui-overlay .hud-anchor--command-dock {
+  flex-direction: column;
+  align-items: stretch;
+  gap: clamp(10px, 4vw, 18px);
+  padding: clamp(12px, 6vw, 20px);
 }
 
 .hud-mobile-bar__tray {
@@ -461,6 +535,14 @@ body > #game-container {
   pointer-events: auto;
 }
 
+#topbar,
+.hud-command-tray,
+.hud-panel-toggle,
+.hud-mobile-bar {
+  position: relative;
+  z-index: 1;
+}
+
 #topbar {
   pointer-events: auto;
   display: flex;
@@ -474,9 +556,23 @@ body > #game-container {
   background:
     linear-gradient(140deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.64));
   backdrop-filter: blur(18px) saturate(140%);
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 26px 48px rgba(8, 25, 53, 0.48);
   color: var(--color-foreground);
   width: min(100%, 680px);
+}
+
+.hud-command-tray {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1 1 100%;
+  gap: clamp(12px, 3vw, 18px);
+  flex-wrap: wrap;
+  min-width: min(100%, 460px);
+}
+
+.hud-command-tray > * {
+  pointer-events: auto;
 }
 
 .topbar-badge-row {
@@ -518,6 +614,8 @@ body > #game-container {
   padding: 0 clamp(6px, 1.4vw, 12px);
   min-width: clamp(108px, 28vw, 140px);
   flex: 1 1 clamp(108px, 28vw, 160px);
+  opacity: 0.9;
+  transition: opacity var(--transition-snappy), transform var(--transition-snappy);
 }
 
 .topbar-badge-icon {
@@ -928,17 +1026,19 @@ body > #game-container {
   pointer-events: auto;
   display: inline-flex;
   align-items: center;
-  gap: 18px;
-  width: 100%;
-  padding: 14px 24px;
+  gap: clamp(14px, 2.6vw, 20px);
+  flex: 0 0 auto;
+  width: auto;
+  min-width: clamp(220px, 28vw, 320px);
+  padding: clamp(12px, 2.8vw, 18px) clamp(18px, 3vw, 26px);
   position: relative;
   z-index: 180;
-  border-radius: var(--radius-panel);
-  border: 1px solid color-mix(in srgb, var(--hud-border) 60%, rgba(56, 189, 248, 0.35));
+  border-radius: clamp(18px, 4vw, 26px);
+  border: 1px solid color-mix(in srgb, var(--hud-border) 60%, rgba(56, 189, 248, 0.45));
   background:
-    radial-gradient(circle at 0% 0%, rgba(56, 189, 248, 0.18), transparent 65%),
-    linear-gradient(155deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.7));
-  box-shadow: var(--shadow-soft);
+    radial-gradient(circle at 0% 0%, rgba(56, 189, 248, 0.22), transparent 65%),
+    linear-gradient(158deg, rgba(15, 23, 42, 0.94), rgba(15, 23, 42, 0.68));
+  box-shadow: 0 22px 48px rgba(8, 25, 53, 0.48);
   color: var(--color-foreground);
   text-align: left;
   letter-spacing: 0.08em;
@@ -1031,6 +1131,8 @@ body > #game-container {
   flex: 1 1 0;
   justify-content: center;
   gap: clamp(8px, 3.5vw, 12px);
+  width: 100%;
+  min-width: 0;
   padding: 12px clamp(12px, 5vw, 18px);
   border-radius: var(--radius-pill);
 }
@@ -1055,7 +1157,7 @@ body > #game-container {
 
 #resource-bar {
   pointer-events: auto;
-  align-self: flex-end;
+  align-self: stretch;
 }
 
 .sauna-roster {
@@ -1071,7 +1173,7 @@ body > #game-container {
     radial-gradient(circle at -40% 0%, rgba(251, 191, 36, 0.18), transparent 60%),
     linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.65));
   backdrop-filter: blur(20px) saturate(165%);
-  box-shadow: 0 28px 52px rgba(8, 25, 53, 0.55);
+  box-shadow: 0 20px 44px rgba(8, 25, 53, 0.42);
   color: var(--color-foreground);
   position: relative;
   overflow: hidden;
@@ -1085,9 +1187,10 @@ body > #game-container {
   position: absolute;
   inset: 0;
   background: radial-gradient(circle at 110% 50%, rgba(56, 189, 248, 0.16), transparent 55%);
-  opacity: 0.85;
+  opacity: 0.45;
   pointer-events: none;
   z-index: -1;
+  transition: opacity var(--transition-snappy);
 }
 
 .sauna-roster:hover,
@@ -1096,6 +1199,11 @@ body > #game-container {
   box-shadow: 0 36px 64px rgba(8, 25, 53, 0.6);
   border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
   outline: none;
+}
+
+.sauna-roster:hover::after,
+.sauna-roster:focus-visible::after {
+  opacity: 0.9;
 }
 
 .sauna-roster__summary {

--- a/src/ui/action-bar/index.tsx
+++ b/src/ui/action-bar/index.tsx
@@ -16,15 +16,10 @@ export function setupActionBar(
   const container = overlay.ownerDocument.createElement('div');
   container.dataset.component = 'action-bar';
   container.dataset.tutorialTarget = 'combat';
-  container.className = 'flex w-full justify-center';
+  container.className = 'hud-command-tray';
 
-  const bottomRegion = layout.regions.bottom;
-  const buildId = bottomRegion.querySelector<HTMLElement>('#build-id');
-  if (buildId) {
-    bottomRegion.insertBefore(container, buildId);
-  } else {
-    bottomRegion.appendChild(container);
-  }
+  const commandDock = layout.anchors.commandDock;
+  commandDock.appendChild(container);
 
   const root: Root = createRoot(container);
   root.render(<ActionBar state={state} abilities={abilities} />);

--- a/src/ui/inventoryHud.ts
+++ b/src/ui/inventoryHud.ts
@@ -252,9 +252,9 @@ export function setupInventoryHud(
     return { destroy: () => {} };
   }
 
-  const { regions } = ensureHudLayout(overlay);
-  const topRegion = regions.top;
-  const toastStack = ensureToastStack(overlay, topRegion);
+  const { anchors } = ensureHudLayout(overlay);
+  const topLeftCluster = anchors.topLeftCluster;
+  const toastStack = ensureToastStack(overlay, anchors.topRightCluster);
 
   overlay.querySelector('#inventory-stash-panel')?.remove();
   overlay.querySelector('#inventory-shop-panel')?.remove();
@@ -264,7 +264,7 @@ export function setupInventoryHud(
     .forEach((el) => el.remove());
   const { button: badgeButton, count: badgeCount } = createBadge();
   badgeButton.dataset.autoequip = inventory.isAutoEquipEnabled() ? 'on' : 'off';
-  topRegion.appendChild(badgeButton);
+  topLeftCluster.appendChild(badgeButton);
 
   const shopNumberFormatter = new Intl.NumberFormat('en-US');
   let shopPanel: SaunaShopPanelController | null = null;
@@ -299,7 +299,7 @@ export function setupInventoryHud(
       options.getSaunaShopViewModel?.() ?? { balance: 0, tiers: [] };
     shopButton = createShopButton();
     shopButton.dataset.state = 'locked';
-    topRegion.appendChild(shopButton);
+    topLeftCluster.appendChild(shopButton);
 
     const emitShopToast = (message: string, variant: SaunaShopToastVariant) => {
       const mapped = shopToastVariants[variant] ?? 'info';

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -6,9 +6,16 @@ export type HudLayoutRegions = {
   bottom: HTMLDivElement;
 };
 
+export type HudLayoutAnchors = {
+  topLeftCluster: HTMLDivElement;
+  topRightCluster: HTMLDivElement;
+  commandDock: HTMLDivElement;
+};
+
 export type HudLayout = {
   root: HTMLDivElement;
   regions: HudLayoutRegions;
+  anchors: HudLayoutAnchors;
   /**
    * @deprecated Prefer {@link regions.left}. Maintained for backwards compatibility.
    */
@@ -34,6 +41,12 @@ const REGION_GRID_CLASSES: Record<keyof HudLayoutRegions, string[]> = {
   content: ['col-start-2', 'row-start-2', 'row-span-1'],
   right: ['col-start-3', 'row-start-2', 'row-span-1'],
   bottom: ['col-span-3', 'row-start-3', 'row-span-1'],
+};
+
+const ANCHOR_DATASET_NAMES: Record<keyof HudLayoutAnchors, string> = {
+  topLeftCluster: 'top-left-cluster',
+  topRightCluster: 'top-right-cluster',
+  commandDock: 'command-dock',
 };
 
 function ensureRoot(overlay: HTMLElement, doc: Document): HTMLDivElement {
@@ -64,6 +77,26 @@ function ensureRegion(
     root.appendChild(region);
   }
   return region;
+}
+
+function ensureAnchor(
+  region: HTMLDivElement,
+  doc: Document,
+  name: keyof HudLayoutAnchors,
+  classNames: string[]
+): HTMLDivElement {
+  const datasetName = ANCHOR_DATASET_NAMES[name];
+  let anchor = region.querySelector<HTMLDivElement>(`[data-hud-anchor="${datasetName}"]`);
+  if (!anchor) {
+    anchor = doc.createElement('div');
+    anchor.dataset.hudAnchor = datasetName;
+    region.appendChild(anchor);
+  }
+  anchor.className = ['hud-anchor', ...classNames].join(' ');
+  if (anchor.parentElement !== region) {
+    region.appendChild(anchor);
+  }
+  return anchor;
 }
 
 function applyVariantClasses(
@@ -105,14 +138,34 @@ export function ensureHudLayout(overlay: HTMLElement): HudLayout {
   // Guarantee consistent DOM order for the layout regions.
   root.append(regions.top, regions.left, regions.content, regions.right, regions.bottom);
 
+  const anchors = {
+    topLeftCluster: ensureAnchor(regions.top, doc, 'topLeftCluster', [
+      'hud-anchor--top-left',
+    ]),
+    topRightCluster: ensureAnchor(regions.top, doc, 'topRightCluster', [
+      'hud-anchor--top-right',
+    ]),
+    commandDock: ensureAnchor(regions.bottom, doc, 'commandDock', [
+      'hud-anchor--command-dock',
+    ]),
+  } satisfies HudLayoutAnchors;
+
+  regions.top.append(anchors.topLeftCluster, anchors.topRightCluster);
+  regions.bottom.prepend(anchors.commandDock);
+
   const isUiV2 = overlay.dataset.hudVariant === 'v2';
   applyVariantClasses(overlay, regions, isUiV2);
 
   if (!isUiV2) {
     const resourceBar = overlay.querySelector<HTMLElement>('#resource-bar');
-    if (resourceBar && resourceBar.parentElement !== regions.right) {
-      regions.right.prepend(resourceBar);
+    if (resourceBar && resourceBar.parentElement !== anchors.topLeftCluster) {
+      anchors.topLeftCluster.prepend(resourceBar);
     }
+  }
+
+  const topbar = overlay.querySelector<HTMLElement>('#topbar');
+  if (topbar && topbar.parentElement !== anchors.topLeftCluster) {
+    anchors.topLeftCluster.appendChild(topbar);
   }
 
   const buildMenu = overlay.querySelector<HTMLElement>('#build-menu');
@@ -125,6 +178,18 @@ export function ensureHudLayout(overlay: HTMLElement): HudLayout {
     regions.bottom.appendChild(buildId);
   }
 
+  const actionBarMounts = overlay.querySelectorAll<HTMLElement>('[data-component="action-bar"]');
+  for (const mount of actionBarMounts) {
+    if (mount.parentElement !== anchors.commandDock) {
+      anchors.commandDock.appendChild(mount);
+    }
+  }
+
+  const commandToggle = overlay.querySelector<HTMLElement>('#right-panel-toggle');
+  if (commandToggle && commandToggle.parentElement !== anchors.commandDock) {
+    anchors.commandDock.prepend(commandToggle);
+  }
+
   let mobileBar = overlay.querySelector<HTMLDivElement>('.hud-mobile-bar__tray');
   let mobileWrapper = mobileBar?.closest<HTMLDivElement>('.hud-mobile-bar') ?? null;
   if (!mobileBar || !mobileWrapper) {
@@ -135,13 +200,14 @@ export function ensureHudLayout(overlay: HTMLElement): HudLayout {
     mobileWrapper.appendChild(mobileBar);
   }
 
-  if (mobileWrapper.parentElement !== regions.bottom) {
-    regions.bottom.appendChild(mobileWrapper);
+  if (mobileWrapper.parentElement !== anchors.commandDock) {
+    anchors.commandDock.appendChild(mobileWrapper);
   }
 
   return {
     root,
     regions,
+    anchors,
     actions: regions.left,
     side: regions.right,
     mobileBar,

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -69,9 +69,9 @@ export function setupRightPanel(
     return { log: () => {}, addEvent: () => {}, renderRoster: () => {}, dispose: () => {} };
   }
 
-  const { regions, mobileBar } = ensureHudLayout(overlay);
-  const topRegion = regions.top;
+  const { regions, anchors, mobileBar } = ensureHudLayout(overlay);
   const rightRegion = regions.right;
+  const commandDock = anchors.commandDock;
 
   const existingPanel = overlay.querySelector<HTMLDivElement>('#right-panel');
   if (existingPanel) {
@@ -135,11 +135,10 @@ export function setupRightPanel(
   toggle.append(toggleIcon, toggleText);
 
   const insertToggle = (): void => {
-    const topbar = topRegion.querySelector<HTMLElement>('#topbar');
-    if (topbar && topbar.parentElement === topRegion) {
-      topbar.insertAdjacentElement('afterend', toggle);
-    } else {
-      topRegion.prepend(toggle);
+    if (toggle.parentElement !== commandDock) {
+      commandDock.prepend(toggle);
+    } else if (commandDock.firstElementChild !== toggle) {
+      commandDock.insertBefore(toggle, commandDock.firstElementChild);
     }
   };
 
@@ -389,7 +388,7 @@ export function setupRightPanel(
       closeMobilePanel({ skipFocus: true });
       slideOver.style.setProperty('--panel-drag-progress', '1');
       slideOver.remove();
-  rightRegion.appendChild(panel);
+      rightRegion.appendChild(panel);
       insertToggle();
       toggle.classList.remove('hud-panel-toggle--mobile');
       toggle.hidden = !smallViewportQuery.matches;

--- a/src/ui/sauna.tsx
+++ b/src/ui/sauna.tsx
@@ -218,8 +218,8 @@ export function setupSaunaUI(
   card.appendChild(label);
 
   container.appendChild(card);
-  const { regions } = ensureHudLayout(overlay);
-  const topRegion = regions.top;
+  const { anchors } = ensureHudLayout(overlay);
+  const topLeftCluster = anchors.topLeftCluster;
 
   const reduceMotionQuery =
     typeof matchMedia === 'function' ? matchMedia('(prefers-reduced-motion: reduce)') : null;
@@ -293,13 +293,13 @@ export function setupSaunaUI(
   }
 
   const placeControl = (): boolean => {
-    if (container.parentElement !== topRegion) {
-      topRegion.appendChild(container);
+    if (container.parentElement !== topLeftCluster) {
+      topLeftCluster.appendChild(container);
     }
-    const topbar = topRegion.querySelector<HTMLDivElement>('#topbar');
-    if (topbar && topbar.parentElement === topRegion) {
+    const topbar = topLeftCluster.querySelector<HTMLDivElement>('#topbar');
+    if (topbar && topbar.parentElement === topLeftCluster) {
       if (topbar.nextSibling !== container) {
-        topRegion.insertBefore(container, topbar.nextSibling);
+        topLeftCluster.insertBefore(container, topbar.nextSibling);
       }
       return true;
     }
@@ -313,7 +313,7 @@ export function setupSaunaUI(
         placementObserver?.disconnect();
       }
     });
-    placementObserver.observe(topRegion, { childList: true });
+    placementObserver.observe(topLeftCluster, { childList: true });
   }
 
   const handleToggle = () => {

--- a/src/ui/topbar.ts
+++ b/src/ui/topbar.ts
@@ -110,12 +110,12 @@ export function setupTopbar(
     };
   }
 
-  const { regions } = ensureHudLayout(overlay);
-  const topRegion = regions.top;
+  const { anchors } = ensureHudLayout(overlay);
+  const topLeftCluster = anchors.topLeftCluster;
 
   const bar = document.createElement('div');
   bar.id = 'topbar';
-  topRegion.prepend(bar);
+  topLeftCluster.appendChild(bar);
 
   const badgeRow = document.createElement('div');
   badgeRow.className = 'topbar-badge-row';

--- a/tests/ui/action-bar.test.ts
+++ b/tests/ui/action-bar.test.ts
@@ -6,13 +6,18 @@ function renderOverlay(): HTMLElement {
   document.body.innerHTML = `
     <div id="ui-overlay">
       <div class="hud-layout-root" data-hud-root>
-        <div class="hud-region hud-top-row" data-hud-region="top"></div>
+        <div class="hud-region hud-top-row" data-hud-region="top">
+          <div class="hud-anchor hud-anchor--top-left" data-hud-anchor="top-left-cluster">
+            <div id="resource-bar"></div>
+          </div>
+          <div class="hud-anchor hud-anchor--top-right" data-hud-anchor="top-right-cluster"></div>
+        </div>
         <div class="hud-region hud-actions" data-hud-region="left"></div>
         <div class="hud-region hud-content" data-hud-region="content"></div>
-        <div class="hud-region hud-right-column" data-hud-region="right">
-          <div id="resource-bar"></div>
+        <div class="hud-region hud-right-column" data-hud-region="right"></div>
+        <div class="hud-region hud-bottom-row" data-hud-region="bottom">
+          <div class="hud-anchor hud-anchor--command-dock" data-hud-anchor="command-dock"></div>
         </div>
-        <div class="hud-region hud-bottom-row" data-hud-region="bottom"></div>
       </div>
     </div>
   `;

--- a/tests/ui/logging.test.ts
+++ b/tests/ui/logging.test.ts
@@ -10,13 +10,18 @@ const renderShell = () => {
   document.body.innerHTML = `
     <div id="ui-overlay">
       <div class="hud-layout-root" data-hud-root>
-        <div class="hud-region hud-top-row" data-hud-region="top"></div>
+        <div class="hud-region hud-top-row" data-hud-region="top">
+          <div class="hud-anchor hud-anchor--top-left" data-hud-anchor="top-left-cluster">
+            <div id="resource-bar"></div>
+          </div>
+          <div class="hud-anchor hud-anchor--top-right" data-hud-anchor="top-right-cluster"></div>
+        </div>
         <div class="hud-region hud-actions" data-hud-region="left"></div>
         <div class="hud-region hud-content" data-hud-region="content"></div>
-        <div class="hud-region hud-right-column" data-hud-region="right">
-          <div id="resource-bar"></div>
+        <div class="hud-region hud-right-column" data-hud-region="right"></div>
+        <div class="hud-region hud-bottom-row" data-hud-region="bottom">
+          <div class="hud-anchor hud-anchor--command-dock" data-hud-anchor="command-dock"></div>
         </div>
-        <div class="hud-region hud-bottom-row" data-hud-region="bottom"></div>
       </div>
     </div>
   `;


### PR DESCRIPTION
## Summary
- add explicit HUD anchors for the resource cluster, notification tray, and command dock and wire the top bar, inventory HUD, sauna controls, and right-panel toggle into them
- refresh the HUD stylesheet with glassmorphic command dock styling, cohesive badge opacity, and a unified resource cluster placement while keeping the mobile tray behavior intact
- update HUD-related tests, action bar hooks, and changelog entries to reflect the new layout structure

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0cd7215c08330a5eb3ab2d25a5cd5