### PR TITLE
feat(renderer): centralize unit sprite rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Introduce a `drawUnitSprite` renderer helper that paints faction-aware oval
+  bases with layered gradients, refactors battlefield unit rendering to reuse
+  the placement math for Sisu outlines and selection cues, extends the Vitest
+  suite for sprite geometry, and documents the polished pipeline.
+
 - Merge the roster, stash, and policies HUD panes into a unified glass dock with
   a shared tab strip, route the stash renderer through the new panel, and refresh
   HUD tests to reflect the tab-driven layout.

--- a/src/render/renderer.test.ts
+++ b/src/render/renderer.test.ts
@@ -4,11 +4,33 @@ import type { Unit } from '../unit/index.ts';
 import type { HexMapRenderer } from './HexMapRenderer.ts';
 import type { PixelCoord } from '../hex/HexUtils.ts';
 import type { Sauna } from '../sim/sauna.ts';
+import type { DrawUnitSpriteOptions, UnitSpriteRenderResult } from './units/UnitSprite.ts';
 import { camera } from '../camera/autoFrame.ts';
 
+const isSisuBurstActive = vi.fn(() => false);
 vi.mock('../sisu/burst.ts', () => ({
-  isSisuBurstActive: () => false
+  isSisuBurstActive: () => isSisuBurstActive()
 }));
+
+type DrawUnitSpriteMock = (
+  ctx: CanvasRenderingContext2D,
+  unit: Unit,
+  options: DrawUnitSpriteOptions
+) => UnitSpriteRenderResult;
+
+const drawUnitSpriteMock = vi.hoisted(() => ({
+  fn: vi.fn<DrawUnitSpriteMock>()
+}));
+
+vi.mock('./units/UnitSprite.ts', async () => {
+  const actual = await vi.importActual<typeof import('./units/UnitSprite.ts')>(
+    './units/UnitSprite.ts'
+  );
+  return {
+    ...actual,
+    drawUnitSprite: drawUnitSpriteMock.fn
+  } satisfies typeof actual;
+});
 
 function createMockContext(): CanvasRenderingContext2D {
   const canvas = {
@@ -19,7 +41,6 @@ function createMockContext(): CanvasRenderingContext2D {
     canvas,
     save: vi.fn(),
     restore: vi.fn(),
-    drawImage: vi.fn(),
     strokeRect: vi.fn(),
     filter: '',
     globalAlpha: 1,
@@ -58,6 +79,33 @@ describe('drawUnits', () => {
     camera.x = 0;
     camera.y = 0;
     camera.zoom = 1;
+    isSisuBurstActive.mockReturnValue(false);
+    drawUnitSpriteMock.fn.mockReset();
+    drawUnitSpriteMock.fn.mockReturnValue({
+      placement: {
+        drawX: 12,
+        drawY: 24,
+        width: 48,
+        height: 64,
+        centerX: 12 + 48 * 0.5,
+        centerY: 24 + 64 * 0.5,
+        metadata: {
+          nativeSize: { width: 64, height: 64 },
+          anchor: { x: 0.5, y: 0.9 },
+          scale: { x: 1, y: 1 },
+          nudge: { x: 0, y: 0 }
+        }
+      },
+      center: { x: 36, y: 56 },
+      footprint: {
+        centerX: 36,
+        centerY: 78,
+        radiusX: 24,
+        radiusY: 12,
+        top: 66,
+        bottom: 90
+      }
+    });
   });
 
   it('renders enemies within friendly vision when Saunoja overlay hides player sprites', () => {
@@ -73,16 +121,21 @@ describe('drawUnits', () => {
       placeholder: makeImage()
     };
 
-    drawUnits(ctx, mapRenderer, assets, [enemy], origin, undefined, [friendly]);
+    drawUnits(ctx, mapRenderer, assets, [enemy], origin, undefined, [friendly], null, null);
 
-    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
-    expect(ctx.drawImage).toHaveBeenCalledWith(
-      assets['unit-marauder'],
-      expect.any(Number),
-      expect.any(Number),
-      expect.any(Number),
-      expect.any(Number)
-    );
+    expect(drawUnitSpriteMock.fn).toHaveBeenCalledTimes(1);
+    const call = drawUnitSpriteMock.fn.mock.calls[0];
+    expect(call[1]).toBe(enemy);
+    expect(call[2]).toMatchObject({
+      faction: 'enemy',
+      placement: {
+        coord: enemy.coord,
+        hexSize: 32,
+        origin,
+        zoom: 1,
+        type: 'marauder'
+      }
+    });
   });
 
   it('renders enemies overlapping the sauna when only sauna vision is supplied', () => {
@@ -101,15 +154,57 @@ describe('drawUnits', () => {
       placeholder: makeImage()
     };
 
-    drawUnits(ctx, mapRenderer, assets, [enemy], origin, undefined, [], sauna);
+    drawUnits(ctx, mapRenderer, assets, [enemy], origin, undefined, [], sauna, null);
 
-    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
-    expect(ctx.drawImage).toHaveBeenCalledWith(
-      assets['unit-marauder'],
-      expect.any(Number),
-      expect.any(Number),
-      expect.any(Number),
-      expect.any(Number)
-    );
+    expect(drawUnitSpriteMock.fn).toHaveBeenCalledTimes(1);
+    const [, , opts] = drawUnitSpriteMock.fn.mock.calls[0];
+    expect(opts.placement.coord).toEqual(enemy.coord);
+    expect(opts.selection?.isSelected).toBe(false);
+  });
+
+  it('passes selection flags and exposes placement for Sisu burst outlines', () => {
+    const player = createStubUnit('player', 'player', { q: 0, r: 0 }, 'soldier');
+    (player as { selected?: boolean }).selected = true;
+    const mapRenderer = { hexSize: 32 } as unknown as HexMapRenderer;
+    const origin: PixelCoord = { x: 0, y: 0 };
+    const ctx = createMockContext();
+    const makeImage = () => document.createElement('img') as HTMLImageElement;
+    const assets = {
+      'unit-soldier': makeImage(),
+      placeholder: makeImage()
+    };
+
+    isSisuBurstActive.mockReturnValue(true);
+    drawUnitSpriteMock.fn.mockReturnValue({
+      placement: {
+        drawX: 10,
+        drawY: 20,
+        width: 30,
+        height: 40,
+        centerX: 25,
+        centerY: 38,
+        metadata: {
+          nativeSize: { width: 64, height: 64 },
+          anchor: { x: 0.5, y: 0.9 },
+          scale: { x: 1, y: 1 },
+          nudge: { x: 0, y: 0 }
+        }
+      },
+      center: { x: 25, y: 38 },
+      footprint: {
+        centerX: 25,
+        centerY: 52,
+        radiusX: 20,
+        radiusY: 10,
+        top: 42,
+        bottom: 62
+      }
+    });
+
+    drawUnits(ctx, mapRenderer, assets, [player], origin, undefined, [player], null, player.coord);
+
+    const [, , opts] = drawUnitSpriteMock.fn.mock.calls[0];
+    expect(opts.selection).toEqual({ isSelected: true, isPrimary: true });
+    expect(ctx.strokeRect).toHaveBeenCalledWith(10, 20, 30, 40);
   });
 });

--- a/src/render/units/UnitSprite.test.ts
+++ b/src/render/units/UnitSprite.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { drawUnitSprite } from './UnitSprite.ts';
+import { getSpritePlacement } from './draw.ts';
+import type { DrawUnitSpriteOptions } from './UnitSprite.ts';
+import type { Unit } from '../../unit/index.ts';
+import type { AxialCoord, PixelCoord } from '../../hex/HexUtils.ts';
+
+function createStubContext(): CanvasRenderingContext2D {
+  const gradientFactory = () => ({
+    addColorStop: vi.fn()
+  }) as unknown as CanvasGradient;
+  const ctx = {
+    canvas: { width: 256, height: 256 } as HTMLCanvasElement,
+    filter: 'none',
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over',
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    ellipse: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    drawImage: vi.fn(),
+    createLinearGradient: vi.fn(() => gradientFactory()),
+    createRadialGradient: vi.fn(() => gradientFactory())
+  } as unknown as CanvasRenderingContext2D;
+  return ctx;
+}
+
+function createUnit(type: string, faction: string, coord: AxialCoord): Unit {
+  return {
+    id: `${type}-${coord.q}-${coord.r}`,
+    type,
+    faction,
+    coord,
+    renderCoord: coord
+  } as unknown as Unit;
+}
+
+describe('drawUnitSprite', () => {
+  let ctx: CanvasRenderingContext2D;
+  let origin: PixelCoord;
+  let coord: AxialCoord;
+  let unit: Unit;
+  let sprite: HTMLImageElement;
+
+  beforeEach(() => {
+    ctx = createStubContext();
+    origin = { x: 12, y: -4 };
+    coord = { q: 1, r: -2 };
+    unit = createUnit('soldier', 'player', coord);
+    sprite = document.createElement('img');
+    Object.defineProperty(sprite, 'naturalWidth', { value: 32 });
+    Object.defineProperty(sprite, 'naturalHeight', { value: 32 });
+  });
+
+  it('reuses sprite placement metadata and returns center coordinates', () => {
+    const placementOptions: DrawUnitSpriteOptions['placement'] = {
+      coord,
+      hexSize: 32,
+      origin,
+      zoom: 1,
+      type: unit.type
+    };
+    const expectedPlacement = getSpritePlacement(placementOptions);
+
+    const result = drawUnitSprite(ctx, unit, {
+      placement: placementOptions,
+      sprite,
+      faction: unit.faction,
+      cameraZoom: 1,
+      motionStrength: 0.25,
+      selection: { isSelected: true, isPrimary: true }
+    });
+
+    expect(ctx.drawImage).toHaveBeenCalledWith(
+      sprite,
+      expectedPlacement.drawX,
+      expectedPlacement.drawY,
+      expectedPlacement.width,
+      expectedPlacement.height
+    );
+    expect(result.placement).toEqual(expectedPlacement);
+    expect(result.center).toEqual({ x: expectedPlacement.centerX, y: expectedPlacement.centerY });
+    expect(result.footprint.centerY).toBeGreaterThan(expectedPlacement.centerY);
+    expect(result.footprint.radiusX).toBeGreaterThan(0);
+    expect(ctx.strokeStyle).toMatch(/255/);
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  it('skips sprite rendering when no image is provided', () => {
+    const placementOptions: DrawUnitSpriteOptions['placement'] = {
+      coord,
+      hexSize: 28,
+      origin,
+      zoom: 0.9,
+      type: unit.type
+    };
+
+    const result = drawUnitSprite(ctx, unit, {
+      placement: placementOptions,
+      sprite: null,
+      faction: 'enemy',
+      cameraZoom: 0.9,
+      motionStrength: 0.6,
+      selection: { isSelected: false }
+    });
+
+    expect(ctx.drawImage).not.toHaveBeenCalled();
+    expect(result.placement).toEqual(getSpritePlacement(placementOptions));
+    expect(result.footprint.radiusY).toBeGreaterThan(0);
+  });
+});

--- a/src/render/units/UnitSprite.ts
+++ b/src/render/units/UnitSprite.ts
@@ -1,0 +1,238 @@
+import type { Unit } from '../../unit/index.ts';
+import type { SpritePlacement, SpritePlacementInput } from './draw.ts';
+import { getSpritePlacement } from './draw.ts';
+import { snapForZoom } from '../zoom.ts';
+
+export interface UnitSpriteFootprint {
+  readonly centerX: number;
+  readonly centerY: number;
+  readonly radiusX: number;
+  readonly radiusY: number;
+  readonly top: number;
+  readonly bottom: number;
+}
+
+export interface UnitSpriteRenderResult {
+  readonly placement: SpritePlacement;
+  readonly center: { x: number; y: number };
+  readonly footprint: UnitSpriteFootprint;
+}
+
+export interface UnitSelectionState {
+  readonly isSelected?: boolean;
+  readonly isPrimary?: boolean;
+}
+
+export interface DrawUnitSpriteOptions {
+  readonly placement: SpritePlacementInput;
+  readonly sprite: CanvasImageSource | null | undefined;
+  readonly faction?: Unit['faction'];
+  readonly motionStrength?: number;
+  readonly cameraZoom?: number;
+  readonly selection?: UnitSelectionState;
+}
+
+interface GradientLike {
+  addColorStop(offset: number, color: string): void;
+}
+
+function createGradientSafe(
+  create: () => CanvasGradient | null,
+  fallbackColor: string
+): [CanvasGradient | null, string] {
+  try {
+    const gradient = create();
+    if (gradient) {
+      return [gradient, ''];
+    }
+  } catch (error) {
+    console.warn('Failed to create canvas gradient', error);
+  }
+  return [null, fallbackColor];
+}
+
+function applyStops(gradient: GradientLike | null, stops: Array<[number, string]>): void {
+  if (!gradient) {
+    return;
+  }
+  for (const [offset, color] of stops) {
+    try {
+      gradient.addColorStop(offset, color);
+    } catch (error) {
+      console.warn('Failed to add gradient stop', { offset, color, error });
+    }
+  }
+}
+
+function resolveBasePalette(
+  faction: string | undefined,
+  selection: UnitSelectionState | undefined,
+  motionStrength: number
+): {
+  shell: string;
+  mid: string;
+  rim: string;
+  highlight: string;
+  ring: string;
+  motionGlow: string;
+} {
+  const normalizedMotion = Math.min(1, Math.max(0, motionStrength));
+  const glowOpacity = 0.12 + normalizedMotion * 0.38;
+  const playerPalette = {
+    shell: 'rgba(30, 38, 58, 0.95)',
+    mid: 'rgba(45, 60, 98, 0.94)',
+    rim: 'rgba(118, 214, 255, 0.7)',
+    highlight: 'rgba(190, 230, 255, 0.65)',
+    ring: 'rgba(86, 151, 255, 0.65)',
+    motionGlow: `rgba(124, 215, 255, ${glowOpacity.toFixed(3)})`
+  } as const;
+  const enemyPalette = {
+    shell: 'rgba(46, 24, 32, 0.95)',
+    mid: 'rgba(66, 36, 44, 0.95)',
+    rim: 'rgba(248, 140, 120, 0.7)',
+    highlight: 'rgba(250, 190, 170, 0.55)',
+    ring: 'rgba(255, 128, 96, 0.6)',
+    motionGlow: `rgba(255, 140, 110, ${glowOpacity.toFixed(3)})`
+  } as const;
+  const neutralPalette = {
+    shell: 'rgba(36, 36, 42, 0.9)',
+    mid: 'rgba(56, 56, 68, 0.92)',
+    rim: 'rgba(198, 198, 210, 0.55)',
+    highlight: 'rgba(220, 220, 238, 0.4)',
+    ring: 'rgba(140, 140, 160, 0.5)',
+    motionGlow: `rgba(210, 210, 230, ${glowOpacity.toFixed(3)})`
+  } as const;
+
+  const palette = faction === 'player' ? playerPalette : faction === 'enemy' ? enemyPalette : neutralPalette;
+
+  if (selection?.isSelected) {
+    const emphasis = selection.isPrimary ? 0.95 : 0.7;
+    return {
+      shell: palette.shell,
+      mid: palette.mid,
+      rim: `rgba(255, 255, 255, ${(0.35 + emphasis * 0.25).toFixed(3)})`,
+      highlight: `rgba(255, 255, 255, ${(0.25 + emphasis * 0.35).toFixed(3)})`,
+      ring: `rgba(255, 255, 255, ${(0.4 + emphasis * 0.35).toFixed(3)})`,
+      motionGlow: palette.motionGlow
+    };
+  }
+
+  return palette;
+}
+
+function drawBase(
+  ctx: CanvasRenderingContext2D,
+  placement: SpritePlacement,
+  hexSize: number,
+  zoom: number,
+  palette: ReturnType<typeof resolveBasePalette>
+): UnitSpriteFootprint {
+  const radiusX = snapForZoom(hexSize * 0.78, zoom);
+  const radiusY = snapForZoom(hexSize * 0.34, zoom);
+  const bottomOffset = snapForZoom(Math.max(hexSize * 0.18, radiusY * 0.6), zoom);
+  const bottomY = placement.drawY + placement.height;
+  const centerX = placement.centerX;
+  const centerY = bottomY - bottomOffset + radiusY * 0.2;
+
+  ctx.save();
+  ctx.filter = 'none';
+
+  ctx.beginPath();
+  ctx.ellipse(centerX, centerY, radiusX, radiusY, 0, 0, Math.PI * 2);
+
+  const [shellGradient, shellFallback] = createGradientSafe(
+    () => ctx.createLinearGradient(centerX, centerY - radiusY, centerX, centerY + radiusY),
+    palette.shell
+  );
+  applyStops(shellGradient, [
+    [0, palette.highlight],
+    [0.55, palette.mid],
+    [1, palette.shell]
+  ]);
+  ctx.fillStyle = shellGradient ?? shellFallback;
+  ctx.fill();
+
+  ctx.globalCompositeOperation = 'multiply';
+  const [shadowGradient, shadowFallback] = createGradientSafe(
+    () => ctx.createRadialGradient(centerX, centerY + radiusY * 0.4, radiusY * 0.35, centerX, centerY + radiusY * 0.4, radiusY * 1.4),
+    'rgba(24, 26, 32, 0.55)'
+  );
+  applyStops(shadowGradient, [
+    [0, palette.motionGlow],
+    [0.45, 'rgba(22, 26, 36, 0.7)'],
+    [1, 'rgba(18, 22, 30, 0)']
+  ]);
+  ctx.fillStyle = shadowGradient ?? shadowFallback;
+  ctx.fill();
+
+  ctx.globalCompositeOperation = 'screen';
+  const [highlightGradient, highlightFallback] = createGradientSafe(
+    () => ctx.createRadialGradient(centerX, centerY - radiusY * 0.65, radiusY * 0.1, centerX, centerY, radiusY * 1.25),
+    palette.highlight
+  );
+  applyStops(highlightGradient, [
+    [0, palette.highlight],
+    [0.6, 'rgba(255, 255, 255, 0.14)'],
+    [1, 'rgba(255, 255, 255, 0)']
+  ]);
+  ctx.fillStyle = highlightGradient ?? highlightFallback;
+  ctx.fill();
+
+  ctx.restore();
+
+  ctx.save();
+  ctx.filter = 'none';
+  ctx.beginPath();
+  ctx.ellipse(centerX, centerY, radiusX * 0.96, radiusY * 0.92, 0, 0, Math.PI * 2);
+  ctx.strokeStyle = palette.ring;
+  ctx.lineWidth = snapForZoom(Math.max(1.5, zoom * 1.2), zoom);
+  ctx.stroke();
+  ctx.restore();
+
+  return {
+    centerX,
+    centerY,
+    radiusX,
+    radiusY,
+    top: centerY - radiusY,
+    bottom: centerY + radiusY
+  } satisfies UnitSpriteFootprint;
+}
+
+export function drawUnitSprite(
+  ctx: CanvasRenderingContext2D,
+  unit: Unit,
+  options: DrawUnitSpriteOptions
+): UnitSpriteRenderResult {
+  if (!ctx || !unit || !options || !options.placement) {
+    throw new Error('drawUnitSprite requires a valid context, unit, and placement data.');
+  }
+
+  const zoom = Number.isFinite(options.cameraZoom) && (options.cameraZoom as number) > 0
+    ? (options.cameraZoom as number)
+    : options.placement.zoom;
+  const spritePlacement = getSpritePlacement(options.placement);
+  const motionStrength = Math.max(0, Math.min(1, options.motionStrength ?? 0));
+  const palette = resolveBasePalette(options.faction ?? unit.faction, options.selection, motionStrength);
+
+  const footprint = drawBase(ctx, spritePlacement, options.placement.hexSize, zoom, palette);
+
+  const sprite = options.sprite;
+  if (sprite) {
+    const previousFilter = ctx.filter;
+    ctx.filter = previousFilter;
+    ctx.drawImage(
+      sprite,
+      spritePlacement.drawX,
+      spritePlacement.drawY,
+      spritePlacement.width,
+      spritePlacement.height
+    );
+  }
+
+  return {
+    placement: spritePlacement,
+    center: { x: spritePlacement.centerX, y: spritePlacement.centerY },
+    footprint
+  } satisfies UnitSpriteRenderResult;
+}


### PR DESCRIPTION
## Summary
- add a dedicated drawUnitSprite helper with faction-aware base gradients and placement metadata
- refactor drawUnits to use the helper for selection-aware rendering and Sisu outlines
- extend renderer coverage with helper unit tests and document the change in the changelog

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0dee60a608330a2d4486fa730a3da