### PR TITLE
Wire unit status overlays through FX buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Route battlefield status overlays through a fresh FX manager frame buffer so
+  the renderer pushes live HP, shield, and modifier data for visible units,
+  drive the sauna countdown ring via the shared UnitStatusLayer payloads, and
+  extend Vitest coverage around the overlay pipeline.
+
 - Introduce a `drawUnitSprite` renderer helper that paints faction-aware oval
   bases with layered gradients, refactors battlefield unit rendering to reuse
   the placement math for Sisu outlines and selection cues, extends the Vitest

--- a/src/render/saunaOverlay.ts
+++ b/src/render/saunaOverlay.ts
@@ -156,15 +156,14 @@ export function drawSaunaOverlay(
 
 
   if (pushStatus) {
-    const gaugeRadius = hexSize * 0.9;
-    const trackRadius = gaugeRadius * 0.78;
+    const statusRadius = Math.max(hexSize * 0.82, Math.min(hexSize * 1.6, auraRadius * 0.62));
     const cooldown = sauna.playerSpawnCooldown > 0 ? sauna.playerSpawnCooldown : 1;
     const remainingSeconds = Math.max(0, Math.min(cooldown, sauna.playerSpawnTimer));
     const progress = cooldown <= 0 ? 1 : 1 - Math.min(1, remainingSeconds / cooldown);
     pushStatus({
       id: sauna.id,
       world: { x: worldCenterX, y: worldCenterY },
-      radius: trackRadius,
+      radius: statusRadius,
       progress,
       countdown: remainingSeconds,
       label: 'Sauna \u2668\ufe0f',

--- a/tests/ui/selectionMiniHud.test.tsx
+++ b/tests/ui/selectionMiniHud.test.tsx
@@ -165,4 +165,24 @@ describe('SelectionMiniHud integration', () => {
     const entry = overlay.querySelector('.ui-selection-mini-hud') as HTMLElement | null;
     expect(entry?.dataset.visible).toBe('false');
   });
+
+  it('only renders unit status overlays from the active frame', () => {
+    manager.beginStatusFrame();
+    manager.pushUnitStatus({
+      id: 'scout-1',
+      world: { x: 200, y: 260 },
+      radius: 20,
+      hp: 8,
+      maxHp: 12,
+      faction: 'enemy'
+    });
+    manager.commitStatusFrame();
+
+    expect(overlay.querySelector('[data-unit-id="scout-1"]')).toBeTruthy();
+
+    manager.beginStatusFrame();
+    manager.commitStatusFrame();
+
+    expect(overlay.querySelector('[data-unit-id="scout-1"]')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- double-buffer battlefield status payloads inside `createUnitFxManager` so begin/commit work on a fresh frame and the selection HUD always reflects the latest committed data
- push unit HP/shield/modifier overlays (plus the sauna timer ring) through the shared UnitStatusLayer by emitting payloads from the renderer and sauna overlay helpers
- extend renderer and FX tests to validate the overlay payload flow and document the migration in the changelog

## Testing
- npm run build
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d0e7cc169483309e2f81f00cf27a9d