### PR TITLE
Lock sauna shop crest and badge dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Lock the Steamforge Atelier crest and tier badges to dedicated 3rem wrappers
+  so the shop assets render at the intended proportions inside the sauna panel.
+
 - Route battlefield status overlays through a fresh FX manager frame buffer so
   the renderer pushes live HP, shield, and modifier data for visible units,
   drive the sauna countdown ring via the shared UnitStatusLayer payloads, and

--- a/src/style.css
+++ b/src/style.css
@@ -91,6 +91,18 @@ img {
   max-width: 100%;
 }
 
+.sauna-shop-panel__crest,
+.sauna-shop-panel__tier-badge {
+  width: 3rem;
+  height: 3rem;
+  flex-shrink: 0;
+}
+
+.sauna-shop-panel__crest img {
+  width: 100%;
+  height: 100%;
+}
+
 button,
 .btn {
   min-height: 44px;

--- a/src/ui/shop/SaunaShopPanel.tsx
+++ b/src/ui/shop/SaunaShopPanel.tsx
@@ -110,13 +110,13 @@ export function createSaunaShopPanel(options: SaunaShopPanelOptions): SaunaShopP
   balanceLabel.appendChild(balanceValue);
 
   const balanceIconWrap = document.createElement('div');
-  balanceIconWrap.className = 'relative h-12 w-12 flex-shrink-0';
+  balanceIconWrap.className = 'sauna-shop-panel__crest relative';
   balanceIconWrap.setAttribute('aria-hidden', 'true');
 
   const balanceIcon = document.createElement('img');
   balanceIcon.src = artocoinIconUrl;
   balanceIcon.alt = '';
-  balanceIcon.className = 'h-full w-full drop-shadow-[0_12px_18px_rgba(255,186,92,0.35)]';
+  balanceIcon.className = 'drop-shadow-[0_12px_18px_rgba(255,186,92,0.35)]';
   balanceIcon.decoding = 'async';
   balanceIconWrap.appendChild(balanceIcon);
 
@@ -154,7 +154,7 @@ export function createSaunaShopPanel(options: SaunaShopPanelOptions): SaunaShopP
     headerRow.appendChild(titleBlock);
 
     const badge = document.createElement('div');
-    badge.className = 'h-12 w-12 flex-shrink-0 overflow-hidden rounded-full border border-white/40 bg-slate-900/40 shadow-[0_8px_16px_rgba(0,0,0,0.35)]';
+    badge.className = 'sauna-shop-panel__tier-badge overflow-hidden rounded-full border border-white/40 bg-slate-900/40 shadow-[0_8px_16px_rgba(0,0,0,0.35)]';
     badge.style.backgroundImage = `url(${tier.art.badge})`;
     badge.style.backgroundSize = 'cover';
     badge.style.backgroundPosition = 'center';


### PR DESCRIPTION
## Summary
- add dedicated sauna shop panel crest and tier badge wrapper classes with fixed 3rem sizing
- swap the shop panel crest and badge elements to the new scoped classes so assets scale inside the wrapper
- note the polished crest/badge alignment in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0f6dd169083309aa1801038c335ef