### PR TITLE
feat: integrate final raider enemy art

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Ship the Avanto raider art drop: replace the placeholder raider sprite with
+  the production SVGs from art, add captain and shaman variants, register their
+  renderer metadata, and expand sprite tests so the anchors and scale ratios
+  stay locked.
+
 - Unify battlefield and HUD faction palettes behind new CSS tokens, teach the
   canvas renderer to read the shared values, layer in a softened rim light for
   premium unit bases, and extend sprite tests to lock the faction styling

--- a/assets/sprites/raider-captain.svg
+++ b/assets/sprites/raider-captain.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 184 206" role="img" aria-labelledby="title desc">
+  <title id="title">Avanto Raider Captain</title>
+  <desc id="desc">Armored raider captain with a polar cloak, runed greataxe, and aurora backlight.</desc>
+  <defs>
+    <linearGradient id="captain-sky" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0" stop-color="#04070f" />
+      <stop offset="0.5" stop-color="#142842" />
+      <stop offset="1" stop-color="#0a1018" />
+    </linearGradient>
+    <radialGradient id="captain-halo" cx="52%" cy="18%" r="78%">
+      <stop offset="0" stop-color="#f0f7ff" stop-opacity="0.95" />
+      <stop offset="0.5" stop-color="#9fd0ff" stop-opacity="0.65" />
+      <stop offset="1" stop-color="#071020" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="captain-fur" x1="10%" y1="15%" x2="90%" y2="85%">
+      <stop offset="0" stop-color="#5c7089" />
+      <stop offset="1" stop-color="#1a212e" />
+    </linearGradient>
+    <linearGradient id="captain-armor" x1="24%" y1="0%" x2="76%" y2="100%">
+      <stop offset="0" stop-color="#f4fbff" />
+      <stop offset="0.35" stop-color="#d0e8ff" />
+      <stop offset="1" stop-color="#6c9fda" />
+    </linearGradient>
+    <linearGradient id="captain-plate" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0" stop-color="#293041" />
+      <stop offset="1" stop-color="#131822" />
+    </linearGradient>
+    <linearGradient id="captain-axe" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0" stop-color="#f7feff" />
+      <stop offset="0.4" stop-color="#b5d4ff" />
+      <stop offset="1" stop-color="#e8f7ff" />
+    </linearGradient>
+    <linearGradient id="captain-glow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0" stop-color="#ff8f6b" />
+      <stop offset="0.5" stop-color="#ff5768" stop-opacity="0.7" />
+      <stop offset="1" stop-color="#ff8f6b" />
+    </linearGradient>
+  </defs>
+  <rect width="184" height="206" rx="20" ry="20" fill="url(#captain-sky)" />
+  <rect width="184" height="206" fill="url(#captain-halo)" />
+  <g transform="translate(16 6)">
+    <path d="M72 18c14-8 32-8 46 0 12 8 18 28 12 44-7 18-30 34-47 34S47 80 40 62c-6-16 2-36 14-44 13-8 29-8 40 0z" fill="#111b2a" opacity="0.8" />
+    <path d="M68 30c10-7 26-7 36 0s14 22 9 34c-5 14-22 24-36 24s-30-10-35-24c-5-12 0-27 9-34z" fill="url(#captain-fur)" />
+    <path d="M80 42c7-5 18-5 24 0 7 4 10 15 6 24-4 10-14 16-24 16s-20-6-24-16c-3-9 0-20 6-24z" fill="#eef7ff" opacity="0.9" />
+    <path d="M66 70c18 8 36 8 52 0l10 20c-16 24-48 26-72 0z" fill="url(#captain-armor)" />
+    <path d="M42 86c22 24 56 24 78 0l22 18-14 44c-22 10-64 12-90 0l-14-44z" fill="url(#captain-plate)" />
+    <path d="M62 96c11 6 23 6 34 0l14 40c-18 12-44 12-62 0z" fill="url(#captain-armor)" />
+    <path d="M34 86c-10 8-20 30-18 44 2 12 12 24 24 30l8-26z" fill="#1d1419" />
+    <path d="M128 86c10 8 20 30 18 44-2 12-12 24-24 30l-8-26z" fill="#1d1419" />
+    <path d="M28 36c-9 8-14 26-10 40 5 16 20 26 32 22l-14-24c-2-10 0-24 5-32 4-8 8-14 16-16-12-2-22 0-29 10z" fill="#0e1623" />
+    <path d="M132 36c9 8 14 26 10 40-5 16-20 26-32 22l14-24c2-10 0-24-5-32-4-8-8-14-16-16 12-2 22 0 29 10z" fill="#0e1623" />
+    <path d="M46 120c-7 18-9 38-7 52 14 10 66 12 92 0 2-14 0-34-7-52-22 14-56 14-78 0z" fill="#0e090f" opacity="0.9" />
+    <path d="M38 178c24 10 76 10 100 0l-6 16c-30 12-58 12-88 0z" fill="#060508" opacity="0.85" />
+    <path d="M-2 112c-1 4 10 14 22 18 8 4 14 4 16 2l8-12-24-16c-8-4-19 0-22 8z" fill="#222a38" />
+    <path d="M152 112c1 4-10 14-22 18-8 4-14 4-16 2l-8-12 24-16c8-4 19 0 22 8z" fill="#222a38" />
+    <path d="M-4 100c-2 8 5 16 16 20 8 3 16 5 22 0s7-13 0-16c-12-6-26-12-38-4z" fill="url(#captain-axe)" transform="rotate(-8 20 112)" />
+    <path d="M156 100c2 8-5 16-16 20-8 3-16 5-22 0s-7-13 0-16c12-6 26-12 38-4z" fill="url(#captain-axe)" transform="rotate(8 132 112)" />
+    <path d="M94 48c4-6 10-6 14 0 2 5-1 10-7 10s-9-5-7-10z" fill="#f3fbff" />
+    <path d="M78 48c4-6 10-6 14 0 2 5-1 10-7 10s-9-5-7-10z" fill="#f3fbff" />
+    <path d="M84 64c7 4 14 4 20 0 0 7-5 14-10 14s-10-7-10-14z" fill="#101622" opacity="0.65" />
+    <path d="M58 152c14 12 48 12 62 0l-12 24c-14 6-24 6-38 0z" fill="#160d12" />
+    <path d="M150 22 170 4c4 8-2 22-12 30l-28 24-10-10z" fill="url(#captain-axe)" />
+    <path d="M42 22 22 4C18 12 24 26 34 34l28 24 10-10z" fill="url(#captain-axe)" />
+    <path d="M166 40 150 52l6 8 20-16z" fill="url(#captain-glow)" />
+    <path d="M14 40 30 52l-6 8L4 44z" fill="url(#captain-glow)" />
+  </g>
+</svg>

--- a/assets/sprites/raider-shaman.svg
+++ b/assets/sprites/raider-shaman.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 212" role="img" aria-labelledby="title desc">
+  <title id="title">Avanto Raider Shaman</title>
+  <desc id="desc">Mystic raider shaman channeling aurora flame through a crystal staff with drifting runes.</desc>
+  <defs>
+    <linearGradient id="shaman-sky" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0" stop-color="#050811" />
+      <stop offset="0.55" stop-color="#152843" />
+      <stop offset="1" stop-color="#080d16" />
+    </linearGradient>
+    <radialGradient id="shaman-halo" cx="48%" cy="20%" r="80%">
+      <stop offset="0" stop-color="#eefbff" stop-opacity="0.95" />
+      <stop offset="0.45" stop-color="#a9ddff" stop-opacity="0.65" />
+      <stop offset="1" stop-color="#060d18" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="shaman-cloak" x1="20%" y1="0%" x2="80%" y2="100%">
+      <stop offset="0" stop-color="#4c5a75" />
+      <stop offset="1" stop-color="#1b222d" />
+    </linearGradient>
+    <linearGradient id="shaman-robe" x1="30%" y1="0%" x2="70%" y2="100%">
+      <stop offset="0" stop-color="#f6fdff" />
+      <stop offset="0.35" stop-color="#d1eaff" />
+      <stop offset="1" stop-color="#78a9dc" />
+    </linearGradient>
+    <linearGradient id="shaman-belt" x1="10%" y1="0%" x2="90%" y2="100%">
+      <stop offset="0" stop-color="#472b35" />
+      <stop offset="1" stop-color="#2a131a" />
+    </linearGradient>
+    <radialGradient id="shaman-crystal" cx="50%" cy="30%" r="50%">
+      <stop offset="0" stop-color="#9efaff" />
+      <stop offset="0.5" stop-color="#4dd5ff" />
+      <stop offset="1" stop-color="#0c385c" />
+    </radialGradient>
+    <linearGradient id="shaman-staff" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0" stop-color="#f8fdff" />
+      <stop offset="0.4" stop-color="#b3d5ff" />
+      <stop offset="1" stop-color="#e4f5ff" />
+    </linearGradient>
+    <radialGradient id="shaman-rune" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#ffc091" />
+      <stop offset="0.6" stop-color="#ff6b7f" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#f53b52" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="180" height="212" rx="20" ry="20" fill="url(#shaman-sky)" />
+  <rect width="180" height="212" fill="url(#shaman-halo)" />
+  <g transform="translate(18 10)">
+    <path d="M66 18c13-7 30-7 42 0 12 7 18 24 12 38-5 15-26 26-42 26S40 71 34 56c-6-14 1-31 12-38 12-7 27-7 38 0z" fill="#0f1827" opacity="0.78" />
+    <path d="M62 28c9-6 23-6 32 0 9 6 14 20 9 32-5 12-20 20-32 20s-26-8-31-20c-5-12-1-26 9-32z" fill="url(#shaman-cloak)" />
+    <path d="M72 40c6-4 15-4 20 0s8 12 5 18c-3 8-11 12-20 12s-17-4-20-12c-3-6-1-14 5-18z" fill="#eef7ff" opacity="0.9" />
+    <path d="M58 60c14 6 28 6 40 0l10 18c-14 20-40 22-60 0z" fill="url(#shaman-robe)" />
+    <path d="M40 74c18 20 44 20 62 0l18 16-12 40c-20 10-56 10-76 0l-12-40z" fill="url(#shaman-belt)" />
+    <path d="M56 86c10 6 20 6 30 0l12 34c-16 10-38 10-54 0z" fill="url(#shaman-robe)" />
+    <path d="M32 76c-8 8-16 26-14 38 2 10 10 20 20 26l6-22z" fill="#20131a" />
+    <path d="M112 76c8 8 16 26 14 38-2 10-10 20-20 26l-6-22z" fill="#20131a" />
+    <path d="M28 36c-9 8-12 24-8 36 4 14 18 22 28 18l-12-20c-2-9 0-20 4-28 4-6 8-12 14-14-10-2-20 0-26 8z" fill="#0d1520" />
+    <path d="M116 36c9 8 12 24 8 36-4 14-18 22-28 18l12-20c2-9 0-20-4-28-4-6-8-12-14-14 10-2 20 0 26 8z" fill="#0d1520" />
+    <path d="M42 110c-6 16-8 34-6 46 12 8 54 10 74 0 2-12 0-30-6-46-18 12-44 12-62 0z" fill="#0d090f" opacity="0.9" />
+    <path d="M34 164c20 8 64 8 84 0l-6 14c-24 10-48 10-72 0z" fill="#050407" opacity="0.85" />
+    <path d="M-6 96c0 4 10 12 20 16 7 2 12 2 14 0l6-10-20-12c-8-2-18 2-20 6z" fill="#1f2430" />
+    <path d="M144 96c0 4-10 12-20 16-7 2-12 2-14 0l-6-10 20-12c8-2 18 2 20 6z" fill="#1f2430" />
+    <path d="M-4 86c-2 8 4 14 14 18 6 2 14 4 18 0s4-10-2-12c-10-4-20-10-30-6z" fill="url(#shaman-staff)" transform="rotate(-10 16 96)" />
+    <path d="M148 86c2 8-4 14-14 18-6 2-14 4-18 0s-4-10 2-12c10-4 20-10 30-6z" fill="url(#shaman-staff)" transform="rotate(10 128 96)" />
+    <path d="M80 48c3-5 9-5 12 0 2 4 0 8-6 8s-8-4-6-8z" fill="#f3fbff" />
+    <path d="M92 48c3-5 9-5 12 0 2 4 0 8-6 8s-8-4-6-8z" fill="#f3fbff" />
+    <path d="M82 60c6 4 12 4 16 0 0 6-4 10-8 10s-8-4-8-10z" fill="#101622" opacity="0.6" />
+    <path d="M50 144c12 10 40 10 52 0l-10 20c-12 4-20 4-32 0z" fill="#170c12" />
+    <path d="M130 8c8 0 18 6 20 14-14 12-26 26-34 42l-12-6z" fill="url(#shaman-staff)" />
+    <circle cx="140" cy="12" r="12" fill="url(#shaman-crystal)" />
+    <path d="M22 8C14 8 4 14 2 22c14 12 26 26 34 42l12-6z" fill="url(#shaman-staff)" />
+    <circle cx="12" cy="12" r="10" fill="url(#shaman-crystal)" />
+  </g>
+  <g opacity="0.8">
+    <circle cx="32" cy="170" r="8" fill="url(#shaman-rune)" />
+    <circle cx="150" cy="160" r="6" fill="url(#shaman-rune)" />
+    <circle cx="120" cy="186" r="5" fill="url(#shaman-rune)" />
+  </g>
+</svg>

--- a/assets/sprites/raider.svg
+++ b/assets/sprites/raider.svg
@@ -1,5 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" fill="#8b0000" />
-  <line x1="18" y1="18" x2="46" y2="46" stroke="#fff" stroke-width="4" />
-  <line x1="46" y1="18" x2="18" y2="46" stroke="#fff" stroke-width="4" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 176 198" role="img" aria-labelledby="title desc">
+  <title id="title">Avanto Raider</title>
+  <desc id="desc">Final production illustration of an Avanto raider cloaked in aurora-lit pelts with twin ice hatchets and drifting embers.</desc>
+  <defs>
+    <linearGradient id="raider-aurora" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0" stop-color="#0a0f1a" />
+      <stop offset="0.55" stop-color="#12243b" />
+      <stop offset="1" stop-color="#0d111c" />
+    </linearGradient>
+    <radialGradient id="raider-halo" cx="50%" cy="18%" r="80%">
+      <stop offset="0" stop-color="#d7f4ff" stop-opacity="0.9" />
+      <stop offset="0.45" stop-color="#8ecbff" stop-opacity="0.55" />
+      <stop offset="1" stop-color="#091020" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="raider-fur" x1="20%" y1="10%" x2="80%" y2="90%">
+      <stop offset="0" stop-color="#4f5d74" />
+      <stop offset="1" stop-color="#202633" />
+    </linearGradient>
+    <linearGradient id="raider-armor" x1="30%" y1="0%" x2="70%" y2="100%">
+      <stop offset="0" stop-color="#f3fcff" />
+      <stop offset="0.35" stop-color="#c5e5ff" />
+      <stop offset="1" stop-color="#6fa1d6" />
+    </linearGradient>
+    <linearGradient id="raider-leather" x1="15%" y1="0%" x2="85%" y2="100%">
+      <stop offset="0" stop-color="#443137" />
+      <stop offset="1" stop-color="#261317" />
+    </linearGradient>
+    <linearGradient id="raider-steel" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0" stop-color="#f8feff" />
+      <stop offset="0.5" stop-color="#b4d7ff" />
+      <stop offset="1" stop-color="#e5f4ff" />
+    </linearGradient>
+    <radialGradient id="raider-ember" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#ffb36b" />
+      <stop offset="0.6" stop-color="#ff7058" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#f53b52" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="176" height="198" rx="18" ry="18" fill="url(#raider-aurora)" />
+  <rect width="176" height="198" fill="url(#raider-halo)" />
+  <g transform="translate(20 8)">
+    <path d="M62 10c12-6 28-6 38 0 11 6 16 22 11 36-6 17-27 30-41 30S35 63 30 46c-4-14 3-30 14-36 10-6 23-6 32 0z" fill="#0d1624" opacity="0.75" />
+    <path d="M58 22c9-6 23-6 31 0 9 6 12 20 8 31-5 12-20 21-31 21S39 65 34 53c-4-11-1-25 8-31z" fill="url(#raider-fur)" />
+    <path d="M66 35c6-4 15-4 21 0 7 4 9 13 6 21-3 8-13 14-21 14s-17-6-20-14c-3-8-1-17 6-21z" fill="#e6f4ff" opacity="0.85" />
+    <path d="M58 62c14 6 27 6 38 0l8 18c-14 20-40 22-56 0l10-18z" fill="url(#raider-armor)" />
+    <path d="M38 78c18 20 44 20 62 0l18 14-12 38c-20 8-53 8-74 0L20 92z" fill="url(#raider-leather)" />
+    <path d="M54 86c9 4 19 4 28 0l12 34c-15 10-36 10-52 0l12-34z" fill="url(#raider-armor)" />
+    <path d="M30 76c-9 6-18 26-16 38 2 10 12 20 22 24l8-24z" fill="#2e1d22" />
+    <path d="M108 76c9 6 18 26 16 38-2 10-12 20-22 24l-8-24z" fill="#2e1d22" />
+    <path d="M22 24c-8 6-12 22-8 34 4 14 18 22 28 18l-12-20c-2-8 0-20 4-26s6-10 12-12c-10-2-18 0-24 6z" fill="#101725" />
+    <path d="M116 24c8 6 12 22 8 34-4 14-18 22-28 18l12-20c2-8 0-20-4-26s-6-10-12-12c10-2 18 0 24 6z" fill="#101725" />
+    <path d="M38 110c-6 16-8 34-6 46 12 8 54 10 74 0 2-12 0-30-6-46-18 12-44 12-62 0z" fill="#110b13" opacity="0.85" />
+    <path d="M30 160c20 8 66 8 86 0l-4 12c-26 10-52 10-78 0z" fill="#070608" opacity="0.8" />
+    <path d="M2 104c-1 2 8 10 18 14 7 4 12 4 14 2l6-10-20-12c-8-4-16 0-18 6z" fill="#1d242f" />
+    <path d="M142 104c1 2-8 10-18 14-7 4-12 4-14 2l-6-10 20-12c8-4 16 0 18 6z" fill="#1d242f" />
+    <path d="M0 96c-2 6 4 12 12 16 6 2 13 4 19 0s6-10 0-12c-10-4-22-10-31-4z" fill="url(#raider-steel)" transform="rotate(-6 20 104)" />
+    <path d="M144 96c2 6-4 12-12 16-6 2-13 4-19 0s-6-10 0-12c10-4 22-10 31-4z" fill="url(#raider-steel)" transform="rotate(6 124 104)" />
+    <g fill="#f1fbff" opacity="0.92">
+      <path d="M70 48c2-4 6-4 8 0 1 3-1 6-4 6s-5-3-4-6z" />
+      <path d="M88 48c2-4 6-4 8 0 1 3-1 6-4 6s-5-3-4-6z" />
+    </g>
+    <path d="M74 60c6 4 12 4 16 0 0 6-4 12-8 12s-8-6-8-12z" fill="#101725" opacity="0.65" />
+    <path d="M52 140c12 10 40 10 52 0l-10 20c-12 4-20 4-32 0z" fill="#1a1016" />
+  </g>
+  <g opacity="0.8">
+    <circle cx="34" cy="164" r="8" fill="url(#raider-ember)" />
+    <circle cx="142" cy="154" r="6" fill="url(#raider-ember)" />
+    <circle cx="112" cy="174" r="5" fill="url(#raider-ember)" />
+  </g>
 </svg>

--- a/src/game/assets.ts
+++ b/src/game/assets.ts
@@ -5,6 +5,9 @@ import mine from '../../assets/sprites/mine.svg';
 import soldier from '../../assets/sprites/soldier.svg';
 import archer from '../../assets/sprites/archer.svg';
 import avantoMarauder from '../../assets/sprites/avanto-marauder.svg';
+import raider from '../../assets/sprites/raider.svg';
+import raiderCaptain from '../../assets/sprites/raider-captain.svg';
+import raiderShaman from '../../assets/sprites/raider-shaman.svg';
 import saunojaGuardian from '../../assets/sprites/saunoja-guardian.svg';
 import saunojaSeer from '../../assets/sprites/saunoja-seer.svg';
 import { ARTOCOIN_CREST_PNG_DATA_URL } from '../media/artocoinCrest.ts';
@@ -32,6 +35,10 @@ export const assetPaths: AssetPaths = {
     'unit-soldier': soldier,
     'unit-archer': archer,
     'unit-avanto-marauder': avantoMarauder,
+    'unit-marauder': avantoMarauder,
+    'unit-raider': raider,
+    'unit-raider-captain': raiderCaptain,
+    'unit-raider-shaman': raiderShaman,
     'unit-saunoja-guardian': saunojaGuardian,
     'unit-saunoja-seer': saunojaSeer,
     'icon-sauna-beer': uiIcons.saunaBeer,

--- a/src/render/units/draw.test.ts
+++ b/src/render/units/draw.test.ts
@@ -108,6 +108,27 @@ describe('unit sprite placement', () => {
         nudge: { x: 0, y: -0.03 }
       },
       {
+        type: 'raider',
+        nativeSize: { width: 176, height: 198 },
+        anchor: { x: 0.5, y: 0.832 },
+        scale: { x: 1.524, y: 1.47 },
+        nudge: { x: 0, y: -0.028 }
+      },
+      {
+        type: 'raider-captain',
+        nativeSize: { width: 184, height: 206 },
+        anchor: { x: 0.5, y: 0.838 },
+        scale: { x: 1.598, y: 1.556 },
+        nudge: { x: 0, y: -0.034 }
+      },
+      {
+        type: 'raider-shaman',
+        nativeSize: { width: 180, height: 212 },
+        anchor: { x: 0.5, y: 0.842 },
+        scale: { x: 1.548, y: 1.532 },
+        nudge: { x: 0, y: -0.036 }
+      },
+      {
         type: 'saunoja-guardian',
         nativeSize: { width: 160, height: 176 },
         anchor: { x: 0.5, y: 0.806 },
@@ -131,5 +152,11 @@ describe('unit sprite placement', () => {
       expect(meta.scale.y).toBeCloseTo(scale.y, 6);
       expect(meta.nudge).toEqual(nudge);
     }
+  });
+
+  it('shares metadata between legacy marauder aliases', () => {
+    const primary = getUnitSpriteMetadata('avanto-marauder');
+    const legacy = getUnitSpriteMetadata('marauder');
+    expect(legacy).toBe(primary);
   });
 });

--- a/src/render/units/sprite_map.ts
+++ b/src/render/units/sprite_map.ts
@@ -19,6 +19,10 @@ export interface UnitSpriteMetadata {
 
 type UnitSpriteId =
   | UnitArchetypeId
+  | 'marauder'
+  | 'raider'
+  | 'raider-captain'
+  | 'raider-shaman'
   | 'saunoja'
   | 'saunoja-guardian'
   | 'saunoja-seer'
@@ -29,6 +33,13 @@ const DEFAULT_SPRITE: UnitSpriteMetadata = {
   anchor: { x: 0.5, y: 0.92 },
   scale: { x: 1, y: 1 },
   nudge: { x: 0, y: -0.05 }
+};
+
+const AVANTO_MARAUDER_META: UnitSpriteMetadata = {
+  nativeSize: { width: 176, height: 196 },
+  anchor: { x: 0.5, y: 0.836 },
+  scale: { x: 1.5553109292455225, y: 1.5 },
+  nudge: { x: 0, y: -0.03 }
 };
 
 export const UNIT_SPRITE_MAP: Record<UnitSpriteId, UnitSpriteMetadata> = {
@@ -45,11 +56,25 @@ export const UNIT_SPRITE_MAP: Record<UnitSpriteId, UnitSpriteMetadata> = {
     scale: { x: 1.4510532031494585, y: 1.40625 },
     nudge: { x: 0, y: -0.015 }
   },
-  'avanto-marauder': {
-    nativeSize: { width: 176, height: 196 },
-    anchor: { x: 0.5, y: 0.836 },
-    scale: { x: 1.5553109292455225, y: 1.5 },
-    nudge: { x: 0, y: -0.03 }
+  'avanto-marauder': AVANTO_MARAUDER_META,
+  marauder: AVANTO_MARAUDER_META,
+  raider: {
+    nativeSize: { width: 176, height: 198 },
+    anchor: { x: 0.5, y: 0.832 },
+    scale: { x: 1.524, y: 1.47 },
+    nudge: { x: 0, y: -0.028 }
+  },
+  'raider-captain': {
+    nativeSize: { width: 184, height: 206 },
+    anchor: { x: 0.5, y: 0.838 },
+    scale: { x: 1.598, y: 1.556 },
+    nudge: { x: 0, y: -0.034 }
+  },
+  'raider-shaman': {
+    nativeSize: { width: 180, height: 212 },
+    anchor: { x: 0.5, y: 0.842 },
+    scale: { x: 1.548, y: 1.532 },
+    nudge: { x: 0, y: -0.036 }
   },
   saunoja: {
     nativeSize: { width: 128, height: 128 },


### PR DESCRIPTION
## Summary
- replace the placeholder raider SVG with the final art drop and add captain and shaman variants from the art team
- register the new sprites with the asset loader and expand the unit sprite map so each variant has tuned anchors, scale, and legacy marauder aliasing
- lock renderer metadata coverage for the new units and document the art drop in the changelog

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d13207411883309cf5c76ae63aae26