### PR TITLE
Support enemy unit selections in HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Route the battlefield selection overlay through unit identifiers so enemy
+  clicks stream polished payloads into the mini HUD: add a unit-driven
+  selection builder, teach the canvas handler to surface hostile focus, keep the
+  FX status frame syncing across sources, and expand Vitest coverage to lock the
+  enemy show/hide flow.
+
 - Carve the command dock into explicit tab and action slots, mount the stash
   panel inside a dedicated bottom-tab pane alongside roster and policies,
   restyle the dock with deeper glassmorphic gradients, and update roster plus

--- a/tests/ui/selectionMiniHud.test.tsx
+++ b/tests/ui/selectionMiniHud.test.tsx
@@ -132,6 +132,46 @@ describe('SelectionMiniHud integration', () => {
     expect(entry?.dataset.visible).toBe('true');
   });
 
+  it('renders and clears an enemy selection payload', () => {
+    const payload: UnitSelectionPayload = {
+      id: 'raider-7',
+      name: 'Frost Raider',
+      faction: 'enemy',
+      coord: { q: -1, r: 2 },
+      hp: 20,
+      maxHp: 24,
+      shield: 0,
+      items: [],
+      statuses: []
+    } satisfies UnitSelectionPayload;
+
+    manager.setSelection(payload);
+    manager.beginStatusFrame();
+    manager.pushUnitStatus({
+      id: 'raider-7',
+      world: { x: 196, y: 256 },
+      radius: 22,
+      hp: 20,
+      maxHp: 24,
+      shield: 0,
+      faction: 'enemy'
+    });
+    manager.commitStatusFrame();
+    manager.step(0);
+
+    const card = overlay.querySelector('.ui-selection-mini-hud__card') as HTMLElement | null;
+    expect(card).toBeTruthy();
+    expect(card?.querySelector('.ui-selection-mini-hud__faction')?.textContent).toBe('ENEMY');
+
+    manager.setSelection(null);
+    manager.beginStatusFrame();
+    manager.commitStatusFrame();
+    manager.step(0);
+
+    const entry = overlay.querySelector('.ui-selection-mini-hud') as HTMLElement | null;
+    expect(entry?.dataset.visible).toBe('false');
+  });
+
   it('hides the card when selection clears', () => {
     const payload: UnitSelectionPayload = {
       id: 'attendant-2',


### PR DESCRIPTION
## Summary
- add a unit-backed selection payload helper and track the currently selected unit id so the FX manager can render enemies
- teach the canvas click flow to focus enemies discovered through `unitsById` and keep the HUD in sync when units disappear
- extend the selection mini HUD integration test to cover rendering and clearing an enemy payload

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d15a7ef9f08330a3faedc91cef70fc