### PR TITLE
Relax sprite transform parsing and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Relax the sprite transform parser to accept whitespace-separated translate
+  and scale values, cover the `parseTransform` helper with Vitest to lock in
+  the tolerant spacing, and refresh the generated sprite manifest to confirm
+  the broadened parsing behaves identically.
+
 - Move the sprite export helper into `tools/export-sprites.ts`, extend it to
   rasterize polished 64×64 PNG outputs (including 2× retina variants) into
   `public/sprites/`, and update the docs plus npm script so art drops ship with

--- a/assets/sprites/manifest.json
+++ b/assets/sprites/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-22T17:42:24.328Z",
+  "generatedAt": "2025-09-22T18:10:47.605Z",
   "sprites": [
     {
       "id": "archer",

--- a/tests/tools/export-sprites.test.ts
+++ b/tests/tools/export-sprites.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { parseTransform } from '../../tools/export-sprites';
+
+describe('parseTransform', () => {
+  it('parses whitespace-separated translate arguments', () => {
+    const result = parseTransform('<g transform="translate(3 0)"></g>');
+
+    expect(result.translateX).toBe(3);
+    expect(result.translateY).toBe(0);
+  });
+
+  it('parses whitespace-separated scale arguments', () => {
+    const result = parseTransform('<g transform="scale(0.35 0.35)"></g>');
+
+    expect(result.scaleX).toBeCloseTo(0.35);
+    expect(result.scaleY).toBeCloseTo(0.35);
+  });
+});

--- a/tools/export-sprites.ts
+++ b/tools/export-sprites.ts
@@ -47,7 +47,7 @@ function parseViewBox(content: string, id: string): SpriteCanvasSize {
   };
 }
 
-function parseTransform(content: string): SpriteTransform {
+export function parseTransform(content: string): SpriteTransform {
   const defaultTransform: SpriteTransform = {
     translateX: 0,
     translateY: 0,
@@ -61,8 +61,8 @@ function parseTransform(content: string): SpriteTransform {
   }
 
   const transform = match[1];
-  const translateMatch = transform.match(/translate\(\s*([\d.-]+)\s*,\s*([\d.-]+)\s*\)/);
-  const scaleMatch = transform.match(/scale\(\s*([\d.-]+)(?:\s*,\s*([\d.-]+))?\s*\)/);
+  const translateMatch = transform.match(/translate\(\s*([\d.-]+)[,\s]+([\d.-]+)\s*\)/);
+  const scaleMatch = transform.match(/scale\(\s*([\d.-]+)(?:[,\s]+([\d.-]+))?\s*\)/);
 
   const translateX = translateMatch ? Number(translateMatch[1]) : 0;
   const translateY = translateMatch ? Number(translateMatch[2]) : 0;


### PR DESCRIPTION
## Summary
- allow the sprite export helper to parse translate/scale arguments separated by spaces or commas
- add a focused Vitest suite that exercises whitespace-separated translate and scale declarations
- regenerate the sprite manifest and document the parser update in the changelog

## Testing
- `npx vitest run tests/tools/export-sprites.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d190b551408330877a733ef22e9ee6