### PR TITLE
Ensure sprite manifest writes wait for PNG export success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Harden the sprite export pipeline so PNG rasterization finishes before the
+  manifest updates, keeping the JSON and bitmap artifacts synchronized when the
+  helper runs via `npm run export:sprites`.
+
 - Relax the sprite transform parser to accept whitespace-separated translate
   and scale values, cover the `parseTransform` helper with Vitest to lock in
   the tolerant spacing, and refresh the generated sprite manifest to confirm

--- a/assets/sprites/manifest.json
+++ b/assets/sprites/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-22T18:10:47.605Z",
+  "generatedAt": "2025-09-22T18:16:29.111Z",
   "sprites": [
     {
       "id": "archer",

--- a/tools/export-sprites.ts
+++ b/tools/export-sprites.ts
@@ -205,14 +205,14 @@ async function main(): Promise<void> {
 
   try {
     const entries = await loadSprites(spriteDir);
-    await writeManifest(manifestPath, entries);
     await exportSpritePngs(entries, spriteDir, pngOutputDir);
+    await writeManifest(manifestPath, entries);
 
     console.log(
-      `Exported ${entries.length} sprite definitions to ${path.relative(
+      `Rendered ${entries.length} sprite PNG sets in ${path.relative(
         root,
-        manifestPath
-      )} and rendered PNG sprites to ${path.relative(root, pngOutputDir)}.`
+        pngOutputDir
+      )} and updated manifest at ${path.relative(root, manifestPath)}.`
     );
   } catch (error) {
     console.error('Failed to export sprite metadata:', error);


### PR DESCRIPTION
## Summary
- render sprite PNGs before writing the manifest so failed rasterization leaves JSON untouched
- refresh the export log copy and document the safer pipeline in the changelog
- regenerate the sprite manifest timestamp via the export helper

## Testing
- npm run build
- npm run export:sprites

------
https://chatgpt.com/codex/tasks/task_e_68d1921333b48330884e0c02834a2e78