### PR TITLE
Adjust HUD grid template for medium widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Rebalance the HUD overlay grid to prioritize the combat viewport on
+  medium-width screens, swap the column template for minmax/fractional tracks,
+  and keep the roster plus dock panels legible through the 820–1024px range.
+
 - Rework the HUD overlay grid rows to auto-size the top bar and command dock,
   expose the new utility class in `src/style.css`, and verify both UI variants
   handle wrapped badges plus expanded docks without overlapping controls.

--- a/src/style.css
+++ b/src/style.css
@@ -204,8 +204,11 @@ body > #game-container {
   grid-template-rows: auto 1fr auto;
 }
 
-.grid-cols-\[280px_1fr_clamp\(260px\,32vw\,420px\)\] {
-  grid-template-columns: 280px 1fr clamp(260px, 32vw, 420px);
+.grid-cols-\[minmax\(clamp\(200px\,22vw\,280px\)\,1fr\)_minmax\(420px\,1\.6fr\)_minmax\(clamp\(200px\,24vw\,340px\)\,1fr\)\] {
+  grid-template-columns:
+    minmax(clamp(200px, 22vw, 280px), 1fr)
+    minmax(420px, 1.6fr)
+    minmax(clamp(200px, 24vw, 340px), 1fr);
 }
 
 .gap-\[clamp\(16px\,3vw\,28px\)\] {

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -51,7 +51,7 @@ const OVERLAY_GRID_CLASSES = [
   'hud-grid',
   'grid',
   'grid-rows-[auto_1fr_auto]',
-  'grid-cols-[280px_1fr_clamp(260px,32vw,420px)]',
+  'grid-cols-[minmax(clamp(200px,22vw,280px),1fr)_minmax(420px,1.6fr)_minmax(clamp(200px,24vw,340px),1fr)]',
   'gap-[clamp(16px,3vw,28px)]',
 ];
 


### PR DESCRIPTION
## Summary
- rebalance the HUD overlay grid to favor the combat viewport on 820–1024px viewports
- switch the three-column template to minmax and fractional tracks for smoother shrinking of side panels
- document the layout change in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d21dbec0e0833089abcf64d261b20e