### PR TITLE
Add Saunoja behavior coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Introduce Saunoja behavior preferences that synchronize with battlefield
+  units, persist through reloads, and default to defend/attack routines based on
+  faction alignment.
+
 - Rebalance the HUD overlay grid to prioritize the combat viewport on
   medium-width screens, swap the column template for minmax/fractional tracks,
   and keep the roster plus dock panels legible through the 820–1024px range.

--- a/src/units/Unit.test.ts
+++ b/src/units/Unit.test.ts
@@ -36,3 +36,35 @@ describe('Unit combat keywords', () => {
   });
 });
 
+describe('Unit behavior', () => {
+  it('defaults to defend for player-controlled units', () => {
+    const stats = { health: 12, attackDamage: 3, attackRange: 1, movementRange: 1 };
+    const unit = new Unit('player-behavior', 'soldier', { ...BASE_COORD }, 'player', stats);
+    expect(unit.getBehavior()).toBe('defend');
+  });
+
+  it('defaults to attack for non-player factions', () => {
+    const stats = { health: 10, attackDamage: 4, attackRange: 1, movementRange: 1 };
+    const foe = new Unit('enemy-behavior', 'soldier', { ...BASE_COORD }, 'enemy', stats);
+    const neutral = new Unit('neutral-behavior', 'soldier', { ...BASE_COORD }, 'neutral', stats);
+    expect(foe.getBehavior()).toBe('attack');
+    expect(neutral.getBehavior()).toBe('attack');
+  });
+
+  it('supports overriding and mutating the behavior preference', () => {
+    const stats = { health: 9, attackDamage: 2, attackRange: 1, movementRange: 1 };
+    const explorer = new Unit(
+      'explorer-behavior',
+      'scout',
+      { ...BASE_COORD },
+      'player',
+      stats,
+      [],
+      'explore'
+    );
+    expect(explorer.getBehavior()).toBe('explore');
+    explorer.setBehavior('attack');
+    expect(explorer.getBehavior()).toBe('attack');
+  });
+});
+


### PR DESCRIPTION
## Summary
- document the Saunoja behavior preference system in the changelog
- add explicit unit tests that cover default and overrideable battlefield behaviors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d220065ac88330a1ad338cc60a1814