### PR TITLE
Refine battlefield behaviors around sauna defense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Refine battlefield routines to source unit behaviors from the new helper, lock
+  defenders to the sauna perimeter unless invaders breach it, drive attackers
+  toward the latest enemy sightings or the board edge, and cover each routine
+  with focused `BattleManager` tests.
+
 - Introduce Saunoja behavior preferences that synchronize with battlefield
   units, persist through reloads, and default to defend/attack routines based on
   faction alignment.


### PR DESCRIPTION
## Summary
- route player unit behavior through the new UnitBehavior helper while keeping enemy routines unchanged
- keep defenders inside the sauna perimeter, chase invaders only when they breach it, and steer attackers toward the latest enemy foothold or board edge
- extend BattleManager coverage for defend, attack, and explore routines and document the changes in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2278ca8b883308979859c6e453f2f