### PR TITLE
Add roster behavior controls and HUD stance display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Elevate the roster experience with stance-aware controls: display each
+  Saunoja's current behavior in the featured HUD card, add a polished
+  Defend/Attack/Explore segmented toggle to roster rows, and persist changes
+  through the right-panel handler so battlefield routines update instantly.
+
 - Refine battlefield routines to source unit behaviors from the new helper, lock
   defenders to the sauna perimeter unless invaders breach it, drive attackers
   toward the latest enemy sightings or the board edge, and cover each routine

--- a/src/style.css
+++ b/src/style.css
@@ -1716,6 +1716,14 @@ body > #game-container {
   color: color-mix(in srgb, var(--color-muted) 55%, white 45%);
 }
 
+.saunoja-card__behavior {
+  margin: 6px 0 0;
+  font-size: clamp(11px, 1.5vw, 12px);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, #38bdf8 65%, white 35%);
+}
+
 .saunoja-card__traits {
   margin: 0;
   font-size: clamp(12px, 1.6vw, 13px);
@@ -2981,6 +2989,84 @@ body > #game-container {
 
 .panel-roster__status[data-status='downed'] {
   background: color-mix(in srgb, var(--color-danger) 28%, transparent);
+}
+
+.panel-roster__behavior {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.panel-roster__behavior-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 65%, white 35%);
+}
+
+.panel-roster__behavior-value {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, #38bdf8 70%, white 30%);
+  text-shadow: 0 0 12px rgba(56, 189, 248, 0.35);
+}
+
+.panel-roster__behavior-options {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 999px;
+  background:
+    linear-gradient(135deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.64)),
+    rgba(15, 23, 42, 0.5);
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.2),
+    0 14px 26px rgba(15, 23, 42, 0.36);
+  backdrop-filter: blur(12px);
+}
+
+.panel-roster__behavior-option {
+  appearance: none;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 70%, white 30%);
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.7), rgba(15, 23, 42, 0.88));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  transition: color 150ms ease, background 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+}
+
+.panel-roster__behavior-option:is(:hover, :focus-visible) {
+  border-color: rgba(148, 163, 184, 0.6);
+  color: color-mix(in srgb, white 70%, #38bdf8 30%);
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.3),
+    0 12px 22px rgba(15, 23, 42, 0.4);
+}
+
+.panel-roster__behavior-option.is-active {
+  border-color: rgba(148, 163, 184, 0.65);
+  color: color-mix(in srgb, white 80%, #38bdf8 20%);
+  background: linear-gradient(140deg, rgba(56, 189, 248, 0.4), rgba(37, 99, 235, 0.5));
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.35),
+    0 18px 28px rgba(15, 23, 42, 0.45);
+}
+
+.panel-roster__behavior-option:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .panel-roster__meta,

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -12,6 +12,7 @@ import { subscribeToIsMobile } from './hooks/useIsMobile.ts';
 import { createRosterPanel } from './panels/RosterPanel.tsx';
 import type { RosterEntry } from './panels/RosterPanel.tsx';
 import type { EquipmentSlotId } from '../items/types.ts';
+import type { UnitBehavior } from '../unit/types.ts';
 import {
   getLogHistory,
   LOG_EVENT_META,
@@ -44,6 +45,7 @@ type RightPanelOptions = {
   onRosterRendererReady?: (renderer: (entries: RosterEntry[]) => void) => void;
   onRosterEquipSlot?: (unitId: string, slot: EquipmentSlotId) => void;
   onRosterUnequipSlot?: (unitId: string, slot: EquipmentSlotId) => void;
+  onRosterBehaviorChange?: (unitId: string, behavior: UnitBehavior) => void;
   getRosterCap?: () => number;
   getRosterCapLimit?: () => number;
   updateMaxRosterSize?: (value: number, options?: { persist?: boolean }) => number;
@@ -522,6 +524,7 @@ export function setupRightPanel(
     onSelect: onRosterSelect,
     onEquipSlot: onRosterEquipSlot,
     onUnequipSlot: onRosterUnequipSlot,
+    onBehaviorChange: options.onRosterBehaviorChange,
     getRosterCap: options.getRosterCap,
     getRosterCapLimit: options.getRosterCapLimit,
     updateMaxRosterSize: options.updateMaxRosterSize

--- a/src/ui/rosterHUD.test.ts
+++ b/src/ui/rosterHUD.test.ts
@@ -27,6 +27,7 @@ describe('rosterHUD', () => {
           name: 'Aurora Kallio',
           traits: ['Brave', 'Sage'],
           upkeep: 17,
+          behavior: 'attack',
           progression: {
             level: 4,
             xp: 700,
@@ -77,6 +78,10 @@ describe('rosterHUD', () => {
       expect(callouts?.textContent).toContain('+7 Focus');
       expect(callouts?.textContent).toContain('+5 Resolve');
 
+      const behavior = root?.querySelector('.saunoja-card__behavior');
+      expect(behavior?.textContent).toBe('Behavior: Attack');
+      expect(behavior?.title).toBe('Behavior: Attack');
+
       const traits = root?.querySelector('.saunoja-card__traits');
       expect(traits?.textContent).toBe('Brave, Sage');
       expect(traits?.title).toBe('Brave, Sage');
@@ -119,6 +124,7 @@ describe('rosterHUD', () => {
         upkeep: 12,
         status: 'reserve',
         selected: false,
+        behavior: 'defend',
         traits: [],
         stats: {
           health: 8,

--- a/src/ui/rosterHUD.ts
+++ b/src/ui/rosterHUD.ts
@@ -1,8 +1,14 @@
 import { ensureHudLayout, type HudBottomTabId } from './layout.ts';
 import type { RosterEntry, RosterProgression } from './rightPanel.tsx';
+import type { UnitBehavior } from '../unit/types.ts';
 
 const rosterCountFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 const rosterUpkeepFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
+const behaviorLabels: Record<UnitBehavior, string> = {
+  defend: 'Defend',
+  attack: 'Attack',
+  explore: 'Explore'
+};
 
 type RosterHudOptions = {
   rosterIcon: string;
@@ -15,6 +21,7 @@ export type RosterCardViewModel = {
   traits: readonly string[];
   upkeep: number;
   progression: RosterProgression;
+  behavior: UnitBehavior;
 };
 
 export type RosterHudSummary = {
@@ -181,6 +188,10 @@ export function setupRosterHUD(
   rosterCardXp.classList.add('saunoja-card__xp');
   rosterCardXp.textContent = '0 / 0 XP • 0%';
 
+  const rosterCardBehavior = document.createElement('p');
+  rosterCardBehavior.classList.add('saunoja-card__behavior');
+  rosterCardBehavior.textContent = 'Behavior: Defend';
+
   rosterCardIdentity.append(rosterCardName, rosterCardXp);
   rosterCardHeader.append(rosterCardLevel, rosterCardIdentity);
 
@@ -194,7 +205,13 @@ export function setupRosterHUD(
   const rosterCardUpkeep = document.createElement('p');
   rosterCardUpkeep.classList.add('saunoja-card__upkeep');
 
-  rosterCard.append(rosterCardHeader, rosterCardTraits, rosterCardStats, rosterCardUpkeep);
+  rosterCard.append(
+    rosterCardHeader,
+    rosterCardBehavior,
+    rosterCardTraits,
+    rosterCardStats,
+    rosterCardUpkeep
+  );
   details.appendChild(rosterCard);
   root.append(header, details);
   container.append(root);
@@ -303,6 +320,11 @@ export function setupRosterHUD(
     rosterCardStats.textContent = bonusLabel;
     rosterCardStats.title = bonusLabel;
 
+    const behaviorLabel = behaviorLabels[card.behavior] ?? card.behavior;
+    const behaviorCopy = `Behavior: ${behaviorLabel}`;
+    rosterCardBehavior.textContent = behaviorCopy;
+    rosterCardBehavior.title = behaviorCopy;
+
     const upkeepValue = Math.max(0, Math.round(card.upkeep));
     const upkeepLabel = `Upkeep: ${rosterUpkeepFormatter.format(upkeepValue)} Beer`;
     rosterCardUpkeep.textContent = upkeepLabel;
@@ -355,6 +377,7 @@ export function setupRosterHUD(
       entry.name,
       entry.upkeep,
       entry.status,
+      entry.behavior,
       entry.selected ? 1 : 0,
       entry.progression.level,
       entry.progression.xp,


### PR DESCRIPTION
## Summary
- extend roster entries with a UnitBehavior field, surface polished Defend/Attack/Explore toggles in the roster panel, and thread the callback through the right panel
- persist behavior updates by syncing Saunoja records, attached units, and the roster HUD summary while styling the controls to match existing panel glassmorphism
- expose the current stance on the roster HUD card and expand tests plus changelog coverage for the new behavior UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68d243aa7d2c8330b4be315cc2fa8599