### PR TITLE
Ensure right panel mobile drawer resets on desktop transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Smooth the command console slide-over transitions so resizing from mobile
+  closes and resets the drawer state, ensuring the body scroll lock clears and
+  the toggle mirrors the desktop collapse status.
+
 - Elevate the roster experience with stance-aware controls: display each
   Saunoja's current behavior in the featured HUD card, add a polished
   Defend/Attack/Explore segmented toggle to roster rows, and persist changes

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -260,9 +260,7 @@ export function setupRightPanel(
   };
 
   const closeMobilePanel = ({ skipFocus = false }: { skipFocus?: boolean } = {}) => {
-    if (!isMobileViewport || !isMobilePanelOpen) {
-      return;
-    }
+    const wasOpen = isMobilePanelOpen;
     resetDrag();
     isMobilePanelOpen = false;
     slideOver.classList.remove('right-panel-slide--open');
@@ -272,7 +270,7 @@ export function setupRightPanel(
     slideOver.style.setProperty('--panel-drag-progress', '0');
     refreshTogglePresentation();
     unbindMobileKeydown();
-    if (!skipFocus) {
+    if (wasOpen && !skipFocus) {
       toggle.focus({ preventScroll: true });
     }
   };
@@ -403,7 +401,6 @@ export function setupRightPanel(
       }
     } else {
       closeMobilePanel({ skipFocus: true });
-      slideOver.style.setProperty('--panel-drag-progress', '1');
       slideOver.remove();
       rightRegion.appendChild(panel);
       insertToggle();


### PR DESCRIPTION
## Summary
- allow the command console mobile drawer cleanup to run after resizing so the scroll lock, aria flags, and toggle state reset correctly
- remove the redundant slide-over progress reset when returning to desktop and document the transition fix in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2509165348330a318438e21bdcc96