### PR TITLE
Collapse HUD grid when the command console closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Collapse the command console track in the HUD grid when the desktop toggle
+  hides the panel, wiring a layout modifier class so the overlay widens the
+  center column cleanly through the 840–1040px breakpoints.
+
 - Align the stash and sauna shop drawers behind the shared
   `--inventory-panel-width`, reserve matching HUD offsets for both inventory
   overlays, and confirm the command dock stays unobstructed through the

--- a/src/style.css
+++ b/src/style.css
@@ -211,6 +211,17 @@ body > #game-container {
     minmax(clamp(200px, 24vw, 340px), 1fr);
 }
 
+#ui-overlay.hud-grid.hud-grid--right-collapsed {
+  grid-template-columns:
+    minmax(clamp(200px, 22vw, 280px), 1fr)
+    minmax(420px, 1.6fr)
+    minmax(0, 0);
+}
+
+#ui-overlay.hud-grid.hud-grid--right-collapsed [data-hud-region='right'] {
+  visibility: hidden;
+}
+
 .gap-\[clamp\(16px\,3vw\,28px\)\] {
   gap: clamp(16px, 3vw, 28px);
 }

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -47,13 +47,18 @@ export type HudLayout = {
   mobileBar: HTMLDivElement;
 };
 
-const OVERLAY_GRID_CLASSES = [
-  'hud-grid',
-  'grid',
-  'grid-rows-[auto_1fr_auto]',
-  'grid-cols-[minmax(clamp(200px,22vw,280px),1fr)_minmax(420px,1.6fr)_minmax(clamp(200px,24vw,340px),1fr)]',
-  'gap-[clamp(16px,3vw,28px)]',
-];
+const OVERLAY_GRID_CLASSES = {
+  base: [
+    'hud-grid',
+    'grid',
+    'grid-rows-[auto_1fr_auto]',
+    'grid-cols-[minmax(clamp(200px,22vw,280px),1fr)_minmax(420px,1.6fr)_minmax(clamp(200px,24vw,340px),1fr)]',
+    'gap-[clamp(16px,3vw,28px)]',
+  ],
+  collapsed: 'hud-grid--right-collapsed',
+} as const;
+
+export const HUD_OVERLAY_COLLAPSED_CLASS = OVERLAY_GRID_CLASSES.collapsed;
 
 const REGION_GRID_CLASSES: Record<keyof HudLayoutRegions, string[]> = {
   top: ['col-span-3', 'row-span-1', 'row-start-1'],
@@ -171,7 +176,7 @@ function applyVariantClasses(
   isUiV2: boolean
 ): void {
   if (isUiV2) {
-    overlay.classList.add(...OVERLAY_GRID_CLASSES);
+    overlay.classList.add(...OVERLAY_GRID_CLASSES.base);
     for (const [name, classes] of Object.entries(REGION_GRID_CLASSES) as Array<[
       keyof HudLayoutRegions,
       string[]
@@ -179,7 +184,8 @@ function applyVariantClasses(
       regions[name].classList.add(...classes);
     }
   } else {
-    overlay.classList.remove(...OVERLAY_GRID_CLASSES);
+    overlay.classList.remove(...OVERLAY_GRID_CLASSES.base);
+    overlay.classList.remove(OVERLAY_GRID_CLASSES.collapsed);
     for (const [name, classes] of Object.entries(REGION_GRID_CLASSES) as Array<[
       keyof HudLayoutRegions,
       string[]

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -7,7 +7,11 @@ import {
   type SchedulerEventContent,
   type SchedulerTriggeredPayload
 } from '../events';
-import { ensureHudLayout, type HudBottomTabId } from './layout.ts';
+import {
+  ensureHudLayout,
+  HUD_OVERLAY_COLLAPSED_CLASS,
+  type HudBottomTabId,
+} from './layout.ts';
 import { subscribeToIsMobile } from './hooks/useIsMobile.ts';
 import { createRosterPanel } from './panels/RosterPanel.tsx';
 import type { RosterEntry } from './panels/RosterPanel.tsx';
@@ -211,6 +215,7 @@ export function setupRightPanel(
     const shouldCollapse = collapsed && matches;
     isCollapsed = shouldCollapse;
     panel.classList.toggle('right-panel--collapsed', shouldCollapse);
+    overlay.classList.toggle(HUD_OVERLAY_COLLAPSED_CLASS, shouldCollapse);
     panel.setAttribute('aria-hidden', shouldCollapse ? 'true' : 'false');
     refreshTogglePresentation();
     if (wasCollapsed && !shouldCollapse && matches) {
@@ -394,6 +399,7 @@ export function setupRightPanel(
       mobileBar.appendChild(toggle);
       toggle.classList.add('hud-panel-toggle--mobile');
       toggle.hidden = false;
+      overlay.classList.remove(HUD_OVERLAY_COLLAPSED_CLASS);
       if (!isMobilePanelOpen) {
         panel.setAttribute('aria-hidden', 'true');
         slideOver.setAttribute('aria-hidden', 'true');
@@ -1000,6 +1006,7 @@ export function setupRightPanel(
     slideOver.remove();
     toggle.remove();
     panel.remove();
+    overlay.classList.remove(HUD_OVERLAY_COLLAPSED_CLASS);
   };
 
   return {


### PR DESCRIPTION
## Summary
- add a dedicated modifier class for the HUD overlay so collapsing the command console updates the layout root
- expose the collapsed modifier from the layout helper and ensure mobile teardown clears the class
- adjust the grid styling to zero out the right column and hide its region when the console is collapsed, and document the change in the changelog

## Testing
- npm run build
- Verified the command console collapse at a 900px viewport to confirm the center column widens

------
https://chatgpt.com/codex/tasks/task_e_68d261b67d988330bb3691f17f897fa5