### PR TITLE
Refactor stash drawer mounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Float the stash drawer alongside the command dock so its fixed overlay can
+  cover the viewport, leave a screen-reader proxy in the stash tab, and confirm
+  the dock chrome stays pristine while the drawer opens at full height.
+
 - Collapse the command console track in the HUD grid when the desktop toggle
   hides the panel, wiring a layout modifier class so the overlay widens the
   center column cleanly through the 840–1040px breakpoints.


### PR DESCRIPTION
## Summary
- mount the inventory stash drawer alongside the command dock so its fixed panel can cover the viewport without clipping
- leave an sr-only proxy message inside the stash tab, synchronize aria attributes, and restore them on teardown
- document the relocation in the changelog

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d2646f86cc8330b12ead23a3881b59