### PR TITLE
Adjust battle targeting by behavior

### DIFF
--- a/src/ai/Targeting.test.ts
+++ b/src/ai/Targeting.test.ts
@@ -59,4 +59,31 @@ describe('Targeting', () => {
     const target = Targeting.selectTarget(attacker, [attacker, enemy1, enemy2]);
     expect(target?.id).toBe('c');
   });
+
+  it('applies custom filters before evaluating priorities', () => {
+    const attacker = createUnit('a', { q: 0, r: 0 }, 'A', {
+      health: 10,
+      attackDamage: 1,
+      attackRange: 3,
+      movementRange: 0
+    }, ['B']);
+    const enemyNear = createUnit('b', { q: 1, r: 0 }, 'B', {
+      health: 5,
+      attackDamage: 0,
+      attackRange: 0,
+      movementRange: 0
+    });
+    const enemyFar = createUnit('c', { q: 3, r: 0 }, 'C', {
+      health: 1,
+      attackDamage: 0,
+      attackRange: 0,
+      movementRange: 0
+    });
+
+    const target = Targeting.selectTarget(attacker, [attacker, enemyNear, enemyFar], (enemy) =>
+      attacker.distanceTo(enemy.coord) <= 1
+    );
+
+    expect(target?.id).toBe('b');
+  });
 });

--- a/src/ai/Targeting.ts
+++ b/src/ai/Targeting.ts
@@ -5,10 +5,17 @@ export class Targeting {
   /**
    * Select an enemy target for a unit based on faction priorities, range and distance.
    */
-  static selectTarget(unit: Unit, units: Unit[]): Unit | null {
+  static selectTarget(
+    unit: Unit,
+    units: Unit[],
+    predicate?: (enemy: Unit) => boolean
+  ): Unit | null {
     let enemies = units.filter(
       (u) => u.faction !== unit.faction && !u.isDead()
     );
+    if (predicate) {
+      enemies = enemies.filter(predicate);
+    }
     if (enemies.length === 0) {
       return null;
     }
@@ -26,7 +33,13 @@ export class Targeting {
       (e) => unit.distanceTo(e.coord) <= unit.stats.attackRange
     );
     if (inRange.length > 0) {
-      inRange.sort((a, b) => a.stats.health - b.stats.health);
+      inRange.sort((a, b) => {
+        const healthDiff = a.stats.health - b.stats.health;
+        if (healthDiff !== 0) {
+          return healthDiff;
+        }
+        return unit.distanceTo(a.coord) - unit.distanceTo(b.coord);
+      });
       return inRange[0];
     }
 


### PR DESCRIPTION
## Summary
- defer target selection until after resolving unit behavior and filter defenders and explorers based on perimeter and vision range
- add a helper for behavior-aware targeting and extend Targeting to accept custom predicates while preserving prioritization
- expand battle manager tests for explorer/attacker behavior and cover predicate handling in targeting

## Testing
- `npm run build`
- `npm run test` *(fails: src/ui/inventoryHud.test.ts > setupInventoryHud > keeps the overlay interactive when focusing the panel throws)*

------
https://chatgpt.com/codex/tasks/task_e_68d267b67e988330bf130d3ce4e62047