### PR TITLE
Handle deferred terrain icon rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Refresh terrain icon rendering by emitting load-completion events from the
+  icon cache, letting the terrain renderer mark affected chunks dirty so freshly
+  loaded art appears during the first frame of a cold start.
+
 - Float the stash drawer alongside the command dock so its fixed overlay can
   cover the viewport, leave a screen-reader proxy in the stash tab, and confirm
   the dock chrome stays pristine while the drawer opens at full height.


### PR DESCRIPTION
## Summary
- emit icon-ready notifications from the shared loader and expose a subscription helper
- teach the terrain cache to track icon usage per chunk and rerender once art finishes loading
- note the terrain icon loading improvement in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d28f56aae4833082a21a91e7a8296d