### PR TITLE
Mount stash drawer overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
   icon cache, letting the terrain renderer mark affected chunks dirty so freshly
   loaded art appears during the first frame of a cold start.
 
-- Float the stash drawer alongside the command dock so its fixed overlay can
-  cover the viewport, leave a screen-reader proxy in the stash tab, and confirm
-  the dock chrome stays pristine while the drawer opens at full height.
+- Mount the stash drawer on the overlay instead of the command dock anchor so
+  its fixed panel spans the viewport, keep a screen-reader proxy in the stash
+  tab, and confirm the dock chrome stays pristine while the drawer opens at
+  full height.
 
 - Collapse the command console track in the HUD grid when the desktop toggle
   hides the panel, wiring a layout modifier class so the overlay widens the

--- a/src/ui/inventoryHud.ts
+++ b/src/ui/inventoryHud.ts
@@ -226,8 +226,6 @@ export function setupInventoryHud(
     stashButton.setAttribute('aria-controls', controlTargets);
   }
 
-  const dockParent = anchors.commandDock.parentElement ?? overlay;
-
   const rosterHudPanel = tabs.panels.roster;
 
   const dispatchRosterEvent = (type: 'expand' | 'collapse' | 'toggle'): void => {
@@ -433,11 +431,12 @@ export function setupInventoryHud(
   if (stashButtonLabelId) {
     panel.element.setAttribute('aria-labelledby', stashButtonLabelId);
   }
-  const dockSibling = anchors.commandDock.nextSibling;
-  if (dockSibling && dockSibling.parentElement === dockParent) {
-    dockParent.insertBefore(panel.element, dockSibling);
+  const layoutRoot = overlay.querySelector<HTMLElement>('[data-hud-root]');
+  const stashMountTarget = layoutRoot?.parentElement ?? overlay;
+  if (layoutRoot && layoutRoot.parentElement === stashMountTarget) {
+    stashMountTarget.insertBefore(panel.element, layoutRoot.nextSibling);
   } else {
-    dockParent.appendChild(panel.element);
+    stashMountTarget.appendChild(panel.element);
   }
 
   let collection: InventoryCollection = 'stash';


### PR DESCRIPTION
## Summary
- mount the inventory stash drawer on the overlay instead of the command dock anchor so the fixed panel can span the viewport while keeping the screen-reader proxy and aria wiring intact
- document the stash drawer relocation in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d294318f1c8330ab39fd9a43b4823a