### PR TITLE
Handle deferred terrain icon rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-- Refresh terrain icon rendering by emitting load-completion events from the
-  icon cache, letting the terrain renderer mark affected chunks dirty so freshly
-  loaded art appears during the first frame of a cold start.
+- Refresh terrain icon rendering by queuing load-completion events from the
+  icon cache, tracking pending images so cached assets still notify listeners,
+  and covering the terrain renderer with a Vitest case that dirties affected
+  chunks to draw freshly decoded art on the first cold frame.
 
 - Mount the stash drawer on the overlay instead of the command dock anchor so
   its fixed panel spans the viewport, keep a screen-reader proxy in the stash

--- a/src/render/terrain_cache.test.ts
+++ b/src/render/terrain_cache.test.ts
@@ -3,6 +3,7 @@ import { HexMap } from '../hexmap.ts';
 import { TerrainCache } from './terrain_cache.ts';
 import { ensureChunksPopulated } from '../map/hex/chunking.ts';
 import { axialToPixel } from '../hex/HexUtils.ts';
+import { clearIconCache } from './loadIcon.ts';
 
 function createStubContext(drawImage: ReturnType<typeof vi.fn>) {
   const gradient = { addColorStop: vi.fn() };
@@ -85,4 +86,181 @@ describe('TerrainCache', () => {
       createElementSpy.mockRestore();
     }
   });
+
+  it('marks affected chunks dirty once terrain icons finish loading', async () => {
+    clearIconCache();
+    const map = new HexMap(1, 1);
+    const tile = map.ensureTile(0, 0);
+    tile.reveal();
+
+    const createdImages: FakeImage[] = [];
+    const originalImage = global.Image;
+    const FakeImageCtor = createFakeImageConstructor(createdImages);
+    (globalThis as unknown as { Image: typeof Image }).Image = FakeImageCtor;
+
+    const drawImage = vi.fn();
+    const ctx = createStubContext(drawImage);
+    const originalCreateElement = document.createElement;
+    const offscreenCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ctx),
+    } as unknown as HTMLCanvasElement;
+
+    const createElementSpy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation((tagName: string) => {
+        if (tagName === 'canvas') {
+          offscreenCanvas.width = 0;
+          offscreenCanvas.height = 0;
+          return offscreenCanvas;
+        }
+        return originalCreateElement.call(document, tagName);
+      });
+
+    let cache: TerrainCache | undefined;
+    try {
+      cache = new TerrainCache(map);
+      const range = { qMin: 0, qMax: 0, rMin: 0, rMax: 0 };
+      ensureChunksPopulated(map, range);
+      const origin = axialToPixel({ q: map.minQ, r: map.minR }, map.hexSize);
+      const images = {
+        'building-farm': originalCreateElement.call(document, 'img') as HTMLImageElement,
+        'building-barracks': originalCreateElement.call(document, 'img') as HTMLImageElement,
+        placeholder: originalCreateElement.call(document, 'img') as HTMLImageElement,
+      };
+
+      const chunks = cache.getRenderableChunks(range, map.hexSize, images, origin);
+      expect(chunks).toHaveLength(1);
+
+      const chunkKey = chunks[0]!.key;
+      expect(createdImages.length).toBeGreaterThan(0);
+      expect((cache as unknown as { dirtyChunks: Set<string> }).dirtyChunks.has(chunkKey)).toBe(
+        false
+      );
+
+      createdImages[0]!.triggerLoad();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect((cache as unknown as { dirtyChunks: Set<string> }).dirtyChunks.has(chunkKey)).toBe(
+        true
+      );
+
+    } finally {
+      cache?.dispose();
+      createElementSpy.mockRestore();
+      (globalThis as unknown as { Image: typeof Image }).Image = originalImage;
+      clearIconCache();
+    }
+  });
 });
+
+type FakeImageListener = (event: Event) => void;
+
+interface FakeImageHandler {
+  listener: FakeImageListener;
+  once: boolean;
+}
+
+class FakeImage {
+  complete = false;
+  naturalWidth = 0;
+  naturalHeight = 0;
+  decoding: ImageDecoding = 'auto';
+  private srcValue = '';
+  private readonly handlers: FakeImageHandler[] = [];
+  private decodeResolver: (() => void) | null = null;
+  private readonly decodePromise: Promise<void>;
+
+  constructor(registry: FakeImage[]) {
+    registry.push(this);
+    this.decodePromise = new Promise((resolve) => {
+      this.decodeResolver = resolve;
+    });
+  }
+
+  get src(): string {
+    return this.srcValue;
+  }
+
+  set src(value: string) {
+    this.srcValue = value;
+  }
+
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+  ): void {
+    if (type !== 'load') {
+      return;
+    }
+
+    const callback: FakeImageListener | undefined =
+      typeof listener === 'function'
+        ? listener
+        : listener && 'handleEvent' in listener
+          ? (event) => listener.handleEvent(event)
+          : undefined;
+
+    if (!callback) {
+      return;
+    }
+
+    const once = typeof options === 'object' && options?.once === true;
+    this.handlers.push({ listener: callback, once });
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    if (type !== 'load') {
+      return;
+    }
+
+    const callback: FakeImageListener | undefined =
+      typeof listener === 'function'
+        ? listener
+        : listener && 'handleEvent' in listener
+          ? (event) => listener.handleEvent(event)
+          : undefined;
+
+    if (!callback) {
+      return;
+    }
+
+    const index = this.handlers.findIndex((entry) => entry.listener === callback);
+    if (index >= 0) {
+      this.handlers.splice(index, 1);
+    }
+  }
+
+  decode(): Promise<void> {
+    return this.decodePromise;
+  }
+
+  triggerLoad(): void {
+    this.complete = true;
+    this.naturalWidth = 64;
+    this.naturalHeight = 64;
+
+    const event = new Event('load');
+    const handlers = [...this.handlers];
+    for (const handler of handlers) {
+      handler.listener.call(this, event);
+    }
+    const persistent = this.handlers.filter((h) => !h.once);
+    this.handlers.length = 0;
+    this.handlers.push(...persistent);
+
+    this.decodeResolver?.();
+    this.decodeResolver = null;
+  }
+}
+
+function createFakeImageConstructor(registry: FakeImage[]): typeof Image {
+  return class FakeImageConstructor extends FakeImage {
+    constructor() {
+      super(registry);
+    }
+  } as unknown as typeof Image;
+}


### PR DESCRIPTION
## Summary
- queue icon load notifications for cached image instances and guard duplicate handlers in the icon loader
- expose a terrain cache regression test that simulates asynchronous icon decoding and verifies dirty chunk invalidation
- document the refreshed icon-loading behaviour in the changelog

## Testing
- `npx vitest run src/render/terrain_cache.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d29ab116a88330a6181b651f4dc4e6