### PR TITLE
Implement dirty frame rendering gate

### DIFF
--- a/src/camera/controls.ts
+++ b/src/camera/controls.ts
@@ -1,6 +1,6 @@
 import { camera } from './autoFrame.ts';
 import type { PixelCoord } from '../hex/HexUtils.ts';
-import { draw } from '../game.ts';
+import { invalidateFrame } from '../game.ts';
 
 export const MIN_ZOOM = 0.5;
 export const MAX_ZOOM = 3.5;
@@ -53,14 +53,14 @@ export function applyZoomAtPoint(
   camera.x += before.x - after.x;
   camera.y += before.y - after.y;
   camera.zoom = clamped;
-  draw();
+  invalidateFrame();
 }
 
 export function panCameraByScreenDelta(dx: number, dy: number): void {
   if (dx === 0 && dy === 0) return;
   camera.x -= dx / camera.zoom;
   camera.y -= dy / camera.zoom;
-  draw();
+  invalidateFrame();
 }
 
 export function resizeCanvasToDisplaySize(canvas: HTMLCanvasElement): void {
@@ -77,7 +77,7 @@ export function resizeCanvasToDisplaySize(canvas: HTMLCanvasElement): void {
   if (ctx) {
     ctx.setTransform(1, 0, 0, 1, 0, 0);
   }
-  draw();
+  invalidateFrame();
 }
 
 export { camera };

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -687,6 +687,9 @@ describe('game lifecycle', () => {
     try {
       await start();
 
+      const pauseModule = await import('./game/pause.ts');
+      pauseModule.setGamePaused(false);
+
       const firstLoop = loopFrames[0];
       expect(firstLoop).toBeDefined();
 


### PR DESCRIPTION
## Summary
- add a dirty-frame invalidation flag and only redraw the canvas when something changes
- route camera controls, animator callbacks, and terrain cache invalidations through the new invalidateFrame helper
- update the animation loop to skip ticking and drawing while paused and adjust the lifecycle test accordingly

## Testing
- `npx vitest run src/game.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68d38cfb4a308333a62bbae780e5a8c9