### PR TITLE
Cache unit bases and fog chunks

### DIFF
--- a/src/render/fog_cache.test.ts
+++ b/src/render/fog_cache.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { HexMap } from '../hexmap.ts';
+import { ensureChunksPopulated } from '../map/hex/chunking.ts';
+import { axialToPixel } from '../hex/HexUtils.ts';
+import { FogCache } from './fog_cache.ts';
+
+vi.mock('./fog.ts', () => ({
+  drawFogHex: vi.fn(),
+}));
+
+const { drawFogHex } = await import('./fog.ts');
+const drawFogHexMock = drawFogHex as unknown as ReturnType<typeof vi.fn>;
+
+function createStubContext() {
+  return {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    clip: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    drawImage: vi.fn(),
+    createLinearGradient: vi.fn(),
+    createRadialGradient: vi.fn(),
+    globalAlpha: 1,
+    filter: 'none',
+    globalCompositeOperation: 'source-over' as GlobalCompositeOperation,
+    lineWidth: 1,
+    lineCap: 'round' as CanvasLineCap,
+    lineJoin: 'round' as CanvasLineJoin,
+    strokeStyle: '',
+    fillStyle: '',
+    shadowBlur: 0,
+    shadowColor: '',
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('FogCache', () => {
+  let createElementSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+  beforeEach(() => {
+    const originalCreateElement = document.createElement;
+    createElementSpy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation((tagName: string, options?: ElementCreationOptions) => {
+        if (tagName === 'canvas') {
+          const ctx = createStubContext();
+          const canvas = {
+            width: 0,
+            height: 0,
+            getContext: vi.fn(() => ctx),
+          } as unknown as HTMLCanvasElement;
+          return canvas;
+        }
+        return originalCreateElement.call(document, tagName, options);
+      });
+  });
+
+  afterEach(() => {
+    createElementSpy?.mockRestore();
+    createElementSpy = null;
+    drawFogHexMock.mockReset();
+  });
+
+  it('caches fog chunks and re-renders only when fog changes', () => {
+    const map = new HexMap(2, 2);
+    const cache = new FogCache(map);
+    const range = { qMin: 0, qMax: 0, rMin: 0, rMax: 0 };
+    ensureChunksPopulated(map, range);
+    const origin = axialToPixel({ q: map.minQ, r: map.minR }, map.hexSize);
+
+    const zoom = 1;
+    const tile = map.getTile(0, 0);
+    expect(tile?.isFogged).toBe(true);
+
+    const first = cache.getRenderableChunks(range, map.hexSize, zoom, origin);
+    expect(first.length).toBeGreaterThan(0);
+    expect(drawFogHexMock.mock.calls.length).toBeGreaterThan(0);
+
+    drawFogHexMock.mockClear();
+    cache.getRenderableChunks(range, map.hexSize, zoom, origin);
+    expect(drawFogHexMock).not.toHaveBeenCalled();
+
+    tile?.reveal();
+    drawFogHexMock.mockClear();
+    cache.getRenderableChunks(range, map.hexSize, zoom, origin);
+    expect(drawFogHexMock.mock.calls.length).toBeGreaterThan(0);
+
+    tile?.setFogged(true);
+    drawFogHexMock.mockClear();
+    cache.getRenderableChunks(range, map.hexSize, zoom, origin);
+    expect(drawFogHexMock.mock.calls.length).toBeGreaterThan(0);
+
+    cache.dispose();
+  });
+
+  it('stores separate variants per zoom level', () => {
+    const map = new HexMap(2, 2);
+    const cache = new FogCache(map);
+    const range = { qMin: 0, qMax: 0, rMin: 0, rMax: 0 };
+    ensureChunksPopulated(map, range);
+    const origin = axialToPixel({ q: map.minQ, r: map.minR }, map.hexSize);
+
+    cache.getRenderableChunks(range, map.hexSize, 1, origin);
+    expect(drawFogHexMock.mock.calls.length).toBeGreaterThan(0);
+
+    drawFogHexMock.mockClear();
+    cache.getRenderableChunks(range, map.hexSize, 1, origin);
+    expect(drawFogHexMock).not.toHaveBeenCalled();
+
+    drawFogHexMock.mockClear();
+    cache.getRenderableChunks(range, map.hexSize, 1.5, origin);
+    expect(drawFogHexMock.mock.calls.length).toBeGreaterThan(0);
+
+    drawFogHexMock.mockClear();
+    cache.getRenderableChunks(range, map.hexSize, 1.5, origin);
+    expect(drawFogHexMock).not.toHaveBeenCalled();
+
+    cache.dispose();
+  });
+});
+

--- a/src/render/fog_cache.ts
+++ b/src/render/fog_cache.ts
@@ -1,0 +1,239 @@
+import { axialToPixel } from '../hex/HexUtils.ts';
+import { getHexDimensions } from '../hex/HexDimensions.ts';
+import type { HexMap } from '../hexmap.ts';
+import type { PixelCoord } from '../hex/HexUtils.ts';
+import {
+  chunkKeyFromAxial,
+  chunkKeyFromCoord,
+  enumerateChunks,
+  HEX_CHUNK_SIZE,
+  type ChunkCoord,
+  type ChunkKey,
+  type ChunkRange,
+} from '../map/hex/chunking.ts';
+import { drawFogHex } from './fog.ts';
+
+export interface FogChunkCanvas {
+  readonly key: ChunkKey;
+  readonly canvas: HTMLCanvasElement;
+  readonly origin: PixelCoord;
+  readonly width: number;
+  readonly height: number;
+}
+
+function chunkBounds(
+  chunk: ChunkCoord,
+  map: HexMap
+): { qStart: number; qEnd: number; rStart: number; rEnd: number } {
+  const qStart = Math.max(chunk.q * HEX_CHUNK_SIZE, map.minQ);
+  const qEnd = Math.min(qStart + HEX_CHUNK_SIZE - 1, map.maxQ);
+  const rStart = Math.max(chunk.r * HEX_CHUNK_SIZE, map.minR);
+  const rEnd = Math.min(rStart + HEX_CHUNK_SIZE - 1, map.maxR);
+  return { qStart, qEnd, rStart, rEnd };
+}
+
+function zoomKey(zoom: number): string {
+  if (!Number.isFinite(zoom) || zoom <= 0) {
+    return '1.000';
+  }
+  return zoom.toFixed(3);
+}
+
+export class FogCache {
+  private readonly chunkCanvases = new Map<ChunkKey, Map<string, FogChunkCanvas>>();
+  private readonly dirtyChunks = new Set<ChunkKey>();
+  private readonly unsubscribe: () => void;
+
+  constructor(private readonly map: HexMap) {
+    this.unsubscribe = map.addTileChangeListener((coord, tile, change) => {
+      if (change === 'fog' || change === 'created') {
+        this.markTileDirty(coord.q, coord.r);
+      } else if (change === 'terrain' || change === 'building') {
+        // No fog change, skip invalidation.
+        if (tile.isFogged) {
+          this.markTileDirty(coord.q, coord.r);
+        }
+      }
+    });
+  }
+
+  dispose(): void {
+    this.unsubscribe();
+    this.chunkCanvases.clear();
+    this.dirtyChunks.clear();
+  }
+
+  invalidate(): void {
+    this.chunkCanvases.clear();
+    this.dirtyChunks.clear();
+  }
+
+  markTileDirty(q: number, r: number): void {
+    this.dirtyChunks.add(chunkKeyFromAxial(q, r));
+  }
+
+  getRenderableChunks(
+    range: ChunkRange,
+    hexSize: number,
+    zoom: number,
+    origin: PixelCoord
+  ): FogChunkCanvas[] {
+    const chunks: FogChunkCanvas[] = [];
+    const { width: hexWidth, height: hexHeight } = getHexDimensions(hexSize);
+    const keyForZoom = zoomKey(zoom);
+
+    for (const chunkCoord of enumerateChunks(range)) {
+      const key = chunkKeyFromCoord(chunkCoord);
+      const chunk = this.ensureChunk(
+        key,
+        chunkCoord,
+        hexSize,
+        hexWidth,
+        hexHeight,
+        zoom,
+        keyForZoom,
+        origin
+      );
+      if (chunk) {
+        chunks.push(chunk);
+      }
+    }
+
+    return chunks;
+  }
+
+  private ensureChunk(
+    key: ChunkKey,
+    chunkCoord: ChunkCoord,
+    hexSize: number,
+    hexWidth: number,
+    hexHeight: number,
+    zoom: number,
+    zoomKeyValue: string,
+    origin: PixelCoord
+  ): FogChunkCanvas | null {
+    let zoomVariants = this.chunkCanvases.get(key);
+    const isDirty = this.dirtyChunks.has(key);
+    if (!zoomVariants || isDirty) {
+      zoomVariants = new Map();
+      this.chunkCanvases.set(key, zoomVariants);
+      this.dirtyChunks.delete(key);
+    }
+
+    const existing = zoomVariants.get(zoomKeyValue);
+    if (existing && !isDirty) {
+      return existing;
+    }
+
+    const reuse = isDirty ? undefined : existing;
+    const rendered = this.renderChunk(
+      key,
+      chunkCoord,
+      hexSize,
+      hexWidth,
+      hexHeight,
+      zoom,
+      origin,
+      reuse ?? null
+    );
+
+    if (!rendered) {
+      zoomVariants.delete(zoomKeyValue);
+      if (zoomVariants.size === 0) {
+        this.chunkCanvases.delete(key);
+      }
+      return null;
+    }
+
+    zoomVariants.set(zoomKeyValue, rendered);
+    return rendered;
+  }
+
+  private renderChunk(
+    key: ChunkKey,
+    chunkCoord: ChunkCoord,
+    hexSize: number,
+    hexWidth: number,
+    hexHeight: number,
+    zoom: number,
+    origin: PixelCoord,
+    existing: FogChunkCanvas | null
+  ): FogChunkCanvas | null {
+    if (typeof document === 'undefined') {
+      return null;
+    }
+
+    const { qStart, qEnd, rStart, rEnd } = chunkBounds(chunkCoord, this.map);
+    if (qStart > qEnd || rStart > rEnd) {
+      return null;
+    }
+
+    const halfHexWidth = hexWidth / 2;
+    const halfHexHeight = hexHeight / 2;
+
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    const fogTiles: Array<{ centerX: number; centerY: number }> = [];
+
+    for (let q = qStart; q <= qEnd; q++) {
+      for (let r = rStart; r <= rEnd; r++) {
+        const tile = this.map.getTile(q, r);
+        if (!tile || !tile.isFogged) {
+          continue;
+        }
+
+        const { x, y } = axialToPixel({ q, r }, hexSize);
+        const drawX = x - origin.x - halfHexWidth;
+        const drawY = y - origin.y - halfHexHeight;
+        const centerX = drawX + hexWidth / 2;
+        const centerY = drawY + hexHeight / 2;
+
+        minX = Math.min(minX, drawX);
+        minY = Math.min(minY, drawY);
+        maxX = Math.max(maxX, drawX + hexWidth);
+        maxY = Math.max(maxY, drawY + hexHeight);
+
+        fogTiles.push({ centerX, centerY });
+      }
+    }
+
+    if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+      return null;
+    }
+
+    const width = Math.max(1, Math.ceil(maxX - minX));
+    const height = Math.max(1, Math.ceil(maxY - minY));
+
+    let canvas = existing?.canvas ?? null;
+    if (!canvas || canvas.width !== width || canvas.height !== height) {
+      canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+    }
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas 2D context not available for fog rendering');
+    }
+
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+
+    for (const tile of fogTiles) {
+      const centerX = tile.centerX - minX;
+      const centerY = tile.centerY - minY;
+      drawFogHex(ctx, centerX, centerY, hexSize, zoom);
+    }
+
+    return {
+      key,
+      canvas,
+      origin: { x: minX, y: minY },
+      width,
+      height,
+    } satisfies FogChunkCanvas;
+  }
+}
+


### PR DESCRIPTION
## Summary
- cache gradient-heavy unit bases in offscreen canvases and reuse them per palette
- introduce a fog chunk cache that blits pre-rendered fog canvases during map draws
- cover the new fog cache with unit tests to ensure reuse across frames and zoom levels

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d3961cb68c83339f4a231a87e529b5