### PR TITLE
Gate animation loop on demand

### DIFF
--- a/src/render/unit_fx.ts
+++ b/src/render/unit_fx.ts
@@ -242,6 +242,12 @@ export function createUnitFxManager(options: UnitFxOptions): UnitFxManager {
     }
 
     selectionHud.refreshPosition();
+
+    const hasActiveAnimations =
+      (!prefersReducedMotion && shakes.length > 0) || fades.size > 0;
+    if (hasActiveAnimations) {
+      scheduleDraw();
+    }
   };
 
   const getShakeOffset = () => ({ x: offset.x, y: offset.y });


### PR DESCRIPTION
## Summary
- gate the game loop behind an on-demand scheduler that restarts when frames are invalidated and halts after several idle paused frames
- reset idle state during draws/cleanup and tie pause state changes to loop scheduling so the loop wakes when play resumes
- let unit FX request follow-up frames while fades or shakes are active to keep overlays animating under the new scheduler

## Testing
- npm run audio:lint
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_b_68d3bf775b7483339fe0cf9c3c8b620e