### PR TITLE
Destroy roster HUD controller during UiV2 teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Guard the roster HUD teardown by destroying the V2 controller before
+  resetting the classic resource bar mount and extend the UI shell bootstrap
+  test suite to assert the cleanup hook fires.
+
 - Refresh terrain icon rendering by queuing load-completion events from the
   icon cache, tracking pending images so cached assets still notify listeners,
   and covering the terrain renderer with a Vitest case that dirties affected

--- a/src/uiV2/UiV2App.tsx
+++ b/src/uiV2/UiV2App.tsx
@@ -276,6 +276,10 @@ function RosterSummaryDock({ resourceBar, summary, entries }: RosterSummaryDockP
     controller.updateSummary(summary);
     controller.renderRoster(entries);
     return () => {
+      const controller = controllerRef.current;
+      if (controller) {
+        controller.destroy();
+      }
       controllerRef.current = null;
       resourceBar.replaceChildren();
       resourceBar.classList.remove('ui-v2-resource-bar');

--- a/tests/uiV2/bootstrap.test.tsx
+++ b/tests/uiV2/bootstrap.test.tsx
@@ -9,6 +9,8 @@ import { eventBus } from '../../src/events';
 import { logEvent, clearLogs, getLogHistory, subscribeToLogs } from '../../src/ui/logging.ts';
 import type { LogEntry } from '../../src/ui/logging.ts';
 
+const destroyRosterHudMock = vi.fn();
+
 type Harness = {
   emitRosterSummary(summary: RosterHudSummary): void;
   emitRosterEntries(entries: RosterEntry[]): void;
@@ -214,7 +216,7 @@ vi.mock('../../src/ui/rosterHUD.ts', () => ({
       renderRoster(entries: RosterEntry[]) {
         element.dataset.rosterEntries = String(entries.length);
       },
-      destroy: () => {}
+      destroy: destroyRosterHudMock
     };
   }
 }));
@@ -249,6 +251,7 @@ const getHarness = async (): Promise<Harness> => {
 
 describe('UiV2 shell', () => {
   beforeEach(async () => {
+    destroyRosterHudMock.mockClear();
     (await getHarness()).reset();
     clearLogs();
     const overlay = document.getElementById('ui-overlay');
@@ -357,5 +360,6 @@ describe('UiV2 shell', () => {
 
     expect(resourceBar.parentElement).toBe(overlay);
     expect(resourceBar.classList.contains('ui-v2-resource-bar')).toBe(false);
+    await waitFor(() => expect(destroyRosterHudMock).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
## Summary
- ensure Ui V2 roster summary cleanup destroys its controller before resetting the classic resource bar mount
- document the regression fix in the changelog
- extend the UI v2 bootstrap test to assert the roster HUD destroy hook is invoked when the shell is torn down

## Testing
- npx vitest run tests/uiV2/bootstrap.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d2e4aa688083308651cfd8c5e13099