### PR TITLE
Align right panel breakpoint with CSS collapse threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Align the command console collapse logic by syncing the desktop media query
+  and HUD toggle listener on a shared 960px breakpoint so both layers hide the
+  panel in lockstep.
+
 - Guard the roster HUD teardown by destroying the V2 controller before
   resetting the classic resource bar mount and extend the UI shell bootstrap
   test suite to assert the cleanup hook fires.

--- a/src/ui/rightPanel.tsx
+++ b/src/ui/rightPanel.tsx
@@ -117,7 +117,7 @@ export function setupRightPanel(
   slideSheet.appendChild(panel);
   slideOver.append(slideBackdrop, slideSheet);
 
-  const smallViewportQuery = window.matchMedia('(max-width: 1040px)');
+  const smallViewportQuery = window.matchMedia('(max-width: 960px)');
   const disposers: Array<() => void> = [];
 
   const applyRosterState = (tabId: HudBottomTabId): void => {


### PR DESCRIPTION
## Summary
- update the right panel media query to match the 960px CSS collapse breakpoint so the HUD toggle and layout stay in sync
- record the unified breakpoint in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3ee9c55348330b820ab6f424566d7