### PR TITLE
feat: refresh unit sprite illustrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Hand-paint high resolution sprites for every Saunoja and raid archetype,
+  refreshing the guardian, seer, soldier, archer, marauder, and raider line so
+  each unit now shares consistent gradients, steam halos, and polished
+  highlights while keeping the sprite manifest in sync.
+
 - Guard the roster HUD teardown by destroying the V2 controller before
   resetting the classic resource bar mount and extend the UI shell bootstrap
   test suite to assert the cleanup hook fires.

--- a/assets/sprites/archer.svg
+++ b/assets/sprites/archer.svg
@@ -1,72 +1,82 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="title desc">
-  <title id="title">Glacier Warden v1</title>
-  <desc id="desc">First-pass production render of the Saunoja glacial archer poised with crystalline bow and aurora snow.</desc>
+  <title id="title">Glacier Warden v2</title>
+  <desc id="desc">Refined illustration of the Saunoja glacial archer framed by auroral snow, crystalline bow, and frostlit armor.</desc>
   <defs>
-    <linearGradient id="archer-sky" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#030914" />
-      <stop offset="1" stop-color="#11243c" />
+    <linearGradient id="archer-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#07152a" />
+      <stop offset="1" stop-color="#12395f" />
     </linearGradient>
     <radialGradient id="archer-aurora" cx="48%" cy="34%" r="82%">
-      <stop offset="0" stop-color="#eefaff" stop-opacity="0.9" />
-      <stop offset="0.48" stop-color="#bde4ff" stop-opacity="0.55" />
-      <stop offset="1" stop-color="#162b46" stop-opacity="0" />
+      <stop offset="0" stop-color="#f2fbff" stop-opacity="0.92" />
+      <stop offset="0.5" stop-color="#c9e8ff" stop-opacity="0.58" />
+      <stop offset="1" stop-color="#122a45" stop-opacity="0" />
     </radialGradient>
-    <linearGradient id="archer-cloak" x1="16%" x2="88%" y1="18%" y2="94%">
-      <stop offset="0" stop-color="#27c5ff" />
-      <stop offset="1" stop-color="#5460ff" />
+    <linearGradient id="archer-cloak" x1="12%" y1="20%" x2="90%" y2="88%">
+      <stop offset="0" stop-color="#2ad5ff" />
+      <stop offset="0.48" stop-color="#2490ff" />
+      <stop offset="1" stop-color="#6a7cff" />
     </linearGradient>
-    <linearGradient id="archer-leather" x1="18%" x2="84%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#ffe5ae" />
-      <stop offset="0.5" stop-color="#f7b84d" />
-      <stop offset="1" stop-color="#de7d2b" />
+    <linearGradient id="archer-armor" x1="30%" y1="8%" x2="74%" y2="96%">
+      <stop offset="0" stop-color="#f9fdff" />
+      <stop offset="0.44" stop-color="#d8e8ff" />
+      <stop offset="0.82" stop-color="#8aa7d3" />
+      <stop offset="1" stop-color="#42567f" />
     </linearGradient>
-    <linearGradient id="archer-armor" x1="30%" x2="72%" y1="6%" y2="96%">
-      <stop offset="0" stop-color="#f5fbff" />
-      <stop offset="0.36" stop-color="#d0ddff" />
-      <stop offset="0.78" stop-color="#8194bf" />
-      <stop offset="1" stop-color="#4b5474" />
+    <linearGradient id="archer-leather" x1="18%" y1="0%" x2="84%" y2="100%">
+      <stop offset="0" stop-color="#ffead0" />
+      <stop offset="0.48" stop-color="#f4b864" />
+      <stop offset="1" stop-color="#d67924" />
     </linearGradient>
-    <radialGradient id="archer-bow" cx="50%" cy="50%" r="50%">
-      <stop offset="0" stop-color="#fdf6d0" />
-      <stop offset="0.4" stop-color="#f6c45f" />
-      <stop offset="1" stop-color="#d87318" />
+    <radialGradient id="archer-bow" cx="50%" cy="52%" r="50%">
+      <stop offset="0" stop-color="#fdf7df" />
+      <stop offset="0.45" stop-color="#f3c86e" />
+      <stop offset="1" stop-color="#c96818" />
     </radialGradient>
-    <linearGradient id="archer-arrow" x1="0%" x2="100%" y1="0%" y2="0%">
-      <stop offset="0" stop-color="#e8f7ff" />
-      <stop offset="1" stop-color="#8bc6ff" />
+    <linearGradient id="archer-arrow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0" stop-color="#f4fbff" />
+      <stop offset="1" stop-color="#8bcaff" />
     </linearGradient>
     <radialGradient id="archer-shadow" cx="52%" cy="86%" r="48%">
-      <stop offset="0" stop-color="rgba(8,14,28,0.55)" />
+      <stop offset="0" stop-color="rgba(8,14,28,0.5)" />
       <stop offset="1" stop-color="rgba(8,14,28,0)" />
+    </radialGradient>
+    <radialGradient id="archer-highlight" cx="52%" cy="28%" r="42%">
+      <stop offset="0" stop-color="rgba(255,255,255,0.8)" />
+      <stop offset="1" stop-color="rgba(255,255,255,0)" />
     </radialGradient>
   </defs>
   <g transform="translate(3.404255319, 0) scale(0.340425532)">
-      <rect width="168" height="188" rx="28" fill="url(#archer-sky)" />
-      <circle cx="86" cy="74" r="76" fill="url(#archer-aurora)" />
-      <ellipse cx="90" cy="152" rx="60" ry="20" fill="url(#archer-shadow)" />
-      <path d="M38 60c-12 28-12 58 2 86l26 14c-2-32 10-64 34-84-24-6-42-10-62-16Z" fill="url(#archer-cloak)" opacity="0.82" />
-      <path d="M144 64c10 26 10 58-6 84l-24 14c4-30-4-60-30-82 22-6 42-10 60-16Z" fill="url(#archer-cloak)" opacity="0.62" />
-      <path d="M74 30 50 64c-12 16-18 36-18 56v26l26 54h48l26-54V102c0-22-6-42-18-56L94 30H74Z" fill="url(#archer-armor)" stroke="#13253f" stroke-width="3" stroke-linejoin="round" />
-      <path d="M60 110h48l8 22c-16 18-30 26-32 26s-18-8-34-26l10-22Z" fill="#e9f4ff" opacity="0.92" />
-      <path d="M86 42c-12 0-26 10-36 20l14 16c14-10 44-10 58 0l14-16c-10-10-24-20-40-20Z" fill="#f8fbff" stroke="#cedcfe" stroke-width="2.4" />
-      <path d="M74 26h28l10 12-24 16-24-16 10-12Z" fill="#e7efff" stroke="#9badcf" stroke-width="2" />
-      <path d="M58 132l12 38-26 16-20-46 22-12 12 4Z" fill="url(#archer-leather)" opacity="0.94" />
-      <path d="M112 130l26-12-14 48-22-14 10-22Z" fill="#ffeccc" opacity="0.74" />
-      <path d="M32 120 16 134l38 38 20-18-42-34Z" fill="url(#archer-bow)" stroke="#934d10" stroke-width="2.6" />
-      <path d="M124 102c16 0 30 16 30 28s-12 24-28 24-24-12-24-24 8-28 22-28Z" fill="none" stroke="#fbd37d" stroke-width="5" stroke-linecap="round" />
-      <path d="M124 104c10 6 16 16 16 26s-6 18-16 24" fill="none" stroke="#f59f0b" stroke-width="2.6" stroke-linecap="round" />
-      <path d="M58 106l16-10 34 32-12 14-38-36Z" fill="url(#archer-leather)" stroke="#934d10" stroke-width="2" />
-      <path d="M124 110l26-6-14 16h-24l12-10Z" fill="url(#archer-arrow)" />
-      <path d="M88 150c-12 0-24 10-30 22 12 8 22 12 34 12s22-4 34-12c-6-12-18-22-38-22Z" fill="#d7e9ff" stroke="#99c9ff" stroke-width="1.8" stroke-linejoin="round" />
-      <path d="M74 96h20l4 12-14 8-14-8 4-12Z" fill="#15263f" />
-      <circle cx="84" cy="98" r="9" fill="#f4f9ff" stroke="#c7d9f3" stroke-width="1.6" />
-      <path d="M66 74c-8 0-14 8-14 18 10-6 22-8 32-8s22 2 32 8c0-10-6-18-14-18H66Z" fill="#0d192e" opacity="0.82" />
-      <g fill="rgba(231,246,255,0.45)">
-        <circle cx="32" cy="48" r="4" />
-        <circle cx="44" cy="34" r="3" />
-        <circle cx="134" cy="42" r="5" />
-        <circle cx="146" cy="56" r="3" />
-        <circle cx="120" cy="32" r="3" />
-      </g>
+    <rect width="168" height="188" rx="28" fill="url(#archer-sky)" />
+    <circle cx="86" cy="74" r="78" fill="url(#archer-aurora)" />
+    <ellipse cx="88" cy="156" rx="60" ry="20" fill="url(#archer-shadow)" />
+    <path d="M32 46c-16 26-20 58-6 90 8 20 22 36 38 46l-12 20c-22-12-38-34-46-58-10-30-4-64 18-98Z" fill="#102e52" opacity="0.32" />
+    <path d="M148 46c22 28 26 70 12 102-8 18-22 34-42 46l-12-20c16-10 30-28 34-46 8-34 2-62-18-82Z" fill="#0a213d" opacity="0.34" />
+    <path d="M40 64c-14 28-14 60 2 90l28 16c-4-34 6-66 32-88-24-6-44-12-62-18Z" fill="url(#archer-cloak)" opacity="0.86" />
+    <path d="M144 64c12 30 10 62-6 88l-26 16c4-34-4-64-30-84 20-6 40-12 62-20Z" fill="url(#archer-cloak)" opacity="0.58" />
+    <path d="M70 28 48 60c-12 16-18 36-18 56v26l28 58h50l28-56V104c0-22-6-42-18-56L96 28H70Z" fill="url(#archer-armor)" stroke="#142c4d" stroke-width="3" stroke-linejoin="round" />
+    <path d="M60 112h48l8 24c-16 18-30 26-32 26s-18-8-34-26l10-24Z" fill="#e8f4ff" opacity="0.92" />
+    <path d="M84 40c-14 0-28 10-38 20l14 16c16-10 48-10 62 0l14-16c-10-12-26-20-40-20Z" fill="#f8fbff" stroke="#cedcf2" stroke-width="2.4" />
+    <path d="M70 24h30l10 12-26 16-24-16 10-12Z" fill="#e9f0ff" stroke="#9aaed0" stroke-width="2" />
+    <path d="M58 134l12 38-26 16-20-46 22-12 12 4Z" fill="url(#archer-leather)" opacity="0.94" />
+    <path d="M114 132l26-12-14 48-24-14 12-22Z" fill="#ffeccd" opacity="0.76" />
+    <path d="M32 120 16 136l40 40 20-18-44-38Z" fill="url(#archer-bow)" stroke="#8e4a14" stroke-width="2.6" />
+    <path d="M58 108l18-12 36 36-14 16-40-40Z" fill="url(#archer-leather)" stroke="#8e4a14" stroke-width="2" />
+    <path d="M126 106c16 0 30 16 30 28s-12 24-28 24-24-12-24-24 8-28 22-28Z" fill="none" stroke="#f9d37a" stroke-width="5" stroke-linecap="round" />
+    <path d="M126 108c10 6 16 16 16 26s-6 18-16 24" fill="none" stroke="#f59c0c" stroke-width="2.8" stroke-linecap="round" />
+    <path d="M126 110l28-6-16 16h-26l14-10Z" fill="url(#archer-arrow)" />
+    <path d="M88 152c-12 0-24 10-30 22 12 8 24 12 36 12s22-4 34-12c-6-12-18-22-40-22Z" fill="#d8eaff" stroke="#9cc6ff" stroke-width="2" stroke-linejoin="round" />
+    <path d="M74 98h22l4 12-16 8-16-8 6-12Z" fill="#162740" />
+    <circle cx="84" cy="100" r="9" fill="#f4f9ff" stroke="#c7d8f2" stroke-width="1.6" />
+    <path d="M68 76c-8 0-14 8-14 18 12-6 24-8 34-8s22 2 34 8c0-10-6-18-14-18H68Z" fill="#0d192e" opacity="0.82" />
+    <path d="M86 56c-20 0-36 8-46 22l12 8c10-10 26-16 44-16s34 6 44 16l12-8c-12-16-30-22-48-22Z" fill="#1d416a" opacity="0.4" />
+    <g fill="rgba(232,246,255,0.46)">
+      <circle cx="30" cy="46" r="4" />
+      <circle cx="44" cy="32" r="3" />
+      <circle cx="136" cy="40" r="5" />
+      <circle cx="148" cy="56" r="3" />
+      <circle cx="118" cy="30" r="3" />
+    </g>
+    <circle cx="88" cy="66" r="44" fill="url(#archer-highlight)" opacity="0.26" />
+    <path d="M40 64c18 8 46 8 64 0l-18-10c-16 4-30 4-48 0L40 64Z" fill="#73e1ff" opacity="0.2" />
   </g>
 </svg>

--- a/assets/sprites/avanto-marauder.svg
+++ b/assets/sprites/avanto-marauder.svg
@@ -1,69 +1,70 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="title desc">
-  <title id="title">Avanto Marauder v1</title>
-  <desc id="desc">First-pass production render of the avanto marauder wielding twin frost axes amid blizzard shards.</desc>
+  <title id="title">Avanto Marauder v2</title>
+  <desc id="desc">Premium illustration of the Avanto marauder clad in basalt armor, steaming hammer, and sauna embers.</desc>
   <defs>
-    <linearGradient id="marauder-sky" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#02070d" />
-      <stop offset="1" stop-color="#0f1a2c" />
+    <linearGradient id="marauder-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#080713" />
+      <stop offset="1" stop-color="#1b1331" />
     </linearGradient>
-    <radialGradient id="marauder-aurora" cx="52%" cy="30%" r="86%">
-      <stop offset="0" stop-color="#f0f7ff" stop-opacity="0.9" />
-      <stop offset="0.46" stop-color="#c0e0ff" stop-opacity="0.55" />
-      <stop offset="1" stop-color="#16263f" stop-opacity="0" />
+    <radialGradient id="marauder-ember" cx="52%" cy="36%" r="80%">
+      <stop offset="0" stop-color="#ffeede" stop-opacity="0.92" />
+      <stop offset="0.48" stop-color="#ffbb7c" stop-opacity="0.54" />
+      <stop offset="1" stop-color="#200c24" stop-opacity="0" />
     </radialGradient>
-    <linearGradient id="marauder-fur" x1="12%" x2="88%" y1="12%" y2="92%">
-      <stop offset="0" stop-color="#4d5a6d" />
-      <stop offset="1" stop-color="#111827" />
+    <linearGradient id="marauder-armor" x1="24%" y1="8%" x2="80%" y2="92%">
+      <stop offset="0" stop-color="#f7f5ff" />
+      <stop offset="0.4" stop-color="#d2cff5" />
+      <stop offset="0.78" stop-color="#8178c8" />
+      <stop offset="1" stop-color="#413a7a" />
     </linearGradient>
-    <linearGradient id="marauder-armor" x1="24%" x2="76%" y1="8%" y2="100%">
-      <stop offset="0" stop-color="#f2fbff" />
-      <stop offset="0.4" stop-color="#cfe6fb" />
-      <stop offset="0.78" stop-color="#7b92b5" />
-      <stop offset="1" stop-color="#27344c" />
+    <linearGradient id="marauder-cloak" x1="18%" y1="16%" x2="90%" y2="92%">
+      <stop offset="0" stop-color="#6337ff" />
+      <stop offset="0.5" stop-color="#5c2dcb" />
+      <stop offset="1" stop-color="#a95dff" />
     </linearGradient>
-    <linearGradient id="marauder-wrap" x1="20%" x2="80%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#ffd770" />
-      <stop offset="0.5" stop-color="#f6a43c" />
-      <stop offset="1" stop-color="#dd6b21" />
+    <linearGradient id="marauder-hammer" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0" stop-color="#ffe3b3" />
+      <stop offset="0.5" stop-color="#ffb45c" />
+      <stop offset="1" stop-color="#ff7640" />
     </linearGradient>
-    <linearGradient id="marauder-axe" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#f2f8ff" />
-      <stop offset="0.6" stop-color="#9ac8ff" />
-      <stop offset="1" stop-color="#18304d" />
-    </linearGradient>
-    <radialGradient id="marauder-shadow" cx="50%" cy="88%" r="50%">
-      <stop offset="0" stop-color="rgba(6,10,20,0.6)" />
-      <stop offset="1" stop-color="rgba(6,10,20,0)" />
+    <radialGradient id="marauder-halo" cx="50%" cy="20%" r="42%">
+      <stop offset="0" stop-color="rgba(255,216,148,0.8)" />
+      <stop offset="1" stop-color="rgba(255,216,148,0)" />
     </radialGradient>
-    <linearGradient id="marauder-ice" x1="0%" x2="100%" y1="0%" y2="0%">
-      <stop offset="0" stop-color="#7dd3fc" />
-      <stop offset="1" stop-color="#bae6fd" />
-    </linearGradient>
+    <radialGradient id="marauder-shadow" cx="50%" cy="88%" r="48%">
+      <stop offset="0" stop-color="rgba(18,10,28,0.56)" />
+      <stop offset="1" stop-color="rgba(18,10,28,0)" />
+    </radialGradient>
   </defs>
   <g transform="translate(3.265306122, 0) scale(0.326530612)">
-      <rect width="176" height="196" rx="30" fill="url(#marauder-sky)" />
-      <circle cx="90" cy="78" r="82" fill="url(#marauder-aurora)" />
-      <ellipse cx="88" cy="164" rx="64" ry="22" fill="url(#marauder-shadow)" />
-      <path d="M32 66c-12 30-10 64 6 94l28 16c-2-36 10-70 38-96-24-6-44-10-72-14Z" fill="url(#marauder-fur)" opacity="0.82" />
-      <path d="M154 62c14 28 16 64 2 96l-26 16c4-38-6-72-34-96 22-4 40-8 58-16Z" fill="url(#marauder-fur)" opacity="0.66" />
-      <path d="M76 30 48 68c-14 18-20 40-20 62v30l28 64h56l32-66v-30c0-24-6-46-20-64L100 30H76Z" fill="url(#marauder-armor)" stroke="#101d32" stroke-width="3.4" stroke-linejoin="round" />
-      <path d="M62 122h52l10 26c-18 20-34 30-36 30s-22-10-38-30l12-26Z" fill="#e6f1ff" opacity="0.92" />
-      <path d="M90 44c-14 0-28 10-40 22l14 16c16-12 48-12 64 0l14-16c-12-12-26-22-44-22Z" fill="#f6fbff" stroke="#ccdcf3" stroke-width="2.8" />
-      <path d="M76 24h32l12 14-28 18-28-18 12-14Z" fill="#e7efff" stroke="#9ab0d0" stroke-width="2.4" />
-      <path d="M66 146l14 44-30 18-24-54 24-12 16 4Z" fill="url(#marauder-wrap)" opacity="0.96" />
-      <path d="M120 142l30-12-16 54-24-16 10-26Z" fill="#ffe8bf" opacity="0.7" />
-      <path d="M30 134 12 150l42 44 24-20-48-40Z" fill="url(#marauder-axe)" stroke="#0b1428" stroke-width="2.8" />
-      <path d="M34 136c12-8 22-4 32 4l-10 16-22-20Z" fill="#f5f8ff" opacity="0.78" />
-      <path d="M140 128c14-4 26 4 34 16l-38 22-16-14 20-24Z" fill="url(#marauder-axe)" stroke="#081220" stroke-width="2.8" />
-      <path d="M140 130c10-2 14 4 20 12l-18 12-10-10 8-14Z" fill="#f4f8ff" opacity="0.74" />
-      <path d="M88 168c-14 0-26 12-34 26 12 10 24 14 38 14s26-4 38-14c-8-14-20-26-42-26Z" fill="#d6e8ff" stroke="#96c5ff" stroke-width="2" stroke-linejoin="round" />
-      <path d="M76 110h24l4 12-16 12-16-12 4-12Z" fill="#111f35" />
-      <circle cx="88" cy="112" r="10" fill="#f6f9ff" stroke="#c7d8ee" stroke-width="1.8" />
-      <path d="M66 86c-8 0-14 8-14 18 12-6 24-8 36-8s24 2 36 8c0-10-6-18-14-18H66Z" fill="#070f1f" opacity="0.85" />
-      <path d="M96 158c-6 0-8 6-8 12 0 12 8 20 14 20s14-8 14-20c0-6-2-12-8-12H96Z" fill="#14223a" opacity="0.72" />
-      <path d="M46 94c-4 0-6 4-6 8 0 10 4 16 10 16s10-6 10-16c0-4-2-8-6-8H46Z" fill="#14223a" opacity="0.72" />
-      <path d="M130 94c-4 0-6 4-6 8 0 10 4 16 10 16s10-6 10-16c0-4-2-8-6-8h-8Z" fill="#14223a" opacity="0.72" />
-      <path d="M22 52c12 4 24-4 36-12 10-6 26-8 40-4 12 4 28 0 36-8-6 12-18 22-32 24-16 2-34 0-54 6-8 2-18 4-26-6Z" fill="#0ea5e9" opacity="0.32" />
-      <path d="M10 84c14 6 26 6 40 0 16-6 32-8 50 0 14 6 26 6 38 0-12 10-24 16-38 16-16 0-34-8-52-8-14 0-26 2-38-8Z" fill="url(#marauder-ice)" opacity="0.4" />
+    <rect width="176" height="196" rx="30" fill="url(#marauder-sky)" />
+    <circle cx="90" cy="78" r="82" fill="url(#marauder-ember)" />
+    <ellipse cx="88" cy="164" rx="66" ry="22" fill="url(#marauder-shadow)" />
+    <path d="M32 56c-18 32-18 70 0 104 10 20 26 38 42 48l-12 24c-24-14-44-38-54-66-14-42-6-84 24-110Z" fill="#190c2e" opacity="0.38" />
+    <path d="M152 50c28 28 38 80 26 118-8 26-28 48-52 66l-12-24c18-12 32-30 38-48 10-32 4-68-16-94Z" fill="#11051f" opacity="0.4" />
+    <path d="M44 68c-16 32-16 70 2 102l32 20c-4-36 6-70 36-96-26-8-48-16-70-26Z" fill="url(#marauder-cloak)" opacity="0.9" />
+    <path d="M150 68c14 32 12 72-8 98l-30 20c4-36-6-68-34-92 24-8 46-16 72-26Z" fill="url(#marauder-cloak)" opacity="0.66" />
+    <path d="M74 26 50 64c-12 18-20 40-20 62v30l32 66h54l34-68V110c0-24-8-46-20-62L100 26H74Z" fill="url(#marauder-armor)" stroke="#211545" stroke-width="3.4" stroke-linejoin="round" />
+    <path d="M62 120h54l10 26c-18 20-32 30-34 30s-20-10-36-30l6-26Z" fill="#eeeaff" opacity="0.86" />
+    <path d="M86 38c-14 0-30 10-40 22l16 18c18-12 50-12 64 0l16-18c-12-12-26-22-40-22Z" fill="#f9f6ff" stroke="#d7d0f6" stroke-width="2.6" />
+    <path d="M70 22h32l12 14-26 18-26-18 8-14Z" fill="#f0ecff" stroke="#a8a0dc" stroke-width="2.2" />
+    <path d="M62 140l16 44-30 20-24-54 26-14 12 4Z" fill="#5630b7" opacity="0.82" />
+    <path d="M120 138l28-14-16 54-24-16 12-24Z" fill="#f7d6aa" opacity="0.74" />
+    <path d="M30 124 12 144l46 44 22-22-50-42Z" fill="#4830ff" opacity="0.62" />
+    <path d="M144 92c20-6 32-12 48-22-4-10-14-20-24-24-14 8-28 16-42 22l18 24Z" fill="#ff8d3b" stroke="#59260d" stroke-width="3" />
+    <path d="M132 76 154 48l24-6c6 6 10 16 10 24-12 12-26 22-42 30l-14-20Z" fill="url(#marauder-hammer)" stroke="#7c3010" stroke-width="2.6" />
+    <path d="M96 154c-14 0-28 12-34 26 14 10 26 14 40 14s26-4 40-14c-8-14-20-26-46-26Z" fill="#d8d2ff" stroke="#9f95ff" stroke-width="2" stroke-linejoin="round" />
+    <path d="M78 104h24l4 12-18 10-18-10 8-12Z" fill="#211d3f" />
+    <circle cx="90" cy="106" r="11" fill="#f5f1ff" stroke="#cfc7f7" stroke-width="1.8" />
+    <path d="M70 82c-10 0-16 8-16 20 12-8 26-10 36-10s24 2 36 10c0-12-8-20-16-20H70Z" fill="#130e2c" opacity="0.78" />
+    <path d="M76 60c-18 4-32 12-40 26l12 8c10-12 28-20 46-20s36 8 46 20l12-8c-10-14-26-22-42-26-12-2-24-2-34 0Z" fill="#2b1b54" opacity="0.44" />
+    <g fill="rgba(255,206,156,0.32)">
+      <circle cx="38" cy="44" r="5" />
+      <circle cx="58" cy="34" r="4" />
+      <circle cx="134" cy="32" r="6" />
+      <circle cx="150" cy="48" r="4" />
+      <circle cx="118" cy="22" r="3" />
+    </g>
+    <circle cx="90" cy="64" r="46" fill="url(#marauder-halo)" opacity="0.32" />
   </g>
 </svg>

--- a/assets/sprites/manifest.json
+++ b/assets/sprites/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-22T18:16:29.111Z",
+  "generatedAt": "2025-09-24T13:31:02.894Z",
   "sprites": [
     {
       "id": "archer",

--- a/assets/sprites/raider-captain.svg
+++ b/assets/sprites/raider-captain.svg
@@ -1,69 +1,70 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="title desc">
-  <title id="title">Avanto Raider Captain</title>
-  <desc id="desc">Armored raider captain with a polar cloak, runed greataxe, and aurora backlight.</desc>
+  <title id="title">Raid Captain v2</title>
+  <desc id="desc">Luxurious portrait of the raid captain with auric pauldrons, twin war banners, and volcanic dusk backdrop.</desc>
   <defs>
-    <linearGradient id="captain-sky" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#04070f" />
-      <stop offset="0.5" stop-color="#142842" />
-      <stop offset="1" stop-color="#0a1018" />
+    <linearGradient id="captain-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#0a0614" />
+      <stop offset="1" stop-color="#2d1424" />
     </linearGradient>
-    <radialGradient id="captain-halo" cx="52%" cy="18%" r="78%">
-      <stop offset="0" stop-color="#f0f7ff" stop-opacity="0.95" />
-      <stop offset="0.5" stop-color="#9fd0ff" stop-opacity="0.65" />
-      <stop offset="1" stop-color="#071020" stop-opacity="0" />
+    <radialGradient id="captain-glow" cx="50%" cy="32%" r="80%">
+      <stop offset="0" stop-color="#ffeeda" stop-opacity="0.92" />
+      <stop offset="0.48" stop-color="#ffb471" stop-opacity="0.54" />
+      <stop offset="1" stop-color="#20080e" stop-opacity="0" />
     </radialGradient>
-    <linearGradient id="captain-fur" x1="10%" y1="15%" x2="90%" y2="85%">
-      <stop offset="0" stop-color="#5c7089" />
-      <stop offset="1" stop-color="#1a212e" />
+    <linearGradient id="captain-armor" x1="22%" y1="6%" x2="80%" y2="94%">
+      <stop offset="0" stop-color="#fff5f1" />
+      <stop offset="0.36" stop-color="#eed4d5" />
+      <stop offset="0.74" stop-color="#a77983" />
+      <stop offset="1" stop-color="#4f2a33" />
     </linearGradient>
-    <linearGradient id="captain-armor" x1="24%" y1="0%" x2="76%" y2="100%">
-      <stop offset="0" stop-color="#f4fbff" />
-      <stop offset="0.35" stop-color="#d0e8ff" />
-      <stop offset="1" stop-color="#6c9fda" />
+    <linearGradient id="captain-cape" x1="16%" y1="16%" x2="90%" y2="94%">
+      <stop offset="0" stop-color="#f26c38" />
+      <stop offset="0.5" stop-color="#d1333f" />
+      <stop offset="1" stop-color="#ff8d5c" />
     </linearGradient>
-    <linearGradient id="captain-plate" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0" stop-color="#293041" />
-      <stop offset="1" stop-color="#131822" />
+    <linearGradient id="captain-gold" x1="12%" y1="0%" x2="84%" y2="100%">
+      <stop offset="0" stop-color="#fff2c9" />
+      <stop offset="0.45" stop-color="#f7c458" />
+      <stop offset="1" stop-color="#e48319" />
     </linearGradient>
-    <linearGradient id="captain-axe" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0" stop-color="#f7feff" />
-      <stop offset="0.4" stop-color="#b5d4ff" />
-      <stop offset="1" stop-color="#e8f7ff" />
-    </linearGradient>
-    <linearGradient id="captain-glow" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0" stop-color="#ff8f6b" />
-      <stop offset="0.5" stop-color="#ff5768" stop-opacity="0.7" />
-      <stop offset="1" stop-color="#ff8f6b" />
-    </linearGradient>
+    <radialGradient id="captain-shadow" cx="50%" cy="86%" r="46%">
+      <stop offset="0" stop-color="rgba(30,12,18,0.54)" />
+      <stop offset="1" stop-color="rgba(30,12,18,0)" />
+    </radialGradient>
+    <radialGradient id="captain-highlight" cx="52%" cy="18%" r="42%">
+      <stop offset="0" stop-color="rgba(255,203,153,0.78)" />
+      <stop offset="1" stop-color="rgba(255,203,153,0)" />
+    </radialGradient>
   </defs>
   <g transform="translate(3.417475728, 0) scale(0.310679612)">
-      <rect width="184" height="206" rx="20" ry="20" fill="url(#captain-sky)" />
-      <rect width="184" height="206" fill="url(#captain-halo)" />
-      <g transform="translate(16 6)">
-        <path d="M72 18c14-8 32-8 46 0 12 8 18 28 12 44-7 18-30 34-47 34S47 80 40 62c-6-16 2-36 14-44 13-8 29-8 40 0z" fill="#111b2a" opacity="0.8" />
-        <path d="M68 30c10-7 26-7 36 0s14 22 9 34c-5 14-22 24-36 24s-30-10-35-24c-5-12 0-27 9-34z" fill="url(#captain-fur)" />
-        <path d="M80 42c7-5 18-5 24 0 7 4 10 15 6 24-4 10-14 16-24 16s-20-6-24-16c-3-9 0-20 6-24z" fill="#eef7ff" opacity="0.9" />
-        <path d="M66 70c18 8 36 8 52 0l10 20c-16 24-48 26-72 0z" fill="url(#captain-armor)" />
-        <path d="M42 86c22 24 56 24 78 0l22 18-14 44c-22 10-64 12-90 0l-14-44z" fill="url(#captain-plate)" />
-        <path d="M62 96c11 6 23 6 34 0l14 40c-18 12-44 12-62 0z" fill="url(#captain-armor)" />
-        <path d="M34 86c-10 8-20 30-18 44 2 12 12 24 24 30l8-26z" fill="#1d1419" />
-        <path d="M128 86c10 8 20 30 18 44-2 12-12 24-24 30l-8-26z" fill="#1d1419" />
-        <path d="M28 36c-9 8-14 26-10 40 5 16 20 26 32 22l-14-24c-2-10 0-24 5-32 4-8 8-14 16-16-12-2-22 0-29 10z" fill="#0e1623" />
-        <path d="M132 36c9 8 14 26 10 40-5 16-20 26-32 22l14-24c2-10 0-24-5-32-4-8-8-14-16-16 12-2 22 0 29 10z" fill="#0e1623" />
-        <path d="M46 120c-7 18-9 38-7 52 14 10 66 12 92 0 2-14 0-34-7-52-22 14-56 14-78 0z" fill="#0e090f" opacity="0.9" />
-        <path d="M38 178c24 10 76 10 100 0l-6 16c-30 12-58 12-88 0z" fill="#060508" opacity="0.85" />
-        <path d="M-2 112c-1 4 10 14 22 18 8 4 14 4 16 2l8-12-24-16c-8-4-19 0-22 8z" fill="#222a38" />
-        <path d="M152 112c1 4-10 14-22 18-8 4-14 4-16 2l-8-12 24-16c8-4 19 0 22 8z" fill="#222a38" />
-        <path d="M-4 100c-2 8 5 16 16 20 8 3 16 5 22 0s7-13 0-16c-12-6-26-12-38-4z" fill="url(#captain-axe)" transform="rotate(-8 20 112)" />
-        <path d="M156 100c2 8-5 16-16 20-8 3-16 5-22 0s-7-13 0-16c12-6 26-12 38-4z" fill="url(#captain-axe)" transform="rotate(8 132 112)" />
-        <path d="M94 48c4-6 10-6 14 0 2 5-1 10-7 10s-9-5-7-10z" fill="#f3fbff" />
-        <path d="M78 48c4-6 10-6 14 0 2 5-1 10-7 10s-9-5-7-10z" fill="#f3fbff" />
-        <path d="M84 64c7 4 14 4 20 0 0 7-5 14-10 14s-10-7-10-14z" fill="#101622" opacity="0.65" />
-        <path d="M58 152c14 12 48 12 62 0l-12 24c-14 6-24 6-38 0z" fill="#160d12" />
-        <path d="M150 22 170 4c4 8-2 22-12 30l-28 24-10-10z" fill="url(#captain-axe)" />
-        <path d="M42 22 22 4C18 12 24 26 34 34l28 24 10-10z" fill="url(#captain-axe)" />
-        <path d="M166 40 150 52l6 8 20-16z" fill="url(#captain-glow)" />
-        <path d="M14 40 30 52l-6 8L4 44z" fill="url(#captain-glow)" />
-      </g>
+    <rect width="184" height="206" rx="30" fill="url(#captain-sky)" />
+    <circle cx="94" cy="80" r="86" fill="url(#captain-glow)" />
+    <ellipse cx="94" cy="166" rx="68" ry="24" fill="url(#captain-shadow)" />
+    <path d="M28 58c-20 30-22 72-8 108 10 26 26 48 44 62l-12 24c-24-16-44-42-56-72-14-42-4-88 32-122Z" fill="#200911" opacity="0.36" />
+    <path d="M160 54c32 32 44 88 32 128-10 30-30 56-58 76l-12-24c18-14 34-34 42-56 12-36 6-76-16-108Z" fill="#15040b" opacity="0.42" />
+    <path d="M44 72c-18 34-16 76 2 110l34 22c-6-38 4-74 38-104-26-10-50-18-74-28Z" fill="url(#captain-cape)" opacity="0.88" />
+    <path d="M154 72c14 34 12 78-8 108l-34 22c6-38-2-72-34-100 24-8 48-18 76-30Z" fill="url(#captain-cape)" opacity="0.64" />
+    <path d="M76 26 50 60c-14 18-20 40-20 64v32l34 70h56l34-72V110c0-24-8-46-22-64L102 26H76Z" fill="url(#captain-armor)" stroke="#3a1a22" stroke-width="3.4" stroke-linejoin="round" />
+    <path d="M64 118h54l8 26c-16 20-30 28-32 28s-20-10-36-28l6-26Z" fill="#fbeef0" opacity="0.86" />
+    <path d="M86 40c-16 0-30 10-40 22l14 18c18-12 52-12 66 0l14-18c-10-12-26-22-40-22Z" fill="#fdf7f7" stroke="#e4cbcf" stroke-width="2.6" />
+    <path d="M70 24h32l10 12-24 18-26-18 8-12Z" fill="#f5e7ea" stroke="#bb93a1" stroke-width="2.2" />
+    <path d="M60 140l14 44-28 20-24-52 24-14 14 2Z" fill="url(#captain-gold)" opacity="0.88" />
+    <path d="M122 138l28-14-16 54-24-16 12-24Z" fill="#ffe0bb" opacity="0.72" />
+    <path d="M30 122 12 142l44 44 22-22-48-42Z" fill="#401723" opacity="0.62" />
+    <path d="M142 90c20-8 30-16 48-26-4-12-10-22-20-28-14 8-26 16-38 24l10 30Z" fill="#f48d49" stroke="#6d2c16" stroke-width="3.2" />
+    <path d="M132 74 146 44l28-2c8 8 12 20 12 30-14 12-28 22-44 30l-10-28Z" fill="#ffb977" stroke="#7a3414" stroke-width="2.8" />
+    <path d="M96 156c-14 0-28 12-34 26 14 10 28 16 42 16s28-6 42-16c-8-14-20-26-50-26Z" fill="#f1dedd" stroke="#cfa29c" stroke-width="2.2" stroke-linejoin="round" />
+    <path d="M78 104h24l4 12-18 10-18-10 8-12Z" fill="#2e1520" />
+    <circle cx="90" cy="106" r="11" fill="#fff5f2" stroke="#e5c6c9" stroke-width="2" />
+    <path d="M70 82c-10 0-16 8-16 20 12-8 26-10 36-10s24 2 36 10c0-12-6-20-16-20H70Z" fill="#1c0c13" opacity="0.8" />
+    <path d="M76 58c-20 6-32 14-42 28l12 10c10-14 28-22 46-22s36 8 46 22l12-10c-10-14-26-22-42-28-12-2-22-2-32 0Z" fill="#411c26" opacity="0.44" />
+    <g fill="rgba(255,197,150,0.34)">
+      <circle cx="40" cy="48" r="5" />
+      <circle cx="54" cy="34" r="4" />
+      <circle cx="138" cy="36" r="6" />
+      <circle cx="152" cy="50" r="4" />
+      <circle cx="118" cy="24" r="3" />
+    </g>
+    <circle cx="94" cy="62" r="48" fill="url(#captain-highlight)" opacity="0.3" />
   </g>
 </svg>

--- a/assets/sprites/raider-shaman.svg
+++ b/assets/sprites/raider-shaman.svg
@@ -1,79 +1,70 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="title desc">
-  <title id="title">Avanto Raider Shaman</title>
-  <desc id="desc">Mystic raider shaman channeling aurora flame through a crystal staff with drifting runes.</desc>
+  <title id="title">Raid Shaman v2</title>
+  <desc id="desc">Elegant rendering of the raid shaman channeling violet runes, obsidian totems, and auric ritual fire.</desc>
   <defs>
-    <linearGradient id="shaman-sky" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#050811" />
-      <stop offset="0.55" stop-color="#152843" />
-      <stop offset="1" stop-color="#080d16" />
+    <linearGradient id="shaman-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#070412" />
+      <stop offset="1" stop-color="#211433" />
     </linearGradient>
-    <radialGradient id="shaman-halo" cx="48%" cy="20%" r="80%">
-      <stop offset="0" stop-color="#eefbff" stop-opacity="0.95" />
-      <stop offset="0.45" stop-color="#a9ddff" stop-opacity="0.65" />
-      <stop offset="1" stop-color="#060d18" stop-opacity="0" />
+    <radialGradient id="shaman-glow" cx="50%" cy="32%" r="82%">
+      <stop offset="0" stop-color="#f7e6ff" stop-opacity="0.95" />
+      <stop offset="0.5" stop-color="#c296ff" stop-opacity="0.56" />
+      <stop offset="1" stop-color="#180926" stop-opacity="0" />
     </radialGradient>
-    <linearGradient id="shaman-cloak" x1="20%" y1="0%" x2="80%" y2="100%">
-      <stop offset="0" stop-color="#4c5a75" />
-      <stop offset="1" stop-color="#1b222d" />
+    <linearGradient id="shaman-robe" x1="16%" y1="12%" x2="88%" y2="96%">
+      <stop offset="0" stop-color="#8f2cff" />
+      <stop offset="0.5" stop-color="#5b1fc1" />
+      <stop offset="1" stop-color="#c45bff" />
     </linearGradient>
-    <linearGradient id="shaman-robe" x1="30%" y1="0%" x2="70%" y2="100%">
-      <stop offset="0" stop-color="#f6fdff" />
-      <stop offset="0.35" stop-color="#d1eaff" />
-      <stop offset="1" stop-color="#78a9dc" />
+    <linearGradient id="shaman-armor" x1="24%" y1="6%" x2="82%" y2="94%">
+      <stop offset="0" stop-color="#fbf1ff" />
+      <stop offset="0.4" stop-color="#e3d1ff" />
+      <stop offset="0.8" stop-color="#8f7ac8" />
+      <stop offset="1" stop-color="#433466" />
     </linearGradient>
-    <linearGradient id="shaman-belt" x1="10%" y1="0%" x2="90%" y2="100%">
-      <stop offset="0" stop-color="#472b35" />
-      <stop offset="1" stop-color="#2a131a" />
-    </linearGradient>
-    <radialGradient id="shaman-crystal" cx="50%" cy="30%" r="50%">
-      <stop offset="0" stop-color="#9efaff" />
-      <stop offset="0.5" stop-color="#4dd5ff" />
-      <stop offset="1" stop-color="#0c385c" />
+    <radialGradient id="shaman-totem" cx="50%" cy="50%" r="50%">
+      <stop offset="0" stop-color="#ffeec8" />
+      <stop offset="0.45" stop-color="#f9c260" />
+      <stop offset="1" stop-color="#d87a2a" />
     </radialGradient>
-    <linearGradient id="shaman-staff" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0" stop-color="#f8fdff" />
-      <stop offset="0.4" stop-color="#b3d5ff" />
-      <stop offset="1" stop-color="#e4f5ff" />
-    </linearGradient>
-    <radialGradient id="shaman-rune" cx="50%" cy="50%" r="50%">
-      <stop offset="0" stop-color="#ffc091" />
-      <stop offset="0.6" stop-color="#ff6b7f" stop-opacity="0.8" />
-      <stop offset="1" stop-color="#f53b52" stop-opacity="0" />
+    <radialGradient id="shaman-shadow" cx="50%" cy="88%" r="48%">
+      <stop offset="0" stop-color="rgba(18,12,30,0.52)" />
+      <stop offset="1" stop-color="rgba(18,12,30,0)" />
+    </radialGradient>
+    <radialGradient id="shaman-highlight" cx="52%" cy="18%" r="42%">
+      <stop offset="0" stop-color="rgba(236,207,255,0.82)" />
+      <stop offset="1" stop-color="rgba(236,207,255,0)" />
     </radialGradient>
   </defs>
   <g transform="translate(4.830188679, 0) scale(0.301886792)">
-      <rect width="180" height="212" rx="20" ry="20" fill="url(#shaman-sky)" />
-      <rect width="180" height="212" fill="url(#shaman-halo)" />
-      <g transform="translate(18 10)">
-        <path d="M66 18c13-7 30-7 42 0 12 7 18 24 12 38-5 15-26 26-42 26S40 71 34 56c-6-14 1-31 12-38 12-7 27-7 38 0z" fill="#0f1827" opacity="0.78" />
-        <path d="M62 28c9-6 23-6 32 0 9 6 14 20 9 32-5 12-20 20-32 20s-26-8-31-20c-5-12-1-26 9-32z" fill="url(#shaman-cloak)" />
-        <path d="M72 40c6-4 15-4 20 0s8 12 5 18c-3 8-11 12-20 12s-17-4-20-12c-3-6-1-14 5-18z" fill="#eef7ff" opacity="0.9" />
-        <path d="M58 60c14 6 28 6 40 0l10 18c-14 20-40 22-60 0z" fill="url(#shaman-robe)" />
-        <path d="M40 74c18 20 44 20 62 0l18 16-12 40c-20 10-56 10-76 0l-12-40z" fill="url(#shaman-belt)" />
-        <path d="M56 86c10 6 20 6 30 0l12 34c-16 10-38 10-54 0z" fill="url(#shaman-robe)" />
-        <path d="M32 76c-8 8-16 26-14 38 2 10 10 20 20 26l6-22z" fill="#20131a" />
-        <path d="M112 76c8 8 16 26 14 38-2 10-10 20-20 26l-6-22z" fill="#20131a" />
-        <path d="M28 36c-9 8-12 24-8 36 4 14 18 22 28 18l-12-20c-2-9 0-20 4-28 4-6 8-12 14-14-10-2-20 0-26 8z" fill="#0d1520" />
-        <path d="M116 36c9 8 12 24 8 36-4 14-18 22-28 18l12-20c2-9 0-20-4-28-4-6-8-12-14-14 10-2 20 0 26 8z" fill="#0d1520" />
-        <path d="M42 110c-6 16-8 34-6 46 12 8 54 10 74 0 2-12 0-30-6-46-18 12-44 12-62 0z" fill="#0d090f" opacity="0.9" />
-        <path d="M34 164c20 8 64 8 84 0l-6 14c-24 10-48 10-72 0z" fill="#050407" opacity="0.85" />
-        <path d="M-6 96c0 4 10 12 20 16 7 2 12 2 14 0l6-10-20-12c-8-2-18 2-20 6z" fill="#1f2430" />
-        <path d="M144 96c0 4-10 12-20 16-7 2-12 2-14 0l-6-10 20-12c8-2 18 2 20 6z" fill="#1f2430" />
-        <path d="M-4 86c-2 8 4 14 14 18 6 2 14 4 18 0s4-10-2-12c-10-4-20-10-30-6z" fill="url(#shaman-staff)" transform="rotate(-10 16 96)" />
-        <path d="M148 86c2 8-4 14-14 18-6 2-14 4-18 0s-4-10 2-12c10-4 20-10 30-6z" fill="url(#shaman-staff)" transform="rotate(10 128 96)" />
-        <path d="M80 48c3-5 9-5 12 0 2 4 0 8-6 8s-8-4-6-8z" fill="#f3fbff" />
-        <path d="M92 48c3-5 9-5 12 0 2 4 0 8-6 8s-8-4-6-8z" fill="#f3fbff" />
-        <path d="M82 60c6 4 12 4 16 0 0 6-4 10-8 10s-8-4-8-10z" fill="#101622" opacity="0.6" />
-        <path d="M50 144c12 10 40 10 52 0l-10 20c-12 4-20 4-32 0z" fill="#170c12" />
-        <path d="M130 8c8 0 18 6 20 14-14 12-26 26-34 42l-12-6z" fill="url(#shaman-staff)" />
-        <circle cx="140" cy="12" r="12" fill="url(#shaman-crystal)" />
-        <path d="M22 8C14 8 4 14 2 22c14 12 26 26 34 42l12-6z" fill="url(#shaman-staff)" />
-        <circle cx="12" cy="12" r="10" fill="url(#shaman-crystal)" />
-      </g>
-      <g opacity="0.8">
-        <circle cx="32" cy="170" r="8" fill="url(#shaman-rune)" />
-        <circle cx="150" cy="160" r="6" fill="url(#shaman-rune)" />
-        <circle cx="120" cy="186" r="5" fill="url(#shaman-rune)" />
-      </g>
+    <rect width="180" height="212" rx="30" fill="url(#shaman-sky)" />
+    <circle cx="94" cy="86" r="88" fill="url(#shaman-glow)" />
+    <ellipse cx="94" cy="174" rx="70" ry="24" fill="url(#shaman-shadow)" />
+    <path d="M28 62c-22 34-24 78-10 118 10 28 28 52 48 68l-12 26c-28-16-50-44-62-78-16-44-6-92 36-134Z" fill="#1a0a29" opacity="0.36" />
+    <path d="M162 58c34 34 46 92 34 134-10 32-32 60-62 82l-12-26c20-14 36-36 44-60 12-38 6-80-16-110Z" fill="#10051c" opacity="0.42" />
+    <path d="M44 78c-18 34-16 78 2 112l36 24c-6-40 4-78 40-110-26-10-50-20-78-26Z" fill="url(#shaman-robe)" opacity="0.9" />
+    <path d="M156 76c16 34 12 80-8 112l-36 24c6-40-4-74-38-104 26-12 50-20 82-32Z" fill="url(#shaman-robe)" opacity="0.66" />
+    <path d="M78 26 52 62c-14 18-20 42-20 66v34l36 74h58l36-76V116c0-24-10-46-24-64L106 26H78Z" fill="url(#shaman-armor)" stroke="#311c58" stroke-width="3.4" stroke-linejoin="round" />
+    <path d="M66 120h56l8 28c-18 20-32 30-34 30s-22-10-38-30l8-28Z" fill="#f3e9ff" opacity="0.88" />
+    <path d="M88 40c-16 0-32 10-42 24l16 18c18-12 54-12 70 0l16-18c-10-14-28-24-44-24Z" fill="#f9f3ff" stroke="#dbcffd" stroke-width="2.6" />
+    <path d="M72 24h34l10 14-26 18-26-18 8-14Z" fill="#f1e7ff" stroke="#b7a2e0" stroke-width="2.2" />
+    <path d="M62 144l16 46-30 20-26-54 26-16 14 4Z" fill="#5828b5" opacity="0.84" />
+    <path d="M124 142l30-16-18 56-24-16 12-24Z" fill="#f7d8a0" opacity="0.74" />
+    <path d="M30 128 12 150l46 46 22-22-50-46Z" fill="#341445" opacity="0.6" />
+    <path d="M140 98c20-8 30-16 46-28-4-12-10-22-18-28-14 8-26 18-38 26l10 30Z" fill="url(#shaman-totem)" stroke="#703616" stroke-width="3" />
+    <path d="M130 82 144 50l28-4c8 8 12 20 12 30-14 12-28 22-44 32l-10-26Z" fill="url(#shaman-totem)" stroke="#7e3c18" stroke-width="2.8" />
+    <path d="M98 162c-16 0-30 12-36 28 16 10 30 16 44 16s30-6 44-16c-8-16-22-28-52-28Z" fill="#e9dafc" stroke="#bba4f2" stroke-width="2.2" stroke-linejoin="round" />
+    <path d="M80 108h24l4 12-18 10-18-10 8-12Z" fill="#221639" />
+    <circle cx="92" cy="110" r="11" fill="#f5ecff" stroke="#dacffc" stroke-width="2" />
+    <path d="M72 84c-10 0-16 8-16 20 12-8 26-10 36-10s24 2 36 10c0-12-8-20-16-20H72Z" fill="#190d2a" opacity="0.82" />
+    <path d="M78 60c-20 6-34 16-44 32l12 8c10-14 28-22 48-22s36 8 48 22l12-8c-12-16-28-26-46-32-12-2-22-2-30 0Z" fill="#2f1850" opacity="0.46" />
+    <g fill="rgba(229,200,255,0.38)">
+      <circle cx="40" cy="50" r="5" />
+      <circle cx="54" cy="36" r="4" />
+      <circle cx="140" cy="40" r="6" />
+      <circle cx="154" cy="54" r="4" />
+      <circle cx="120" cy="26" r="3" />
+    </g>
+    <circle cx="94" cy="68" r="50" fill="url(#shaman-highlight)" opacity="0.3" />
   </g>
 </svg>

--- a/assets/sprites/raider.svg
+++ b/assets/sprites/raider.svg
@@ -1,72 +1,70 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="title desc">
-  <title id="title">Avanto Raider</title>
-  <desc id="desc">Final production illustration of an Avanto raider cloaked in aurora-lit pelts with twin ice hatchets and drifting embers.</desc>
+  <title id="title">Ashen Raider v2</title>
+  <desc id="desc">High fidelity depiction of the raider with ember-wreathed axes, volcanic armor, and stormlit sky.</desc>
   <defs>
-    <linearGradient id="raider-aurora" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#0a0f1a" />
-      <stop offset="0.55" stop-color="#12243b" />
-      <stop offset="1" stop-color="#0d111c" />
+    <linearGradient id="raider-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#080811" />
+      <stop offset="1" stop-color="#261321" />
     </linearGradient>
-    <radialGradient id="raider-halo" cx="50%" cy="18%" r="80%">
-      <stop offset="0" stop-color="#d7f4ff" stop-opacity="0.9" />
-      <stop offset="0.45" stop-color="#8ecbff" stop-opacity="0.55" />
-      <stop offset="1" stop-color="#091020" stop-opacity="0" />
+    <radialGradient id="raider-glow" cx="52%" cy="32%" r="78%">
+      <stop offset="0" stop-color="#ffe7d6" stop-opacity="0.92" />
+      <stop offset="0.46" stop-color="#ffb27a" stop-opacity="0.55" />
+      <stop offset="1" stop-color="#241018" stop-opacity="0" />
     </radialGradient>
-    <linearGradient id="raider-fur" x1="20%" y1="10%" x2="80%" y2="90%">
-      <stop offset="0" stop-color="#4f5d74" />
-      <stop offset="1" stop-color="#202633" />
+    <linearGradient id="raider-cloak" x1="16%" y1="12%" x2="90%" y2="90%">
+      <stop offset="0" stop-color="#ee4055" />
+      <stop offset="0.5" stop-color="#b51c3f" />
+      <stop offset="1" stop-color="#ff7648" />
     </linearGradient>
-    <linearGradient id="raider-armor" x1="30%" y1="0%" x2="70%" y2="100%">
-      <stop offset="0" stop-color="#f3fcff" />
-      <stop offset="0.35" stop-color="#c5e5ff" />
-      <stop offset="1" stop-color="#6fa1d6" />
+    <linearGradient id="raider-armor" x1="24%" y1="8%" x2="80%" y2="92%">
+      <stop offset="0" stop-color="#fdf5f6" />
+      <stop offset="0.4" stop-color="#e1cfd5" />
+      <stop offset="0.78" stop-color="#9a6d78" />
+      <stop offset="1" stop-color="#4a2b34" />
     </linearGradient>
-    <linearGradient id="raider-leather" x1="15%" y1="0%" x2="85%" y2="100%">
-      <stop offset="0" stop-color="#443137" />
-      <stop offset="1" stop-color="#261317" />
+    <linearGradient id="raider-axe" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0" stop-color="#ffecc6" />
+      <stop offset="0.5" stop-color="#ffb86a" />
+      <stop offset="1" stop-color="#f0632e" />
     </linearGradient>
-    <linearGradient id="raider-steel" x1="0%" x2="100%" y1="0%" y2="0%">
-      <stop offset="0" stop-color="#f8feff" />
-      <stop offset="0.5" stop-color="#b4d7ff" />
-      <stop offset="1" stop-color="#e5f4ff" />
-    </linearGradient>
-    <radialGradient id="raider-ember" cx="50%" cy="50%" r="50%">
-      <stop offset="0" stop-color="#ffb36b" />
-      <stop offset="0.6" stop-color="#ff7058" stop-opacity="0.8" />
-      <stop offset="1" stop-color="#f53b52" stop-opacity="0" />
+    <radialGradient id="raider-shadow" cx="50%" cy="86%" r="46%">
+      <stop offset="0" stop-color="rgba(28,12,18,0.56)" />
+      <stop offset="1" stop-color="rgba(28,12,18,0)" />
+    </radialGradient>
+    <radialGradient id="raider-highlight" cx="52%" cy="20%" r="40%">
+      <stop offset="0" stop-color="rgba(255,204,160,0.76)" />
+      <stop offset="1" stop-color="rgba(255,204,160,0)" />
     </radialGradient>
   </defs>
   <g transform="translate(3.555555556, 0) scale(0.323232323)">
-      <rect width="176" height="198" rx="18" ry="18" fill="url(#raider-aurora)" />
-      <rect width="176" height="198" fill="url(#raider-halo)" />
-      <g transform="translate(20 8)">
-        <path d="M62 10c12-6 28-6 38 0 11 6 16 22 11 36-6 17-27 30-41 30S35 63 30 46c-4-14 3-30 14-36 10-6 23-6 32 0z" fill="#0d1624" opacity="0.75" />
-        <path d="M58 22c9-6 23-6 31 0 9 6 12 20 8 31-5 12-20 21-31 21S39 65 34 53c-4-11-1-25 8-31z" fill="url(#raider-fur)" />
-        <path d="M66 35c6-4 15-4 21 0 7 4 9 13 6 21-3 8-13 14-21 14s-17-6-20-14c-3-8-1-17 6-21z" fill="#e6f4ff" opacity="0.85" />
-        <path d="M58 62c14 6 27 6 38 0l8 18c-14 20-40 22-56 0l10-18z" fill="url(#raider-armor)" />
-        <path d="M38 78c18 20 44 20 62 0l18 14-12 38c-20 8-53 8-74 0L20 92z" fill="url(#raider-leather)" />
-        <path d="M54 86c9 4 19 4 28 0l12 34c-15 10-36 10-52 0l12-34z" fill="url(#raider-armor)" />
-        <path d="M30 76c-9 6-18 26-16 38 2 10 12 20 22 24l8-24z" fill="#2e1d22" />
-        <path d="M108 76c9 6 18 26 16 38-2 10-12 20-22 24l-8-24z" fill="#2e1d22" />
-        <path d="M22 24c-8 6-12 22-8 34 4 14 18 22 28 18l-12-20c-2-8 0-20 4-26s6-10 12-12c-10-2-18 0-24 6z" fill="#101725" />
-        <path d="M116 24c8 6 12 22 8 34-4 14-18 22-28 18l12-20c2-8 0-20-4-26s-6-10-12-12c10-2 18 0 24 6z" fill="#101725" />
-        <path d="M38 110c-6 16-8 34-6 46 12 8 54 10 74 0 2-12 0-30-6-46-18 12-44 12-62 0z" fill="#110b13" opacity="0.85" />
-        <path d="M30 160c20 8 66 8 86 0l-4 12c-26 10-52 10-78 0z" fill="#070608" opacity="0.8" />
-        <path d="M2 104c-1 2 8 10 18 14 7 4 12 4 14 2l6-10-20-12c-8-4-16 0-18 6z" fill="#1d242f" />
-        <path d="M142 104c1 2-8 10-18 14-7 4-12 4-14 2l-6-10 20-12c8-4 16 0 18 6z" fill="#1d242f" />
-        <path d="M0 96c-2 6 4 12 12 16 6 2 13 4 19 0s6-10 0-12c-10-4-22-10-31-4z" fill="url(#raider-steel)" transform="rotate(-6 20 104)" />
-        <path d="M144 96c2 6-4 12-12 16-6 2-13 4-19 0s-6-10 0-12c10-4 22-10 31-4z" fill="url(#raider-steel)" transform="rotate(6 124 104)" />
-        <g fill="#f1fbff" opacity="0.92">
-          <path d="M70 48c2-4 6-4 8 0 1 3-1 6-4 6s-5-3-4-6z" />
-          <path d="M88 48c2-4 6-4 8 0 1 3-1 6-4 6s-5-3-4-6z" />
-        </g>
-        <path d="M74 60c6 4 12 4 16 0 0 6-4 12-8 12s-8-6-8-12z" fill="#101725" opacity="0.65" />
-        <path d="M52 140c12 10 40 10 52 0l-10 20c-12 4-20 4-32 0z" fill="#1a1016" />
-      </g>
-      <g opacity="0.8">
-        <circle cx="34" cy="164" r="8" fill="url(#raider-ember)" />
-        <circle cx="142" cy="154" r="6" fill="url(#raider-ember)" />
-        <circle cx="112" cy="174" r="5" fill="url(#raider-ember)" />
-      </g>
+    <rect width="176" height="198" rx="28" fill="url(#raider-sky)" />
+    <circle cx="88" cy="74" r="80" fill="url(#raider-glow)" />
+    <ellipse cx="90" cy="158" rx="62" ry="20" fill="url(#raider-shadow)" />
+    <path d="M30 56c-18 30-20 66-8 96 8 24 24 44 40 56l-12 22c-22-14-40-38-48-66-10-40-2-80 28-108Z" fill="#1e0d16" opacity="0.34" />
+    <path d="M146 50c26 28 36 70 28 106-8 26-24 50-48 68l-12-22c16-12 30-30 36-50 10-32 6-70-12-102Z" fill="#14060d" opacity="0.4" />
+    <path d="M42 68c-16 30-14 66 2 96l30 18c-4-34 6-64 34-88-22-8-44-16-66-26Z" fill="url(#raider-cloak)" opacity="0.86" />
+    <path d="M144 68c12 30 10 64-6 92l-28 18c4-34-4-64-30-84 22-8 44-16 64-26Z" fill="url(#raider-cloak)" opacity="0.64" />
+    <path d="M72 28 48 60c-12 16-18 34-18 56v28l30 60h50l30-60V104c0-22-8-40-18-56L96 28H72Z" fill="url(#raider-armor)" stroke="#331420" stroke-width="3" stroke-linejoin="round" />
+    <path d="M60 112h48l8 24c-16 18-28 26-30 26s-18-8-32-26l6-24Z" fill="#f6edef" opacity="0.84" />
+    <path d="M82 40c-14 0-28 10-38 20l14 16c16-12 48-12 62 0l14-16c-10-12-24-20-40-20Z" fill="#fdf7f8" stroke="#e2ccd1" stroke-width="2.4" />
+    <path d="M68 24h30l10 12-24 16-24-16 8-12Z" fill="#f2e4eb" stroke="#bb90a0" stroke-width="2" />
+    <path d="M60 134l12 40-26 18-20-48 22-12 12 2Z" fill="#ff7b55" opacity="0.78" />
+    <path d="M116 132l26-12-14 48-22-14 10-22Z" fill="#ffd8b8" opacity="0.7" />
+    <path d="M24 120 8 134l40 38 22-20-46-32Z" fill="#2f1626" opacity="0.6" />
+    <path d="M142 90c18-6 28-12 44-22-4-12-10-22-20-28-14 8-26 16-38 24l14 26Z" fill="url(#raider-axe)" stroke="#6e2b16" stroke-width="3" />
+    <path d="M132 72 148 42l26-2c8 6 12 18 12 28-14 10-28 20-44 28l-10-24Z" fill="url(#raider-axe)" stroke="#7a3118" stroke-width="2.6" />
+    <path d="M92 150c-12 0-24 10-30 22 12 10 24 14 38 14s26-4 38-14c-6-12-18-22-46-22Z" fill="#f0d9dd" stroke="#c598a4" stroke-width="2" stroke-linejoin="round" />
+    <path d="M74 100h22l4 12-16 8-16-8 6-12Z" fill="#28131f" />
+    <circle cx="84" cy="102" r="10" fill="#fff4f2" stroke="#e0c2c9" stroke-width="1.8" />
+    <path d="M66 78c-8 0-14 8-14 18 12-6 24-10 34-10s22 4 34 10c0-10-6-18-14-18H66Z" fill="#1c0e13" opacity="0.82" />
+    <path d="M72 56c-18 4-30 12-40 26l12 8c8-12 24-20 40-20s32 8 40 20l12-8c-10-14-24-22-40-26-8-2-18-2-24 0Z" fill="#3c1924" opacity="0.42" />
+    <g fill="rgba(255,188,150,0.32)">
+      <circle cx="34" cy="46" r="4" />
+      <circle cx="50" cy="32" r="3" />
+      <circle cx="130" cy="36" r="5" />
+      <circle cx="142" cy="50" r="3" />
+      <circle cx="118" cy="24" r="3" />
+    </g>
+    <circle cx="88" cy="60" r="44" fill="url(#raider-highlight)" opacity="0.28" />
   </g>
 </svg>

--- a/assets/sprites/saunoja-guardian.svg
+++ b/assets/sprites/saunoja-guardian.svg
@@ -1,50 +1,67 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="title desc">
-  <title id="title">Saunoja Guardian v1</title>
-  <desc id="desc">First production badge of a Saunoja guardian wrapped in steamlight with herbal satchel.</desc>
+  <title id="title">Saunoja Guardian v2</title>
+  <desc id="desc">Luxe depiction of a Saunoja guardian cradled in steam with herbal satchel, auric trim, and twilight pane.</desc>
   <defs>
-    <radialGradient id="guardian-halo" cx="50%" cy="34%" r="80%">
-      <stop offset="0" stop-color="#fefaf5" stop-opacity="0.92" />
-      <stop offset="0.48" stop-color="#dbe9ff" stop-opacity="0.54" />
-      <stop offset="1" stop-color="#18223a" stop-opacity="0" />
+    <linearGradient id="guardian-panel" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#120b28" />
+      <stop offset="1" stop-color="#23345c" />
+    </linearGradient>
+    <radialGradient id="guardian-halo" cx="50%" cy="30%" r="80%">
+      <stop offset="0" stop-color="#fcf8ff" stop-opacity="0.94" />
+      <stop offset="0.48" stop-color="#d4e4ff" stop-opacity="0.58" />
+      <stop offset="1" stop-color="#17263f" stop-opacity="0" />
     </radialGradient>
-    <linearGradient id="guardian-panel" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#1a0f2f" />
-      <stop offset="1" stop-color="#1c2747" />
-    </linearGradient>
-    <linearGradient id="guardian-robe" x1="20%" x2="80%" y1="14%" y2="92%">
+    <linearGradient id="guardian-robe" x1="18%" y1="16%" x2="84%" y2="94%">
       <stop offset="0" stop-color="#f8f3ff" />
-      <stop offset="0.44" stop-color="#d8c9ff" />
-      <stop offset="1" stop-color="#9a86ff" />
+      <stop offset="0.42" stop-color="#d9caff" />
+      <stop offset="1" stop-color="#9c88ff" />
     </linearGradient>
-    <linearGradient id="guardian-trim" x1="22%" x2="78%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#fde49a" />
-      <stop offset="0.52" stop-color="#f2a94d" />
-      <stop offset="1" stop-color="#de6f28" />
+    <linearGradient id="guardian-trim" x1="18%" y1="0%" x2="82%" y2="100%">
+      <stop offset="0" stop-color="#ffecc6" />
+      <stop offset="0.5" stop-color="#f1b65a" />
+      <stop offset="1" stop-color="#d97a22" />
     </linearGradient>
-    <linearGradient id="guardian-hair" x1="18%" x2="82%" y1="22%" y2="88%">
-      <stop offset="0" stop-color="#251138" />
-      <stop offset="1" stop-color="#532d7f" />
+    <linearGradient id="guardian-hair" x1="20%" y1="16%" x2="80%" y2="88%">
+      <stop offset="0" stop-color="#2c1746" />
+      <stop offset="1" stop-color="#5a2f7d" />
     </linearGradient>
     <radialGradient id="guardian-shadow" cx="50%" cy="86%" r="48%">
-      <stop offset="0" stop-color="rgba(12,18,36,0.55)" />
-      <stop offset="1" stop-color="rgba(12,18,36,0)" />
+      <stop offset="0" stop-color="rgba(16,24,42,0.55)" />
+      <stop offset="1" stop-color="rgba(16,24,42,0)" />
+    </radialGradient>
+    <radialGradient id="guardian-highlight" cx="50%" cy="24%" r="40%">
+      <stop offset="0" stop-color="rgba(255,255,255,0.78)" />
+      <stop offset="1" stop-color="rgba(255,255,255,0)" />
     </radialGradient>
   </defs>
   <g transform="translate(2.909090909, 0) scale(0.363636364)">
-      <rect width="160" height="176" rx="28" fill="url(#guardian-panel)" />
-      <circle cx="80" cy="70" r="70" fill="url(#guardian-halo)" />
-      <ellipse cx="82" cy="142" rx="54" ry="18" fill="url(#guardian-shadow)" />
-      <path d="M66 42 44 70c-10 12-16 28-16 46v22l24 46h44l24-48v-20c0-18-6-34-16-46L94 42H66Z" fill="url(#guardian-robe)" stroke="#1a2742" stroke-width="2.6" stroke-linejoin="round" />
-      <path d="M62 110h40l6 16c-12 14-24 20-26 20s-16-6-28-20l8-16Z" fill="#f3f4ff" opacity="0.92" />
-      <path d="M80 50c-10 0-20 6-28 14l10 12c12-8 36-8 48 0l10-12c-8-8-18-14-30-14Z" fill="#fff9ff" stroke="#d3c9ff" stroke-width="2" />
-      <path d="M70 34h20l8 10-18 12-18-12 8-10Z" fill="#ede7ff" stroke="#9f9fe0" stroke-width="1.8" />
-      <path d="M58 128l10 30-18 12-18-36 16-8 10 2Z" fill="url(#guardian-trim)" opacity="0.96" />
-      <path d="M102 126l20-8-10 34-18-10 8-16Z" fill="#ffe8c8" opacity="0.76" />
-      <path d="M88 92c-18 0-30-14-30-30 0-12 10-22 22-22s22 10 22 22c0 16-10 30-14 30Z" fill="url(#guardian-hair)" />
-      <circle cx="70" cy="90" r="6" fill="#2b1b3f" opacity="0.8" />
-      <circle cx="96" cy="90" r="6" fill="#2b1b3f" opacity="0.8" />
-      <path d="M70 74c-6 0-10 6-10 14 8-4 16-6 24-6s16 2 24 6c0-8-4-14-10-14H70Z" fill="#1f1733" opacity="0.82" />
-      <path d="M72 98h16l4 10-12 8-12-8 4-10Z" fill="#1b2036" />
-      <circle cx="80" cy="100" r="8" fill="#f6f9ff" stroke="#cfd7f5" stroke-width="1.6" />
+    <rect width="160" height="176" rx="28" fill="url(#guardian-panel)" />
+    <circle cx="82" cy="68" r="72" fill="url(#guardian-halo)" />
+    <ellipse cx="82" cy="142" rx="54" ry="18" fill="url(#guardian-shadow)" />
+    <path d="M32 46c-14 24-18 52-10 80 6 22 20 40 34 52l-10 18c-20-12-36-34-44-58-10-32-4-68 20-92Z" fill="#0f1a32" opacity="0.32" />
+    <path d="M132 42c22 24 30 60 22 90-6 24-22 46-44 60l-10-18c12-10 22-26 28-40 8-28 4-60-12-92Z" fill="#0b1024" opacity="0.34" />
+    <path d="M64 40 42 68c-10 14-16 32-16 50v24l24 48h46l26-50v-22c0-18-6-36-16-48L90 40H64Z" fill="url(#guardian-robe)" stroke="#1c2f50" stroke-width="2.8" stroke-linejoin="round" />
+    <path d="M58 108h44l8 20c-14 16-24 22-26 22s-16-6-30-22l4-20Z" fill="#f4f4ff" opacity="0.92" />
+    <path d="M80 48c-12 0-22 6-30 14l10 12c14-10 38-10 50 0l10-12c-8-8-18-14-30-14Z" fill="#fff9ff" stroke="#d8cff7" stroke-width="2.2" />
+    <path d="M70 32h22l8 10-18 12-18-12 6-10Z" fill="#efe7ff" stroke="#a6a0dd" stroke-width="1.9" />
+    <path d="M54 120c-8 18-14 28-26 34l-8-20 22-14 12 0Z" fill="url(#guardian-trim)" opacity="0.88" />
+    <path d="M108 118l24-12-8 32c-12-2-20-6-28-14l12-6Z" fill="#ffe4c6" opacity="0.72" />
+    <path d="M38 100 24 112l32 30 16-14-34-28Z" fill="url(#guardian-trim)" opacity="0.66" />
+    <path d="M102 94c16-6 24-12 36-20-4-8-10-14-16-18-10 6-20 12-30 18l10 20Z" fill="#ffd9a0" stroke="#8a4a16" stroke-width="2.4" />
+    <path d="M62 98l-18 8 10 28 26-12-18-24Z" fill="#ffe5c8" opacity="0.74" />
+    <ellipse cx="82" cy="122" rx="26" ry="16" fill="#ece7ff" stroke="#c4b9ff" stroke-width="2" />
+    <path d="M70 88h22l4 12-16 8-16-8 6-12Z" fill="#1f223d" />
+    <circle cx="82" cy="90" r="10" fill="#f5f6ff" stroke="#d2d7f4" stroke-width="1.8" />
+    <path d="M64 66c-8 0-14 6-14 16 10-6 20-8 30-8s20 2 30 8c0-10-6-16-14-16H64Z" fill="#111b33" opacity="0.82" />
+    <path d="M70 52c-16 4-26 10-34 20l10 6c8-8 20-14 32-14s26 6 34 14l10-6c-8-12-22-18-36-20-6-2-12-2-16 0Z" fill="#22345a" opacity="0.42" />
+    <path d="M76 22c-12 4-18 12-20 20l10 4c4-8 10-12 18-12s16 4 20 12l10-4c-4-8-12-16-24-20-4-2-8-2-14 0Z" fill="url(#guardian-hair)" />
+    <g fill="rgba(230,243,255,0.4)">
+      <circle cx="32" cy="46" r="4" />
+      <circle cx="46" cy="34" r="3" />
+      <circle cx="126" cy="40" r="5" />
+      <circle cx="138" cy="54" r="3" />
+      <circle cx="112" cy="26" r="3" />
+    </g>
+    <circle cx="82" cy="60" r="40" fill="url(#guardian-highlight)" opacity="0.28" />
   </g>
 </svg>

--- a/assets/sprites/saunoja-seer.svg
+++ b/assets/sprites/saunoja-seer.svg
@@ -1,57 +1,72 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="title desc">
-  <title id="title">Saunoja Seer v1</title>
-  <desc id="desc">First production badge of a Saunoja seer with crystal focus and drifting steam.</desc>
+  <title id="title">Saunoja Seer v2</title>
+  <desc id="desc">Refined portrait of a Saunoja seer with crystal focus, drifting steam, and aurora palette.</desc>
   <defs>
-    <linearGradient id="seer-panel" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#0f1a2c" />
-      <stop offset="1" stop-color="#1a2f48" />
+    <linearGradient id="seer-panel" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#0e1a2f" />
+      <stop offset="1" stop-color="#1b3354" />
     </linearGradient>
-    <radialGradient id="seer-halo" cx="48%" cy="36%" r="82%">
-      <stop offset="0" stop-color="#f6faff" stop-opacity="0.94" />
-      <stop offset="0.48" stop-color="#d8f4ff" stop-opacity="0.54" />
-      <stop offset="1" stop-color="#13243b" stop-opacity="0" />
+    <radialGradient id="seer-halo" cx="50%" cy="32%" r="82%">
+      <stop offset="0" stop-color="#f5faff" stop-opacity="0.94" />
+      <stop offset="0.48" stop-color="#d6f0ff" stop-opacity="0.58" />
+      <stop offset="1" stop-color="#13263f" stop-opacity="0" />
     </radialGradient>
-    <linearGradient id="seer-robe" x1="24%" x2="78%" y1="14%" y2="94%">
+    <linearGradient id="seer-robe" x1="24%" y1="14%" x2="80%" y2="94%">
       <stop offset="0" stop-color="#fefcff" />
-      <stop offset="0.4" stop-color="#e4d9ff" />
-      <stop offset="1" stop-color="#9ac4ff" />
+      <stop offset="0.4" stop-color="#e5ddff" />
+      <stop offset="1" stop-color="#a0c9ff" />
     </linearGradient>
-    <linearGradient id="seer-sash" x1="18%" x2="82%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#8de7ff" />
-      <stop offset="0.52" stop-color="#54b9ff" />
-      <stop offset="1" stop-color="#3f6bff" />
+    <linearGradient id="seer-sash" x1="16%" y1="0%" x2="84%" y2="100%">
+      <stop offset="0" stop-color="#8fe8ff" />
+      <stop offset="0.5" stop-color="#5cb8ff" />
+      <stop offset="1" stop-color="#436cff" />
     </linearGradient>
-    <linearGradient id="seer-hair" x1="18%" x2="82%" y1="22%" y2="88%">
-      <stop offset="0" stop-color="#2e143f" />
-      <stop offset="1" stop-color="#753a8f" />
+    <linearGradient id="seer-hair" x1="20%" y1="16%" x2="80%" y2="90%">
+      <stop offset="0" stop-color="#321648" />
+      <stop offset="1" stop-color="#7a3f94" />
     </linearGradient>
-    <radialGradient id="seer-crystal" cx="50%" cy="50%" r="60%">
-      <stop offset="0" stop-color="#fef7ff" />
-      <stop offset="0.5" stop-color="#b9e0ff" />
-      <stop offset="1" stop-color="#5b9dff" />
+    <radialGradient id="seer-crystal" cx="50%" cy="52%" r="60%">
+      <stop offset="0" stop-color="#f7feff" />
+      <stop offset="0.5" stop-color="#c2e8ff" />
+      <stop offset="1" stop-color="#5b9cff" />
     </radialGradient>
     <radialGradient id="seer-shadow" cx="50%" cy="86%" r="48%">
-      <stop offset="0" stop-color="rgba(10,20,40,0.55)" />
-      <stop offset="1" stop-color="rgba(10,20,40,0)" />
+      <stop offset="0" stop-color="rgba(12,20,42,0.55)" />
+      <stop offset="1" stop-color="rgba(12,20,42,0)" />
+    </radialGradient>
+    <radialGradient id="seer-highlight" cx="50%" cy="24%" r="40%">
+      <stop offset="0" stop-color="rgba(235,247,255,0.78)" />
+      <stop offset="1" stop-color="rgba(235,247,255,0)" />
     </radialGradient>
   </defs>
   <g transform="translate(2.909090909, 0) scale(0.363636364)">
-      <rect width="160" height="176" rx="28" fill="url(#seer-panel)" />
-      <circle cx="78" cy="72" r="72" fill="url(#seer-halo)" />
-      <ellipse cx="80" cy="144" rx="54" ry="18" fill="url(#seer-shadow)" />
-      <path d="M64 40 42 68c-10 12-16 28-16 46v24l24 46h44l24-46v-24c0-18-6-34-16-46L92 40H64Z" fill="url(#seer-robe)" stroke="#1a2c46" stroke-width="2.6" stroke-linejoin="round" />
-      <path d="M60 110h40l6 18c-12 14-24 20-26 20s-16-6-28-20l8-18Z" fill="#f2f4ff" opacity="0.9" />
-      <path d="M78 50c-10 0-22 6-30 14l10 12c12-8 34-8 46 0l10-12c-8-8-16-14-28-14Z" fill="#fbf9ff" stroke="#ccd7ff" stroke-width="2" />
-      <path d="M68 34h20l8 10-18 12-18-12 8-10Z" fill="#ecefff" stroke="#9cb5e0" stroke-width="1.8" />
-      <path d="M56 130l12 30-20 12-18-36 14-8 12 2Z" fill="url(#seer-sash)" opacity="0.94" />
-      <path d="M100 128l18-8-8 34-18-10 8-16Z" fill="#e8f3ff" opacity="0.74" />
-      <path d="M74 90c-16 0-26-12-26-26 0-10 8-18 18-18s18 8 18 18c0 14-8 26-10 26Z" fill="url(#seer-hair)" />
-      <path d="M52 118l18 26-16 10-18-30 16-6Z" fill="url(#seer-crystal)" />
-      <circle cx="66" cy="90" r="6" fill="#2a1f3a" opacity="0.8" />
-      <circle cx="90" cy="90" r="6" fill="#2a1f3a" opacity="0.8" />
-      <path d="M66 74c-6 0-10 6-10 14 8-4 16-6 24-6s16 2 24 6c0-8-4-14-10-14H66Z" fill="#18233a" opacity="0.82" />
-      <path d="M68 96h16l4 10-12 8-12-8 4-10Z" fill="#172034" />
-      <circle cx="76" cy="98" r="7" fill="#f7faff" stroke="#cad6f3" stroke-width="1.6" />
-      <circle cx="104" cy="122" r="10" fill="url(#seer-crystal)" stroke="#4c85ff" stroke-width="1.6" />
+    <rect width="160" height="176" rx="28" fill="url(#seer-panel)" />
+    <circle cx="80" cy="70" r="72" fill="url(#seer-halo)" />
+    <ellipse cx="82" cy="142" rx="54" ry="18" fill="url(#seer-shadow)" />
+    <path d="M30 48c-14 26-18 54-10 82 8 22 22 40 36 52l-10 18c-20-12-36-34-44-58-10-32-4-68 18-94Z" fill="#102239" opacity="0.32" />
+    <path d="M132 44c22 24 30 60 22 90-6 24-20 46-42 60l-10-18c12-10 22-26 28-40 8-28 4-60-12-92Z" fill="#0d1a31" opacity="0.34" />
+    <path d="M64 40 42 68c-10 14-16 32-16 52v22l24 48h46l26-50v-22c0-20-6-36-16-50L90 40H64Z" fill="url(#seer-robe)" stroke="#1b2f4d" stroke-width="2.8" stroke-linejoin="round" />
+    <path d="M60 108h44l8 20c-14 16-24 22-26 22s-16-6-30-22l4-20Z" fill="#f5f7ff" opacity="0.92" />
+    <path d="M80 50c-12 0-22 6-30 14l10 12c14-10 38-10 50 0l10-12c-8-8-18-14-30-14Z" fill="#fff9ff" stroke="#dbe3ff" stroke-width="2.2" />
+    <path d="M68 34h22l8 10-18 12-18-12 6-10Z" fill="#f0eaff" stroke="#a6afdf" stroke-width="1.9" />
+    <path d="M76 20c-14 4-22 12-24 22l10 4c4-8 10-12 18-12s16 4 20 12l10-4c-4-10-12-18-26-22-4-2-6-2-8 0Z" fill="url(#seer-hair)" />
+    <path d="M58 126c-10 18-16 28-28 34l-8-20 24-14 12 0Z" fill="url(#seer-sash)" opacity="0.84" />
+    <path d="M106 124l26-12-8 32c-12-2-20-6-28-14l10-6Z" fill="#e5f3ff" opacity="0.76" />
+    <path d="M38 102 24 116l32 30 16-14-34-30Z" fill="url(#seer-sash)" opacity="0.66" />
+    <path d="M96 98c14-4 22-10 34-18-4-10-10-16-16-20-12 8-22 14-30 20l12 18Z" fill="url(#seer-crystal)" stroke="#3a6fde" stroke-width="2.2" />
+    <path d="M68 98l-18 8 10 28 26-12-18-24Z" fill="url(#seer-crystal)" opacity="0.78" />
+    <ellipse cx="82" cy="122" rx="26" ry="16" fill="#f0f6ff" stroke="#bcd6ff" stroke-width="2" />
+    <path d="M70 90h22l4 12-16 8-16-8 6-12Z" fill="#202c43" />
+    <circle cx="82" cy="92" r="10" fill="#f4f8ff" stroke="#d5e2ff" stroke-width="1.8" />
+    <path d="M64 68c-8 0-14 6-14 16 10-6 20-8 30-8s20 2 30 8c0-10-6-16-14-16H64Z" fill="#112438" opacity="0.82" />
+    <path d="M70 54c-16 4-26 10-34 20l10 6c8-8 20-14 32-14s26 6 34 14l10-6c-8-12-20-18-34-22-8-2-14-2-18 0Z" fill="#253e63" opacity="0.44" />
+    <g fill="rgba(224,244,255,0.42)">
+      <circle cx="34" cy="48" r="4" />
+      <circle cx="48" cy="34" r="3" />
+      <circle cx="124" cy="38" r="5" />
+      <circle cx="136" cy="52" r="3" />
+      <circle cx="112" cy="24" r="3" />
+    </g>
+    <circle cx="80" cy="60" r="42" fill="url(#seer-highlight)" opacity="0.28" />
   </g>
 </svg>

--- a/assets/sprites/soldier.svg
+++ b/assets/sprites/soldier.svg
@@ -1,71 +1,82 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-labelledby="title desc">
-  <title id="title">Auric Warder v1</title>
-  <desc id="desc">First-pass production render of the Saunoja frontline warder with aurora-lit shield and radiant blade.</desc>
+  <title id="title">Auric Warder v2</title>
+  <desc id="desc">Polished illustration of the Saunoja frontline warder with luminous shield, aurora-lit cape, and gilded blade.</desc>
   <defs>
-    <radialGradient id="soldier-glow" cx="52%" cy="32%" r="78%">
-      <stop offset="0" stop-color="#eef8ff" stop-opacity="0.95" />
-      <stop offset="0.45" stop-color="#b9dcff" stop-opacity="0.58" />
-      <stop offset="1" stop-color="#12243d" stop-opacity="0" />
+    <radialGradient id="soldier-aura" cx="54%" cy="32%" r="78%">
+      <stop offset="0" stop-color="#f6fbff" stop-opacity="0.98" />
+      <stop offset="0.42" stop-color="#c6dcff" stop-opacity="0.62" />
+      <stop offset="1" stop-color="#13223d" stop-opacity="0" />
     </radialGradient>
-    <linearGradient id="soldier-night" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#061021" />
-      <stop offset="1" stop-color="#10213b" />
+    <linearGradient id="soldier-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#040b1d" />
+      <stop offset="1" stop-color="#10254a" />
     </linearGradient>
-    <linearGradient id="soldier-armor" x1="22%" x2="78%" y1="6%" y2="94%">
+    <linearGradient id="soldier-armor" x1="18%" y1="6%" x2="84%" y2="94%">
       <stop offset="0" stop-color="#f9fbff" />
-      <stop offset="0.36" stop-color="#d7e3fb" />
-      <stop offset="0.72" stop-color="#9ab2d8" />
-      <stop offset="1" stop-color="#506187" />
+      <stop offset="0.38" stop-color="#dce8ff" />
+      <stop offset="0.76" stop-color="#95afd6" />
+      <stop offset="1" stop-color="#4b5d82" />
     </linearGradient>
-    <linearGradient id="soldier-gold" x1="18%" x2="82%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#fde9a5" />
-      <stop offset="0.44" stop-color="#f7c657" />
-      <stop offset="1" stop-color="#f59e0b" />
+    <linearGradient id="soldier-cape" x1="22%" y1="12%" x2="86%" y2="96%">
+      <stop offset="0" stop-color="#2d84ff" />
+      <stop offset="0.52" stop-color="#3878f2" />
+      <stop offset="1" stop-color="#12c6ff" />
     </linearGradient>
-    <linearGradient id="soldier-cloak" x1="14%" x2="92%" y1="18%" y2="90%">
-      <stop offset="0" stop-color="#2e5de3" />
-      <stop offset="1" stop-color="#1bb4f2" />
+    <linearGradient id="soldier-gold" x1="12%" y1="0%" x2="88%" y2="100%">
+      <stop offset="0" stop-color="#fff4d0" />
+      <stop offset="0.45" stop-color="#f7c85a" />
+      <stop offset="1" stop-color="#e58c19" />
     </linearGradient>
-    <radialGradient id="soldier-shield" cx="42%" cy="46%" r="70%">
-      <stop offset="0" stop-color="#fdf7d1" />
-      <stop offset="0.44" stop-color="#9dd1ff" />
-      <stop offset="1" stop-color="#1c57d9" />
+    <radialGradient id="soldier-shield" cx="48%" cy="46%" r="72%">
+      <stop offset="0" stop-color="#fdf6d8" />
+      <stop offset="0.38" stop-color="#a4d8ff" />
+      <stop offset="0.78" stop-color="#2d68de" />
+      <stop offset="1" stop-color="#12326d" />
     </radialGradient>
-    <linearGradient id="soldier-sword" x1="0%" x2="0%" y1="0%" y2="100%">
-      <stop offset="0" stop-color="#f4fbff" />
-      <stop offset="0.62" stop-color="#9cc7fb" />
-      <stop offset="1" stop-color="#1a2750" />
+    <linearGradient id="soldier-sword" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0" stop-color="#f1f8ff" />
+      <stop offset="0.55" stop-color="#a1c7ff" />
+      <stop offset="1" stop-color="#16274d" />
     </linearGradient>
     <radialGradient id="soldier-shadow" cx="50%" cy="86%" r="46%">
-      <stop offset="0" stop-color="rgba(10,16,32,0.55)" />
+      <stop offset="0" stop-color="rgba(10,16,32,0.52)" />
       <stop offset="1" stop-color="rgba(10,16,32,0)" />
+    </radialGradient>
+    <radialGradient id="soldier-highlight" cx="52%" cy="22%" r="42%">
+      <stop offset="0" stop-color="rgba(255,255,255,0.8)" />
+      <stop offset="1" stop-color="rgba(255,255,255,0)" />
     </radialGradient>
   </defs>
   <g transform="translate(4.173913043, 0) scale(0.347826087)">
-      <rect width="160" height="184" rx="26" fill="url(#soldier-night)" />
-      <circle cx="82" cy="70" r="72" fill="url(#soldier-glow)" />
-      <ellipse cx="80" cy="150" rx="58" ry="18" fill="url(#soldier-shadow)" />
-      <path d="M34 58c-10 26-8 54 6 82l24 12c-2-30 8-58 30-78-22-6-40-10-60-16Z" fill="url(#soldier-cloak)" opacity="0.82" />
-      <path d="M136 62c12 24 12 54-2 80l-24 12c4-30-6-58-28-78 20-4 38-8 54-14Z" fill="url(#soldier-cloak)" opacity="0.62" />
-      <path d="M68 28 46 58c-10 14-16 32-16 52v28l26 56h48l28-58V98c0-20-6-38-18-52L92 28H68Z" fill="url(#soldier-armor)" stroke="#12243d" stroke-width="3.2" stroke-linejoin="round" />
-      <path d="M58 104h44l8 20c-14 16-28 24-30 24s-18-8-32-24l10-20Z" fill="#e8f4ff" opacity="0.9" />
-      <path d="M80 40c-12 0-24 8-34 18l12 14c14-10 44-10 58 0l12-14c-10-12-22-18-36-18Z" fill="#f8fbff" stroke="#cad8f2" stroke-width="2.6" />
-      <path d="M66 24h28l10 12-24 14-24-14 10-12Z" fill="#e7edfb" stroke="#9aaed6" stroke-width="2.2" />
-      <path d="M62 126l12 36-24 14-20-44 20-10 12 4Z" fill="url(#soldier-gold)" opacity="0.94" />
-      <path d="M104 124l24-10-14 46-22-14 12-22Z" fill="#fff3d6" opacity="0.7" />
-      <path d="M38 112 20 126l34 36 20-18-36-32Z" fill="url(#soldier-shield)" stroke="#16337f" stroke-width="2.6" />
-      <circle cx="50" cy="130" r="12" fill="rgba(255,255,255,0.45)" />
-      <path d="M128 102 112 90l-32 74 14 12 34-74Z" fill="url(#soldier-sword)" stroke="#091733" stroke-width="2.6" stroke-linejoin="round" />
-      <path d="M92 96 72 144l18 10 26-56-24-2Z" fill="#f4f7ff" opacity="0.72" />
-      <path d="M80 146c-12 0-24 10-30 22 10 8 20 12 32 12s20-4 32-12c-6-12-18-22-34-22Z" fill="#d8e8ff" stroke="#95c5ff" stroke-width="1.9" stroke-linejoin="round" />
-      <path d="M70 90h20l4 12-14 8-14-8 4-12Z" fill="#152744" />
-      <circle cx="80" cy="92" r="10" fill="#f5f8ff" stroke="#c7d6f0" stroke-width="1.8" />
-      <path d="M64 70c-8 0-14 8-14 18 10-6 20-8 30-8s20 2 30 8c0-10-6-18-14-18H64Z" fill="#0c1730" opacity="0.82" />
-      <g fill="rgba(224,241,255,0.42)">
-        <circle cx="30" cy="46" r="4" />
-        <circle cx="46" cy="36" r="3" />
-        <circle cx="134" cy="44" r="5" />
-        <circle cx="122" cy="30" r="3" />
-      </g>
+    <rect width="160" height="184" rx="26" fill="url(#soldier-sky)" />
+    <circle cx="84" cy="70" r="74" fill="url(#soldier-aura)" />
+    <path d="M26 38c-4 16 10 40 6 60-4 22 6 36 20 44l-10 18c-16-10-28-28-34-50-6-26 2-52 18-72Z" fill="#10325d" opacity="0.34" />
+    <path d="M142 34c16 18 26 46 20 74-6 24-18 42-36 52l-10-18c14-8 24-26 22-44-4-22 12-44 4-64Z" fill="#0b213c" opacity="0.36" />
+    <ellipse cx="82" cy="150" rx="58" ry="18" fill="url(#soldier-shadow)" />
+    <path d="M38 58c-12 28-10 58 4 86l26 12c-2-30 8-58 30-78-24-6-42-12-60-20Z" fill="url(#soldier-cape)" opacity="0.82" />
+    <path d="M136 60c12 28 12 58-2 84l-24 12c4-30-6-58-28-78 20-6 38-10 54-18Z" fill="url(#soldier-cape)" opacity="0.58" />
+    <path d="M68 26 46 58c-12 16-18 34-18 54v28l26 56h50l28-58V98c0-22-8-40-20-54L92 26H68Z" fill="url(#soldier-armor)" stroke="#162c4b" stroke-width="3" stroke-linejoin="round" />
+    <path d="M58 104h48l8 22c-16 18-30 26-32 26s-18-8-34-26l10-22Z" fill="#e8f1ff" opacity="0.9" />
+    <path d="M80 38c-12 0-26 8-36 20l14 16c16-10 46-10 60 0l14-16c-10-12-24-20-38-20Z" fill="#f8fbff" stroke="#cdd9f0" stroke-width="2.6" />
+    <path d="M66 22h30l10 12-24 16-26-16 10-12Z" fill="#ebf2ff" stroke="#9db1d8" stroke-width="2" />
+    <path d="M60 126l14 38-26 16-20-46 22-12 10 4Z" fill="url(#soldier-gold)" opacity="0.96" />
+    <path d="M108 124l24-12-16 48-22-14 14-22Z" fill="#ffefd6" opacity="0.72" />
+    <path d="M36 112 18 128l36 38 22-18-40-36Z" fill="url(#soldier-shield)" stroke="#13377a" stroke-width="2.8" />
+    <circle cx="52" cy="132" r="13" fill="rgba(255,255,255,0.45)" />
+    <path d="M126 102 108 90l-34 78 16 12 36-78Z" fill="url(#soldier-sword)" stroke="#091832" stroke-width="2.8" stroke-linejoin="round" />
+    <path d="M90 96 70 146l20 10 28-60-28 0Z" fill="#f4f7ff" opacity="0.74" />
+    <path d="M80 148c-12 0-24 10-30 22 12 8 22 12 34 12s22-4 34-12c-6-12-18-22-38-22Z" fill="#d8e8ff" stroke="#9ccaff" stroke-width="1.9" stroke-linejoin="round" />
+    <path d="M68 90h22l4 12-16 8-16-8 6-12Z" fill="#172a46" />
+    <circle cx="80" cy="92" r="10" fill="#f4f8ff" stroke="#c5d6f0" stroke-width="1.8" />
+    <path d="M62 68c-8 0-14 8-14 18 10-6 22-8 32-8s22 2 32 8c0-10-6-18-14-18H62Z" fill="#0c1730" opacity="0.84" />
+    <path d="M70 54c14-4 26-4 40 0 6 2 10 6 12 10l-12 8c-16-6-32-6-48 0l-12-8c2-4 6-8 12-10Z" fill="#173a6a" opacity="0.42" />
+    <g fill="rgba(226,242,255,0.45)">
+      <circle cx="30" cy="44" r="4" />
+      <circle cx="44" cy="32" r="3" />
+      <circle cx="124" cy="36" r="5" />
+      <circle cx="136" cy="50" r="3" />
+      <circle cx="116" cy="26" r="3" />
+    </g>
+    <circle cx="82" cy="62" r="42" fill="url(#soldier-highlight)" opacity="0.28" />
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- repaint the Saunoja guardian and seer portraits with richer gradients, steam halos, and refined silhouettes
- refresh player soldier and archer vectors alongside enemy marauder and raider variants for consistent premium lighting
- note the art overhaul in the changelog and update the sprite manifest timestamp to match the new assets

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3ef59dc488330882bac0c7e286754