### PR TITLE
Batch unit sprite rendering through atlas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-
+- Batch unit sprite rendering through a cached atlas, precomputing placements
+  so draw calls reuse the same geometry and can be issued in filter/shadow
+  batches, slashing the overhead of 50-unit scenes and expanding the renderer
+  tests to assert atlas usage.
 
 - Carve the sauna shop progression logic into `src/game/saunaShopState.ts`,
   wiring polished helpers for artocoin balances, tier ownership, and listener

--- a/src/render/units/UnitSprite.ts
+++ b/src/render/units/UnitSprite.ts
@@ -32,6 +32,7 @@ export interface DrawUnitSpriteOptions {
   readonly atlas?: CanvasImageSource | null;
   readonly slice?: SpriteAtlasSlice | null;
   readonly renderSprite?: boolean;
+  readonly precomputedPlacement?: SpritePlacement | null;
   readonly faction?: Unit['faction'];
   readonly motionStrength?: number;
   readonly cameraZoom?: number;
@@ -99,6 +100,18 @@ function createGradientSafe(
     console.warn('Failed to create canvas gradient', error);
   }
   return [null, fallbackColor];
+}
+
+function clonePlacement(placement: SpritePlacement): SpritePlacement {
+  return {
+    drawX: placement.drawX,
+    drawY: placement.drawY,
+    width: placement.width,
+    height: placement.height,
+    centerX: placement.centerX,
+    centerY: placement.centerY,
+    metadata: placement.metadata
+  } satisfies SpritePlacement;
 }
 
 function applyStops(gradient: GradientLike | null, stops: Array<[number, string]>): void {
@@ -368,7 +381,9 @@ export function drawUnitSprite(
   const zoom = Number.isFinite(options.cameraZoom) && (options.cameraZoom as number) > 0
     ? (options.cameraZoom as number)
     : options.placement.zoom;
-  const basePlacement = getSpritePlacement(options.placement);
+  const basePlacement = options.precomputedPlacement
+    ? clonePlacement(options.precomputedPlacement)
+    : getSpritePlacement(options.placement);
   const motionStrength = Math.max(0, Math.min(1, options.motionStrength ?? 0));
   const palette = resolveBasePalette(options.faction ?? unit.faction, options.selection, motionStrength);
 


### PR DESCRIPTION
## Summary
- precompute unit sprite placements, build batching queues, and draw atlas-backed sprites with shared filter/shadow state to reduce per-frame canvas work
- extend UnitSprite to reuse cached placements while keeping base rendering intact
- expand renderer tests to assert atlas batches use ctx.drawImage and capture the new render flow, and document the feature in the changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d4125fe210833094dc87e5de65b1a3