### PR TITLE
Replace raider sprites with new enemy orc PNGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Refresh Frost Raider unit icons by wiring the newly supplied high-resolution
+  PNG renders into the sprite loader so encounters showcase the polished enemy
+  art.
 - Batch unit sprite rendering through a cached atlas, precomputing placements
   so draw calls reuse the same geometry and can be issued in filter/shadow
   batches, slashing the overhead of 50-unit scenes and expanding the renderer

--- a/src/game/assets.ts
+++ b/src/game/assets.ts
@@ -5,9 +5,8 @@ import mine from '../../assets/sprites/mine.svg';
 import soldier from '../../assets/sprites/soldier.svg';
 import archer from '../../assets/sprites/archer.svg';
 import avantoMarauder from '../../assets/sprites/avanto-marauder.svg';
-import raider from '../../assets/sprites/raider.svg';
-import raiderCaptain from '../../assets/sprites/raider-captain.svg';
-import raiderShaman from '../../assets/sprites/raider-shaman.svg';
+import enemyOrc1 from '../../assets/sprites/enemy-orc-1.png';
+import enemyOrc2 from '../../assets/sprites/enemy-orc-2.png';
 import saunojaGuardian from '../../assets/sprites/saunoja-guardian.svg';
 import saunojaSeer from '../../assets/sprites/saunoja-seer.svg';
 import { ARTOCOIN_CREST_PNG_DATA_URL } from '../media/artocoinCrest.ts';
@@ -36,9 +35,9 @@ export const assetPaths: AssetPaths = {
     'unit-archer': archer,
     'unit-avanto-marauder': avantoMarauder,
     'unit-marauder': avantoMarauder,
-    'unit-raider': raider,
-    'unit-raider-captain': raiderCaptain,
-    'unit-raider-shaman': raiderShaman,
+    'unit-raider': enemyOrc1,
+    'unit-raider-captain': enemyOrc2,
+    'unit-raider-shaman': enemyOrc2,
     'unit-saunoja': saunojaGuardian,
     'unit-saunoja-guardian': saunojaGuardian,
     'unit-saunoja-seer': saunojaSeer,


### PR DESCRIPTION
## Summary
- swap the raider, captain, and shaman sprite imports to the new enemy orc PNG renders
- document the refreshed Frost Raider artwork in the changelog so the upgrade is tracked

## Testing
- npm run build
- npm test *(fails: `src/game.test.ts > rollSaunojaUpkeep > returns inclusive upkeep rolls between the configured bounds` timed out after 10000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68d426ab59648330923d6c3f2bc4b66e