### PR TITLE
Swap Saunoja icons to new PNG art

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Refresh the Saunoja unit icons with the newly supplied high-resolution PNG
+  renders, update the sprite metadata to honor their native sizes, and route the
+  asset loader through the polished artwork for both battlefield and roster
+  presentations.
+
 - Batch unit sprite rendering through a cached atlas, precomputing placements
   so draw calls reuse the same geometry and can be issued in filter/shadow
   batches, slashing the overhead of 50-unit scenes and expanding the renderer

--- a/src/game/assets.ts
+++ b/src/game/assets.ts
@@ -8,8 +8,9 @@ import avantoMarauder from '../../assets/sprites/avanto-marauder.svg';
 import raider from '../../assets/sprites/raider.svg';
 import raiderCaptain from '../../assets/sprites/raider-captain.svg';
 import raiderShaman from '../../assets/sprites/raider-shaman.svg';
-import saunojaGuardian from '../../assets/sprites/saunoja-guardian.svg';
-import saunojaSeer from '../../assets/sprites/saunoja-seer.svg';
+import saunojaDefault from '../../assets/units/saunoja-01.png';
+import saunojaGuardian from '../../assets/units/saunoja-02.png';
+import saunojaSeer from '../../assets/units/saunoja-03.png';
 import { ARTOCOIN_CREST_PNG_DATA_URL } from '../media/artocoinCrest.ts';
 import type { AssetPaths, LoadedAssets } from '../loader.ts';
 
@@ -39,7 +40,7 @@ export const assetPaths: AssetPaths = {
     'unit-raider': raider,
     'unit-raider-captain': raiderCaptain,
     'unit-raider-shaman': raiderShaman,
-    'unit-saunoja': saunojaGuardian,
+    'unit-saunoja': saunojaDefault,
     'unit-saunoja-guardian': saunojaGuardian,
     'unit-saunoja-seer': saunojaSeer,
     'icon-sauna-beer': uiIcons.saunaBeer,

--- a/src/render/units/draw.test.ts
+++ b/src/render/units/draw.test.ts
@@ -130,21 +130,21 @@ describe('unit sprite placement', () => {
       },
       {
         type: 'saunoja',
-        nativeSize: { width: 64, height: 64 },
+        nativeSize: { width: 1024, height: 1024 },
         anchor: { x: 0.5, y: 0.66 },
         scale: { x: 1.154700538, y: 1 },
         nudge: { x: 0, y: -0.02 }
       },
       {
         type: 'saunoja-guardian',
-        nativeSize: { width: 64, height: 64 },
+        nativeSize: { width: 1024, height: 1536 },
         anchor: { x: 0.5, y: 0.806 },
         scale: { x: 1.515544457, y: 1.3125 },
         nudge: { x: 0, y: -0.015 }
       },
       {
         type: 'saunoja-seer',
-        nativeSize: { width: 64, height: 64 },
+        nativeSize: { width: 1024, height: 1536 },
         anchor: { x: 0.5, y: 0.806 },
         scale: { x: 1.515544457, y: 1.3125 },
         nudge: { x: 0, y: -0.015 }

--- a/src/render/units/sprite_map.ts
+++ b/src/render/units/sprite_map.ts
@@ -77,19 +77,19 @@ export const UNIT_SPRITE_MAP: Record<UnitSpriteId, UnitSpriteMetadata> = {
     nudge: { x: 0, y: -0.036 }
   },
   saunoja: {
-    nativeSize: { width: 64, height: 64 },
+    nativeSize: { width: 1024, height: 1024 },
     anchor: { x: 0.5, y: 0.66 },
     scale: { x: 1.154700538, y: 1 },
     nudge: { x: 0, y: -0.02 }
   },
   'saunoja-guardian': {
-    nativeSize: { width: 64, height: 64 },
+    nativeSize: { width: 1024, height: 1536 },
     anchor: { x: 0.5, y: 0.806 },
     scale: { x: 1.515544457, y: 1.3125 },
     nudge: { x: 0, y: -0.015 }
   },
   'saunoja-seer': {
-    nativeSize: { width: 64, height: 64 },
+    nativeSize: { width: 1024, height: 1536 },
     anchor: { x: 0.5, y: 0.806 },
     scale: { x: 1.515544457, y: 1.3125 },
     nudge: { x: 0, y: -0.015 }


### PR DESCRIPTION
## Summary
- load the Saunoja unit sprites from the newly supplied high-resolution PNG renders
- refresh the unit sprite metadata and tests to reflect the native PNG dimensions
- document the icon refresh in the changelog

## Testing
- npm run build
- npm run test *(fails: several src/game.test.ts cases exceed their configured timeouts in this environment)*
- npx vitest run src/game.test.ts --testTimeout 30000 --hookTimeout 30000 --maxWorkers 1 --minWorkers 1 *(fails: rollSaunojaUpkeep timeout persists at 10000ms)*

------
https://chatgpt.com/codex/tasks/task_e_68d426ab59648330923d6c3f2bc4b66e