### PR TITLE
Polish stash header with sauna bucket emblem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Polish the Quartermaster stash header with the new sauna bucket emblem,
+  layering in the freshly supplied PNG art so the inventory panel immediately
+  reflects the upgraded stash branding.
+
 - Swap enemy combatants over to the new orc portrait PNGs, retune the sprite
   metadata for their taller aspect ratio, and map player-controlled units to the
   freshly supplied Saunoja renders so battlefield and HUD art stays polished and

--- a/src/ui/stash/StashPanel.module.css
+++ b/src/ui/stash/StashPanel.module.css
@@ -33,6 +33,16 @@
     max-width: 100%;
     background: linear-gradient(185deg, rgba(16, 20, 26, 0.98), rgba(6, 8, 12, 0.98));
   }
+
+  .titleWrap {
+    gap: 0.75rem;
+  }
+
+  .emblem {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 14px;
+  }
 }
 
 .header {
@@ -43,6 +53,45 @@
   gap: 1rem;
   border-bottom: 1px solid rgba(122, 139, 168, 0.16);
   backdrop-filter: blur(24px);
+}
+
+.titleWrap {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.emblem {
+  position: relative;
+  width: 3.4rem;
+  height: 3.4rem;
+  border-radius: 16px;
+  background-image:
+    linear-gradient(140deg, rgba(122, 176, 255, 0.42), rgba(34, 52, 88, 0.78)),
+    url('../../../assets/ui/inventory-saunabucket-01.png');
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  border: 1px solid rgba(132, 182, 255, 0.45);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.35),
+    0 18px 36px rgba(10, 20, 38, 0.45);
+  overflow: hidden;
+}
+
+.emblem::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.45), transparent 55%);
+  mix-blend-mode: screen;
+  opacity: 0.75;
 }
 
 .title {

--- a/src/ui/stash/StashPanel.tsx
+++ b/src/ui/stash/StashPanel.tsx
@@ -69,15 +69,25 @@ export function createStashPanel(callbacks: StashPanelCallbacks): StashPanelCont
   header.className = panelStyles.header;
 
   const titleWrap = document.createElement('div');
+  titleWrap.className = panelStyles.titleWrap;
+
+  const emblem = document.createElement('div');
+  emblem.className = panelStyles.emblem;
+
+  const titleBlock = document.createElement('div');
+  titleBlock.className = panelStyles.titleBlock;
+
   const title = document.createElement('h2');
   title.className = panelStyles.title;
   title.textContent = 'Quartermaster Stash';
-  titleWrap.appendChild(title);
+  titleBlock.appendChild(title);
 
   const meta = document.createElement('div');
   meta.className = panelStyles.meta;
   meta.textContent = 'Loading…';
-  titleWrap.appendChild(meta);
+  titleBlock.appendChild(meta);
+
+  titleWrap.append(emblem, titleBlock);
 
   const close = document.createElement('button');
   close.type = 'button';


### PR DESCRIPTION
## Summary
- highlight the quartermaster stash header with the sauna bucket emblem artwork
- wrap the stash title and metadata in a dedicated block so the emblem layout stays consistent
- document the refreshed stash branding in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b3f223e88330a5e7fbc5bd790657