### PR TITLE
Use sauna bucket art in stash panel background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Stage the quartermaster stash against the freshly supplied sauna bucket art,
+  folding the PNG into the panel backdrop with responsive gradients so the
+  inventory overlay lands with richer, polished ambience across desktop and
+  mobile layouts.
+
 - Swap enemy combatants over to the new orc portrait PNGs, retune the sprite
   metadata for their taller aspect ratio, and map player-controlled units to the
   freshly supplied Saunoja renders so battlefield and HUD art stays polished and

--- a/src/ui/stash/StashPanel.module.css
+++ b/src/ui/stash/StashPanel.module.css
@@ -15,12 +15,47 @@
   opacity: 0;
   z-index: 960;
   pointer-events: none;
+  overflow: hidden;
+  isolation: isolate;
 }
 
 .panel[data-open='true'] {
   transform: translate3d(0, 0, 0);
   opacity: 1;
   pointer-events: auto;
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  background-image:
+    linear-gradient(182deg, rgba(6, 10, 18, 0.68), rgba(8, 12, 20, 0.92)),
+    radial-gradient(120% 140% at 84% 102%, rgba(114, 186, 255, 0.4), rgba(114, 186, 255, 0)),
+    var(--stash-panel-art, none);
+  background-repeat: no-repeat;
+  background-size:
+    100% 100%,
+    115% auto,
+    clamp(320px, 52vw, 560px) auto;
+  background-position:
+    center,
+    92% 106%,
+    118% 110%;
+  filter: saturate(1.05);
+  opacity: 0.45;
+  pointer-events: none;
+  transition: opacity 280ms ease;
+  z-index: 0;
+}
+
+.panel[data-open='true']::before {
+  opacity: 0.7;
+}
+
+.panel > * {
+  position: relative;
+  z-index: 1;
 }
 
 @media (max-width: 720px) {
@@ -32,6 +67,18 @@
     width: 100%;
     max-width: 100%;
     background: linear-gradient(185deg, rgba(16, 20, 26, 0.98), rgba(6, 8, 12, 0.98));
+  }
+
+  .panel::before {
+    background-size:
+      100% 100%,
+      140% auto,
+      clamp(260px, 88vw, 420px) auto;
+    background-position:
+      center,
+      82% 108%,
+      115% 112%;
+    opacity: 0.55;
   }
 }
 

--- a/src/ui/stash/StashPanel.tsx
+++ b/src/ui/stash/StashPanel.tsx
@@ -8,6 +8,11 @@ import type {
   InventorySort
 } from '../../state/inventory.ts';
 
+const STASH_PANEL_ART_URL = new URL(
+  '../../../assets/ui/inventory-saunabucket-01.png',
+  import.meta.url
+).href;
+
 export interface StashPanelCallbacks {
   readonly onClose?: () => void;
   readonly onCollectionChange?: (collection: InventoryCollection) => void;
@@ -64,6 +69,7 @@ export function createStashPanel(callbacks: StashPanelCallbacks): StashPanelCont
   element.tabIndex = -1;
   element.dataset.open = 'false';
   element.setAttribute('aria-label', 'Quartermaster stash');
+  element.style.setProperty('--stash-panel-art', `url("${STASH_PANEL_ART_URL}")`);
 
   const header = document.createElement('header');
   header.className = panelStyles.header;


### PR DESCRIPTION
## Summary
- layer the new sauna bucket illustration behind the inventory stash panel with responsive gradients and opacity animation
- expose the art through a CSS variable set by the stash panel controller so the asset is processed by the build pipeline
- document the refreshed stash presentation in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b3f223e88330a5e7fbc5bd790657