### PR TITLE
Disable HTML caching and bundle HUD icons through Vite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   across every polished model without desynchronising combat scaling, and cover
   the behaviour with fresh Vitest cases.
 
+- Ensure freshly deployed builds bypass stale caches by marking the HTML shell
+  as non-cacheable and bundling the roster and resource crest SVGs through the
+  Vite asset pipeline so the high-fidelity unit art and HUD chrome always draw
+  the latest polished visuals on load.
+
 - Randomize Saunoja and orc battlefield models so freshly spawned units pull
   from every high-fidelity render, persist attendant appearances across saves,
   and update the renderer plus atlas metadata to honor the polished variants.

--- a/src/game/assets.ts
+++ b/src/game/assets.ts
@@ -7,17 +7,19 @@ import saunojaGuardian from '../../assets/units/saunoja-02.png';
 import saunojaSeer from '../../assets/units/saunoja-03.png';
 import enemyOrcVanguard from '../../assets/units/enemy-orc-1.png';
 import enemyOrcWarlock from '../../assets/units/enemy-orc-2.png';
+import saunaBeerIcon from '../../assets/ui/sauna-beer.svg';
+import saunaRosterIcon from '../../assets/ui/saunoja-roster.svg';
+import resourceIcon from '../../assets/ui/resource.svg';
+import soundIcon from '../../assets/ui/sound.svg';
 import { ARTOCOIN_CREST_PNG_DATA_URL } from '../media/artocoinCrest.ts';
 import type { AssetPaths, LoadedAssets } from '../loader.ts';
 
-const PUBLIC_ASSET_BASE = import.meta.env.BASE_URL ?? '/';
-
 export const uiIcons = {
-  saunaBeer: `${PUBLIC_ASSET_BASE}assets/ui/sauna-beer.svg`,
-  saunojaRoster: `${PUBLIC_ASSET_BASE}assets/ui/saunoja-roster.svg`,
-  resource: `${PUBLIC_ASSET_BASE}assets/ui/resource.svg`,
-  sisu: `${PUBLIC_ASSET_BASE}assets/ui/resource.svg`,
-  sound: `${PUBLIC_ASSET_BASE}assets/ui/sound.svg`,
+  saunaBeer: saunaBeerIcon,
+  saunojaRoster: saunaRosterIcon,
+  resource: resourceIcon,
+  sisu: resourceIcon,
+  sound: soundIcon,
   artocoin: ARTOCOIN_CREST_PNG_DATA_URL
 } as const;
 

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,9 @@
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
     <title>Autobattles4xFinsauna</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- mark the HTML entrypoint as non-cacheable so new deployments always fetch the latest bundle
- pipe roster/resource HUD icons through Vite's asset pipeline to guarantee fresh polished visuals
- document the cache-hardening work in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e65383f88330a4e0ab3e4735a48b