### PR TITLE
feat: randomize saunoja and orc spawn visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Adopt the new high-resolution Saunoja (01–03) and orc (1–2) PNG renders for
+  every spawn, randomising battlefield appearances across the polished variants
+  while refreshing the sprite atlas metadata so the upgraded silhouettes stay
+  perfectly framed on their hex bases.
+
 - Extend unit spawning with dedicated appearance samplers that fall back to the
   provided deterministic RNG, ensuring Saunoja recruits and invading orcs roll
   across every polished model without desynchronising combat scaling, and cover

--- a/assets/sprites/manifest.json
+++ b/assets/sprites/manifest.json
@@ -8,14 +8,14 @@
         "height": 64
       },
       "transform": {
-        "translateX": 3.404255319,
+        "translateX": 10.666666496,
         "translateY": 0,
-        "scaleX": 0.340425532,
-        "scaleY": 0.340425532
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
       },
       "source": {
-        "width": 168,
-        "height": 188
+        "width": 1024,
+        "height": 1536
       }
     },
     {
@@ -25,14 +25,14 @@
         "height": 64
       },
       "transform": {
-        "translateX": 3.265306122,
+        "translateX": 10.666666496,
         "translateY": 0,
-        "scaleX": 0.326530612,
-        "scaleY": 0.326530612
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
       },
       "source": {
-        "width": 176,
-        "height": 196
+        "width": 1024,
+        "height": 1536
       }
     },
     {
@@ -67,6 +67,40 @@
       "source": {
         "width": 64,
         "height": 64
+      }
+    },
+    {
+      "id": "enemy-orc-1",
+      "canvas": {
+        "width": 64,
+        "height": 64
+      },
+      "transform": {
+        "translateX": 10.666666496,
+        "translateY": 0,
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
+      },
+      "source": {
+        "width": 1024,
+        "height": 1536
+      }
+    },
+    {
+      "id": "enemy-orc-2",
+      "canvas": {
+        "width": 64,
+        "height": 64
+      },
+      "transform": {
+        "translateX": 10.666666496,
+        "translateY": 0,
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
+      },
+      "source": {
+        "width": 1024,
+        "height": 1536
       }
     },
     {
@@ -172,20 +206,37 @@
       }
     },
     {
+      "id": "raider",
+      "canvas": {
+        "width": 64,
+        "height": 64
+      },
+      "transform": {
+        "translateX": 10.666666496,
+        "translateY": 0,
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
+      },
+      "source": {
+        "width": 1024,
+        "height": 1536
+      }
+    },
+    {
       "id": "raider-captain",
       "canvas": {
         "width": 64,
         "height": 64
       },
       "transform": {
-        "translateX": 3.417475728,
+        "translateX": 10.666666496,
         "translateY": 0,
-        "scaleX": 0.310679612,
-        "scaleY": 0.310679612
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
       },
       "source": {
-        "width": 184,
-        "height": 206
+        "width": 1024,
+        "height": 1536
       }
     },
     {
@@ -195,65 +246,65 @@
         "height": 64
       },
       "transform": {
-        "translateX": 4.830188679,
+        "translateX": 10.666666496,
         "translateY": 0,
-        "scaleX": 0.301886792,
-        "scaleY": 0.301886792
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
       },
       "source": {
-        "width": 180,
-        "height": 212
+        "width": 1024,
+        "height": 1536
       }
     },
     {
-      "id": "raider",
+      "id": "saunoja-01",
       "canvas": {
         "width": 64,
         "height": 64
       },
       "transform": {
-        "translateX": 3.555555556,
+        "translateX": 0,
         "translateY": 0,
-        "scaleX": 0.323232323,
-        "scaleY": 0.323232323
+        "scaleX": 0.0625,
+        "scaleY": 0.0625
       },
       "source": {
-        "width": 176,
-        "height": 198
+        "width": 1024,
+        "height": 1024
       }
     },
     {
-      "id": "saunoja-guardian",
+      "id": "saunoja-02",
       "canvas": {
         "width": 64,
         "height": 64
       },
       "transform": {
-        "translateX": 2.909090909,
+        "translateX": 10.666666496,
         "translateY": 0,
-        "scaleX": 0.363636364,
-        "scaleY": 0.363636364
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
       },
       "source": {
-        "width": 160,
-        "height": 176
+        "width": 1024,
+        "height": 1536
       }
     },
     {
-      "id": "saunoja-seer",
+      "id": "saunoja-03",
       "canvas": {
         "width": 64,
         "height": 64
       },
       "transform": {
-        "translateX": 2.909090909,
+        "translateX": 10.666666496,
         "translateY": 0,
-        "scaleX": 0.363636364,
-        "scaleY": 0.363636364
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
       },
       "source": {
-        "width": 160,
-        "height": 176
+        "width": 1024,
+        "height": 1536
       }
     },
     {
@@ -263,14 +314,14 @@
         "height": 64
       },
       "transform": {
-        "translateX": 4.173913043,
+        "translateX": 10.666666496,
         "translateY": 0,
-        "scaleX": 0.347826087,
-        "scaleY": 0.347826087
+        "scaleX": 0.041666667,
+        "scaleY": 0.041666667
       },
       "source": {
-        "width": 160,
-        "height": 184
+        "width": 1024,
+        "height": 1536
       }
     }
   ]

--- a/src/game.ts
+++ b/src/game.ts
@@ -2257,7 +2257,7 @@ export function draw(): void {
               ? attendant.appearanceId
               : null;
           },
-          fallbackSpriteId: 'saunoja-guardian'
+          fallbackSpriteId: 'saunoja-02'
         }
       : undefined;
 

--- a/src/game/assets.ts
+++ b/src/game/assets.ts
@@ -2,9 +2,9 @@ import farm from '../../assets/sprites/farm.svg';
 import barracks from '../../assets/sprites/barracks.svg';
 import city from '../../assets/sprites/city.svg';
 import mine from '../../assets/sprites/mine.svg';
-import saunojaVanguard from '../../assets/units/saunoja-01.png';
-import saunojaGuardian from '../../assets/units/saunoja-02.png';
-import saunojaSeer from '../../assets/units/saunoja-03.png';
+import saunojaVariant01 from '../../assets/units/saunoja-01.png';
+import saunojaVariant02 from '../../assets/units/saunoja-02.png';
+import saunojaVariant03 from '../../assets/units/saunoja-03.png';
 import enemyOrcVanguard from '../../assets/units/enemy-orc-1.png';
 import enemyOrcWarlock from '../../assets/units/enemy-orc-2.png';
 import saunaBeerIcon from '../../assets/ui/sauna-beer.svg';
@@ -31,8 +31,8 @@ export const assetPaths: AssetPaths = {
     'building-barracks': barracks,
     'building-city': city,
     'building-mine': mine,
-    'unit-soldier': saunojaGuardian,
-    'unit-archer': saunojaSeer,
+    'unit-soldier': saunojaVariant02,
+    'unit-archer': saunojaVariant03,
     'unit-avanto-marauder': enemyOrcVanguard,
     'unit-marauder': enemyOrcVanguard,
     'unit-raider': enemyOrcVanguard,
@@ -40,9 +40,13 @@ export const assetPaths: AssetPaths = {
     'unit-raider-shaman': enemyOrcWarlock,
     'unit-enemy-orc-1': enemyOrcVanguard,
     'unit-enemy-orc-2': enemyOrcWarlock,
-    'unit-saunoja': saunojaVanguard,
-    'unit-saunoja-guardian': saunojaGuardian,
-    'unit-saunoja-seer': saunojaSeer,
+    'unit-saunoja-01': saunojaVariant01,
+    'unit-saunoja-02': saunojaVariant02,
+    'unit-saunoja-03': saunojaVariant03,
+    // Compatibility aliases for legacy save data and tooling.
+    'unit-saunoja': saunojaVariant01,
+    'unit-saunoja-guardian': saunojaVariant02,
+    'unit-saunoja-seer': saunojaVariant03,
     'icon-sauna-beer': uiIcons.saunaBeer,
     'icon-saunoja-roster': uiIcons.saunojaRoster,
     'icon-resource': uiIcons.resource,

--- a/src/render/units/draw.test.ts
+++ b/src/render/units/draw.test.ts
@@ -129,21 +129,21 @@ describe('unit sprite placement', () => {
         nudge: { x: 0, y: -0.028 }
       },
       {
-        type: 'saunoja',
+        type: 'saunoja-01',
         nativeSize: { width: 1024, height: 1024 },
         anchor: { x: 0.5, y: 0.7 },
         scaleY: 1.2,
         nudge: { x: 0, y: -0.018 }
       },
       {
-        type: 'saunoja-guardian',
+        type: 'saunoja-02',
         nativeSize: { width: 1024, height: 1536 },
         anchor: { x: 0.5, y: 0.81 },
         scaleY: 1.32,
         nudge: { x: 0, y: -0.016 }
       },
       {
-        type: 'saunoja-seer',
+        type: 'saunoja-03',
         nativeSize: { width: 1024, height: 1536 },
         anchor: { x: 0.5, y: 0.81 },
         scaleY: 1.32,

--- a/src/render/units/sprite_map.ts
+++ b/src/render/units/sprite_map.ts
@@ -23,9 +23,9 @@ type UnitSpriteId =
   | 'raider'
   | 'raider-captain'
   | 'raider-shaman'
-  | 'saunoja'
-  | 'saunoja-guardian'
-  | 'saunoja-seer'
+  | 'saunoja-01'
+  | 'saunoja-02'
+  | 'saunoja-03'
   | 'enemy-orc-1'
   | 'enemy-orc-2'
   | 'default';
@@ -98,9 +98,9 @@ export const UNIT_SPRITE_MAP: Record<UnitSpriteId, UnitSpriteMetadata> = {
   'raider-shaman': ENEMY_WARLOCK_META,
   'enemy-orc-1': ENEMY_VANGUARD_META,
   'enemy-orc-2': ENEMY_WARLOCK_META,
-  saunoja: PLAYER_SQUARE_META,
-  'saunoja-guardian': PLAYER_TALL_META,
-  'saunoja-seer': PLAYER_TALL_META
+  'saunoja-01': PLAYER_SQUARE_META,
+  'saunoja-02': PLAYER_TALL_META,
+  'saunoja-03': PLAYER_TALL_META
 };
 
 export function getUnitSpriteMetadata(type: string): UnitSpriteMetadata {

--- a/src/unit/appearance.test.ts
+++ b/src/unit/appearance.test.ts
@@ -12,7 +12,7 @@ function makeSampler(sequence: number[]): () => number {
 
 describe('unit appearance helpers', () => {
   it('normalizes candidate identifiers', () => {
-    expect(normalizeAppearanceId('  saunoja-seer  ')).toBe('saunoja-seer');
+    expect(normalizeAppearanceId('  saunoja-seer  ')).toBe('saunoja-03');
     expect(normalizeAppearanceId('unit-enemy-orc-1')).toBe('enemy-orc-1');
     expect(normalizeAppearanceId('unknown-variant')).toBeNull();
     expect(normalizeAppearanceId(42)).toBeNull();
@@ -22,9 +22,9 @@ describe('unit appearance helpers', () => {
     const sample = resolveUnitAppearance('soldier', undefined, makeSampler([0, 0.4, 0.9]));
     const followUp = resolveUnitAppearance('soldier', undefined, makeSampler([0.4]));
     const final = resolveUnitAppearance('soldier', undefined, makeSampler([0.9]));
-    expect(sample).toBe('saunoja');
-    expect(followUp).toBe('saunoja-guardian');
-    expect(final).toBe('saunoja-seer');
+    expect(sample).toBe('saunoja-01');
+    expect(followUp).toBe('saunoja-02');
+    expect(final).toBe('saunoja-03');
   });
 
   it('prefers explicit variants when they match the archetype', () => {
@@ -35,8 +35,8 @@ describe('unit appearance helpers', () => {
   });
 
   it('resolves saunoja appearances independently', () => {
-    expect(resolveSaunojaAppearance('saunoja')).toBe('saunoja');
-    expect(resolveSaunojaAppearance('archer', makeSampler([0]))).toBe('saunoja');
-    expect(resolveSaunojaAppearance(undefined, makeSampler([0.75]))).toBe('saunoja-seer');
+    expect(resolveSaunojaAppearance('saunoja')).toBe('saunoja-01');
+    expect(resolveSaunojaAppearance('archer', makeSampler([0]))).toBe('saunoja-01');
+    expect(resolveSaunojaAppearance(undefined, makeSampler([0.75]))).toBe('saunoja-03');
   });
 });

--- a/src/unit/appearance.ts
+++ b/src/unit/appearance.ts
@@ -2,13 +2,19 @@ import type { UnitArchetypeId } from './types.ts';
 
 export type UnitAppearanceId =
   | UnitArchetypeId
-  | 'saunoja'
-  | 'saunoja-guardian'
-  | 'saunoja-seer'
+  | 'saunoja-01'
+  | 'saunoja-02'
+  | 'saunoja-03'
   | 'enemy-orc-1'
   | 'enemy-orc-2';
 
-const SAUNOJA_APPEARANCES = ['saunoja', 'saunoja-guardian', 'saunoja-seer'] as const satisfies readonly UnitAppearanceId[];
+const LEGACY_APPEARANCE_ALIASES: Readonly<Record<string, UnitAppearanceId>> = Object.freeze({
+  saunoja: 'saunoja-01',
+  'saunoja-guardian': 'saunoja-02',
+  'saunoja-seer': 'saunoja-03'
+});
+
+const SAUNOJA_APPEARANCES = ['saunoja-01', 'saunoja-02', 'saunoja-03'] as const satisfies readonly UnitAppearanceId[];
 const ORC_APPEARANCES = ['enemy-orc-1', 'enemy-orc-2'] as const satisfies readonly UnitAppearanceId[];
 
 const UNIT_APPEARANCE_VARIANTS: Readonly<Record<UnitArchetypeId, readonly UnitAppearanceId[]>> = Object.freeze({
@@ -21,16 +27,14 @@ const UNIT_APPEARANCE_VARIANTS: Readonly<Record<UnitArchetypeId, readonly UnitAp
 });
 
 const VALID_APPEARANCE_IDS: ReadonlySet<UnitAppearanceId> = new Set<UnitAppearanceId>([
-  ...new Set<UnitAppearanceId>([
-    ...SAUNOJA_APPEARANCES,
-    ...ORC_APPEARANCES,
-    'soldier',
-    'archer',
-    'avanto-marauder',
-    'raider',
-    'raider-captain',
-    'raider-shaman'
-  ])
+  ...SAUNOJA_APPEARANCES,
+  ...ORC_APPEARANCES,
+  'soldier',
+  'archer',
+  'avanto-marauder',
+  'raider',
+  'raider-captain',
+  'raider-shaman'
 ]);
 
 function clamp01(value: number): number {
@@ -70,6 +74,10 @@ export function normalizeAppearanceId(candidate: unknown): UnitAppearanceId | nu
     return null;
   }
   const normalized = trimmed.startsWith('unit-') ? trimmed.slice(5) : trimmed;
+  const legacy = LEGACY_APPEARANCE_ALIASES[normalized];
+  if (legacy) {
+    return legacy;
+  }
   return VALID_APPEARANCE_IDS.has(normalized as UnitAppearanceId)
     ? (normalized as UnitAppearanceId)
     : null;
@@ -99,7 +107,7 @@ export function resolveSaunojaAppearance(
   if (normalizedCandidate && SAUNOJA_APPEARANCES.includes(normalizedCandidate)) {
     return normalizedCandidate;
   }
-  return sampleVariant(SAUNOJA_APPEARANCES, random, 'saunoja-guardian');
+  return sampleVariant(SAUNOJA_APPEARANCES, random, 'saunoja-02');
 }
 
 export function getUnitAppearanceVariants(

--- a/src/units/UnitFactory.test.ts
+++ b/src/units/UnitFactory.test.ts
@@ -76,11 +76,11 @@ describe('UnitFactory', () => {
     const unit = spawnUnit(state, 'soldier', 's-appearance', origin, 'player', {
       appearanceRandom: () => 0.4
     }) as Unit;
-    expect(unit.getAppearanceId()).toBe('saunoja-guardian');
+    expect(unit.getAppearanceId()).toBe('saunoja-02');
     const alternate = spawnUnit(state, 'soldier', 's-appearance-2', origin, 'player', {
       appearanceRandom: () => 0.9
     }) as Unit;
-    expect(alternate.getAppearanceId()).toBe('saunoja-seer');
+    expect(alternate.getAppearanceId()).toBe('saunoja-03');
   });
 
   it('falls back to the generic RNG when appearanceRandom is absent', () => {
@@ -90,7 +90,7 @@ describe('UnitFactory', () => {
     try {
       const unit = spawnUnit(state, 'soldier', 's-random', origin, 'player');
       expect(unit).not.toBeNull();
-      expect(unit!.getAppearanceId()).toBe('saunoja');
+      expect(unit!.getAppearanceId()).toBe('saunoja-01');
     } finally {
       mathRandomSpy.mockRestore();
     }

--- a/src/units/renderSaunoja.test.ts
+++ b/src/units/renderSaunoja.test.ts
@@ -52,7 +52,7 @@ describe('drawSaunojas', () => {
       {
         id: 'unit-1',
         name: 'Uno',
-        appearanceId: 'saunoja-guardian',
+        appearanceId: 'saunoja-02',
         coord: { q: 0, r: 0 },
         maxHp: 10,
         hp: 6,
@@ -76,7 +76,7 @@ describe('drawSaunojas', () => {
       {
         id: 'solo',
         name: 'Solo',
-        appearanceId: 'saunoja-guardian',
+        appearanceId: 'saunoja-02',
         coord: { q: 1, r: 1 },
         maxHp: 8,
         hp: 4,
@@ -113,7 +113,7 @@ describe('drawSaunojas', () => {
 
     const assets = {
       placeholder: createSpriteStub(),
-      'unit-saunoja-guardian': guardianSprite,
+      'unit-saunoja-02': guardianSprite,
       'unit-archer': archerSprite,
       'unit-soldier': soldierSprite
     } satisfies Record<string, HTMLImageElement>;
@@ -122,7 +122,7 @@ describe('drawSaunojas', () => {
       {
         id: 'south',
         name: 'South',
-        appearanceId: 'saunoja-guardian',
+        appearanceId: 'saunoja-02',
         coord: { q: -1, r: 2 },
         maxHp: 18,
         hp: 12,
@@ -135,7 +135,7 @@ describe('drawSaunojas', () => {
       {
         id: 'north',
         name: 'North',
-        appearanceId: 'saunoja-guardian',
+        appearanceId: 'saunoja-02',
         coord: { q: 0, r: -1 },
         maxHp: 14,
         hp: 8,
@@ -148,7 +148,7 @@ describe('drawSaunojas', () => {
       {
         id: 'center',
         name: 'Center',
-        appearanceId: 'saunoja-guardian',
+        appearanceId: 'saunoja-02',
         coord: { q: 1, r: 0 },
         maxHp: 16,
         hp: 5,
@@ -226,7 +226,7 @@ describe('drawSaunojas', () => {
 
     const drawCalls = (ctx.drawImage as unknown as Mock).mock.calls;
     sorted.forEach(({ unit, coord }, index) => {
-      const spriteId = spriteChoices.get(unit.id)?.trim() ? spriteChoices.get(unit.id)!.trim() : 'saunoja-guardian';
+      const spriteId = spriteChoices.get(unit.id)?.trim() ? spriteChoices.get(unit.id)!.trim() : 'saunoja-02';
       const placement = getSpritePlacement({
         coord,
         hexSize: radius,
@@ -249,7 +249,7 @@ describe('drawSaunojas', () => {
 
     const assets = {
       placeholder: createSpriteStub(),
-      'unit-saunoja-guardian': createSpriteStub()
+      'unit-saunoja-02': createSpriteStub()
     } satisfies Record<string, HTMLImageElement>;
 
     const { ctx } = createMockContext();
@@ -298,14 +298,14 @@ describe('drawSaunojas', () => {
       hexSize: 28,
       origin: { x: 0, y: 0 },
       zoom: 1,
-      type: 'saunoja-guardian'
+      type: 'saunoja-02'
     });
     const placementB = getSpritePlacement({
       coord: units[1]!.coord,
       hexSize: 28,
       origin: { x: 0, y: 0 },
       zoom: 1,
-      type: 'saunoja-guardian'
+      type: 'saunoja-02'
     });
 
     expect(drawCalls[0][1]).toBe(placementA.drawX);

--- a/src/units/renderSaunoja.ts
+++ b/src/units/renderSaunoja.ts
@@ -7,7 +7,7 @@ import type { UnitStatusBuff, UnitStatusPayload } from '../ui/fx/types.ts';
 
 type SpriteResolver = (saunoja: Saunoja) => string | null | undefined;
 
-const DEFAULT_SAUNOJA_SPRITE_ID = 'saunoja-guardian';
+const DEFAULT_SAUNOJA_SPRITE_ID = 'saunoja-02';
 
 function normalizeSpriteId(candidate: string | null | undefined): string {
   if (typeof candidate !== 'string') {

--- a/src/units/saunoja.test.ts
+++ b/src/units/saunoja.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { makeSaunoja, SAUNOJA_DEFAULT_UPKEEP, SAUNOJA_UPKEEP_MAX } from './saunoja.ts';
 import { applyDamage } from './combat.ts';
 
-const SAUNOJA_APPEARANCES = new Set(['saunoja', 'saunoja-guardian', 'saunoja-seer']);
+const SAUNOJA_APPEARANCES = new Set(['saunoja-01', 'saunoja-02', 'saunoja-03']);
 
 describe('makeSaunoja', () => {
   it('applies defaults and clamps mutable values', () => {
@@ -67,7 +67,7 @@ describe('makeSaunoja', () => {
     expect(saunoja.behavior).toBe('defend');
     expect(saunoja.baseStats.health).toBe(1);
     expect(saunoja.equipment.weapon).toBeNull();
-    expect(saunoja.appearanceId).toBe('saunoja');
+    expect(saunoja.appearanceId).toBe('saunoja-01');
     randomSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- canonicalize unit appearance IDs around the new saunoja-01/02/03 and enemy orc renders while mapping legacy names for saves.
- wire the asset loader, sprite metadata, and atlas manifest to the high-resolution PNG variants so every spawn samples a polished portrait.
- refresh the changelog and HUD fallbacks to prefer the updated Saunoja sprite treatment.

## Testing
- npm run test -- --runInBand
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4f3de586483309c0c6082e645d925