### PR TITLE
Refine inventory stash access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Relocate the quartermaster stash behind a polished inventory crest toggle, add
+  a glassmorphism popup with responsive scrim, and update the HUD layout plus
+  tests so the command dock no longer reserves a bottom tab for the drawer.
+
 - Extend unit spawning with dedicated appearance samplers that fall back to the
   provided deterministic RNG, ensuring Saunoja recruits and invading orcs roll
   across every polished model without desynchronising combat scaling, and cover

--- a/src/main.hud.test.ts
+++ b/src/main.hud.test.ts
@@ -66,7 +66,7 @@ describe('main HUD lifecycle', () => {
     await Promise.resolve();
 
     expect(document.querySelectorAll('#topbar')).toHaveLength(1);
-    expect(document.querySelectorAll('[data-hud-tab="stash"]')).toHaveLength(1);
+    expect(document.querySelectorAll('[data-ui="inventory-toggle"]')).toHaveLength(1);
     expect(document.querySelectorAll('#inventory-stash-panel')).toHaveLength(1);
     expect(document.querySelectorAll('#right-panel')).toHaveLength(1);
 
@@ -74,7 +74,7 @@ describe('main HUD lifecycle', () => {
     await Promise.resolve();
 
     expect(document.querySelectorAll('#topbar')).toHaveLength(0);
-    expect(document.querySelectorAll('[data-hud-tab="stash"]')).toHaveLength(1);
+    expect(document.querySelectorAll('[data-ui="inventory-toggle"]')).toHaveLength(0);
     expect(document.querySelectorAll('#inventory-stash-panel')).toHaveLength(0);
     expect(document.querySelectorAll('#right-panel')).toHaveLength(0);
 
@@ -82,7 +82,7 @@ describe('main HUD lifecycle', () => {
     await Promise.resolve();
 
     expect(document.querySelectorAll('#topbar')).toHaveLength(1);
-    expect(document.querySelectorAll('[data-hud-tab="stash"]')).toHaveLength(1);
+    expect(document.querySelectorAll('[data-ui="inventory-toggle"]')).toHaveLength(1);
     expect(document.querySelectorAll('#inventory-stash-panel')).toHaveLength(1);
     expect(document.querySelectorAll('#right-panel')).toHaveLength(1);
   });
@@ -118,7 +118,7 @@ describe('main HUD lifecycle', () => {
     expect(overlay?.dataset.hudVariant).toBe('classic');
     expect(document.querySelector('[data-testid="return-to-classic-hud"]')).toBeNull();
     expect(document.querySelector('#topbar')).not.toBeNull();
-    expect(document.querySelector('[data-hud-tab="stash"]')).not.toBeNull();
+    expect(document.querySelector('[data-ui="inventory-toggle"]')).not.toBeNull();
     expect(document.querySelector('#inventory-stash-panel')).not.toBeNull();
     expect(document.querySelector('#right-panel')).not.toBeNull();
 

--- a/src/style.css
+++ b/src/style.css
@@ -275,9 +275,53 @@ body > #game-container {
   pointer-events: auto;
 }
 
-#ui-overlay.inventory-panel-open #inventory-stash-panel,
+#ui-overlay.inventory-panel-open #inventory-stash-layer,
 #ui-overlay.inventory-shop-open #inventory-shop-panel {
   pointer-events: auto;
+}
+
+.inventory-stash-layer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(18px, 4vw, 36px);
+  z-index: 970;
+  pointer-events: none;
+}
+
+.inventory-stash-layer[data-open='true'] {
+  pointer-events: auto;
+}
+
+.inventory-stash-scrim {
+  position: absolute;
+  inset: 0;
+  border-radius: clamp(24px, 4vw, 32px);
+  background:
+    radial-gradient(circle at 20% 14%, rgba(82, 140, 255, 0.26), transparent 58%),
+    radial-gradient(circle at 80% 24%, rgba(79, 209, 197, 0.18), transparent 60%),
+    rgba(7, 12, 20, 0.72);
+  backdrop-filter: blur(18px) saturate(132%);
+  opacity: 0;
+  transition: opacity 240ms ease;
+  pointer-events: none;
+}
+
+.inventory-stash-scrim[data-open='true'] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (max-width: 720px) {
+  .inventory-stash-layer {
+    padding: clamp(12px, 5vw, 18px);
+  }
+
+  .inventory-stash-scrim {
+    border-radius: 0;
+  }
 }
 
 #inventory-shop-panel {
@@ -443,7 +487,6 @@ body > #game-container {
 }
 
 @media (min-width: 721px) {
-  #ui-overlay.inventory-panel-open .hud-anchor--command-dock,
   #ui-overlay.inventory-shop-open .hud-anchor--command-dock {
     margin-right: calc(var(--inventory-panel-width) + var(--inventory-panel-gap));
     max-width: calc(100% - var(--inventory-panel-width) - var(--inventory-panel-gap));
@@ -574,7 +617,6 @@ body > #game-container {
 }
 
 @media (min-width: 721px) {
-  #ui-overlay.inventory-panel-open .hud-bottom-tabs__chrome,
   #ui-overlay.inventory-shop-open .hud-bottom-tabs__chrome {
     margin-right: calc(var(--inventory-panel-width) + var(--inventory-panel-gap));
     max-width: calc(100% - var(--inventory-panel-width) - var(--inventory-panel-gap));

--- a/src/ui/inventoryHud.test.ts
+++ b/src/ui/inventoryHud.test.ts
@@ -69,27 +69,21 @@ describe('setupInventoryHud', () => {
 
     const hud = setupInventoryHud(inventory);
 
-    const stashPanelHost = overlay.querySelector('[data-hud-tab-panel="stash"]');
-    expect(stashPanelHost).not.toBeNull();
-    expect(stashPanelHost?.contains(stashPanel.element)).toBe(true);
+    const stashLayer = overlay.querySelector('#inventory-stash-layer');
+    expect(stashLayer).not.toBeNull();
+    expect(stashLayer?.contains(stashPanel.element)).toBe(true);
 
-    const dockTabs = overlay.querySelector('[data-hud-command-dock-section="tabs"]');
-    expect(dockTabs?.contains(stashPanelHost!)).toBe(true);
-
-    const stashTab = overlay.querySelector<HTMLButtonElement>('[data-hud-tab="stash"]');
-    const rosterTab = overlay.querySelector<HTMLButtonElement>('[data-hud-tab="roster"]');
-
-    expect(stashTab).not.toBeNull();
-    expect(rosterTab).not.toBeNull();
+    const inventoryToggle = overlay.querySelector<HTMLButtonElement>('[data-ui="inventory-toggle"]');
+    expect(inventoryToggle).not.toBeNull();
 
     setOpenMock.mockClear();
 
-    stashTab!.click();
+    inventoryToggle!.click();
 
     expect(setOpenMock).toHaveBeenCalledWith(true);
     expect(overlay.classList.contains('inventory-panel-open')).toBe(true);
 
-    rosterTab!.click();
+    inventoryToggle!.click();
 
     expect(setOpenMock).toHaveBeenCalledWith(false);
     expect(overlay.classList.contains('inventory-panel-open')).toBe(false);

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -18,7 +18,7 @@ export type HudLayoutDock = {
   actions: HTMLDivElement;
 };
 
-export type HudBottomTabId = 'roster' | 'stash' | 'policies';
+export type HudBottomTabId = 'roster' | 'policies';
 
 export type HudBottomTabs = {
   container: HTMLDivElement;
@@ -74,11 +74,10 @@ const ANCHOR_DATASET_NAMES: Record<keyof HudLayoutAnchors, string> = {
   commandDock: 'command-dock',
 };
 
-const BOTTOM_TAB_ORDER: HudBottomTabId[] = ['roster', 'stash', 'policies'];
+const BOTTOM_TAB_ORDER: HudBottomTabId[] = ['roster', 'policies'];
 
 const BOTTOM_TAB_LABELS: Record<HudBottomTabId, string> = {
   roster: 'Roster',
-  stash: 'Stash',
   policies: 'Policies',
 };
 
@@ -303,8 +302,6 @@ function ensureBottomTabs(
     if (tabId === 'roster') {
       panel.id = 'resource-bar';
       panel.classList.add('hud-bottom-tabs__panel--roster');
-    } else if (tabId === 'stash') {
-      panel.classList.add('hud-bottom-tabs__panel--stash');
     } else if (!panel.id) {
       panel.id = `hud-bottom-panel-${tabId}`;
     }

--- a/src/ui/rosterHUD.test.ts
+++ b/src/ui/rosterHUD.test.ts
@@ -167,8 +167,8 @@ describe('rosterHUD', () => {
       const rosterContainer = layout.tabs.panels.roster;
       const hud = setupRosterHUD(rosterContainer, { rosterIcon: '/icon.svg' });
 
-      layout.tabs.setActive('stash');
-      expect(layout.tabs.getActive()).toBe('stash');
+      layout.tabs.setActive('policies');
+      expect(layout.tabs.getActive()).toBe('policies');
 
       rosterContainer.dispatchEvent(
         new CustomEvent('sauna-roster:expand', { bubbles: true })

--- a/src/ui/stash/StashPanel.module.css
+++ b/src/ui/stash/StashPanel.module.css
@@ -25,6 +25,26 @@
   pointer-events: auto;
 }
 
+.panel[data-variant='popup'] {
+  top: 50%;
+  left: 50%;
+  right: auto;
+  bottom: auto;
+  width: min(960px, calc(100% - (var(--hud-padding) * 2)));
+  max-width: min(960px, calc(100% - (var(--hud-padding) * 2)));
+  max-height: min(90vh, 720px);
+  border-radius: clamp(18px, 3vw, 28px);
+  transform: translate3d(-50%, -46%, 0) scale(0.94);
+  box-shadow: 0 44px 84px rgba(4, 10, 20, 0.62);
+  transition:
+    transform 320ms cubic-bezier(0.26, 0.82, 0, 1),
+    opacity 220ms ease;
+}
+
+.panel[data-variant='popup'][data-open='true'] {
+  transform: translate3d(-50%, -50%, 0) scale(1);
+}
+
 .panel::before {
   content: '';
   position: absolute;
@@ -58,6 +78,22 @@
   z-index: 1;
 }
 
+.panel[data-variant='popup']::before {
+  background-size:
+    100% 100%,
+    128% auto,
+    clamp(380px, 68vw, 620px) auto;
+  background-position:
+    center,
+    84% 118%,
+    118% 120%;
+  opacity: 0.55;
+}
+
+.panel[data-variant='popup'][data-open='true']::before {
+  opacity: 0.78;
+}
+
 @media (max-width: 720px) {
   .panel {
     top: 0;
@@ -67,6 +103,17 @@
     width: 100%;
     max-width: 100%;
     background: linear-gradient(185deg, rgba(16, 20, 26, 0.98), rgba(6, 8, 12, 0.98));
+  }
+
+  .panel[data-variant='popup'] {
+    transform: translate3d(0, 16px, 0) scale(0.98);
+    border-radius: 0;
+    max-height: 100%;
+    width: 100%;
+  }
+
+  .panel[data-variant='popup'][data-open='true'] {
+    transform: translate3d(0, 0, 0) scale(1);
   }
 
   .panel::before {
@@ -79,6 +126,17 @@
       82% 108%,
       115% 112%;
     opacity: 0.55;
+  }
+
+  .panel[data-variant='popup']::before {
+    background-size:
+      100% 100%,
+      150% auto,
+      clamp(320px, 92vw, 520px) auto;
+    background-position:
+      center,
+      78% 112%,
+      120% 118%;
   }
 }
 

--- a/tests/ui/hudTabs.test.tsx
+++ b/tests/ui/hudTabs.test.tsx
@@ -31,31 +31,29 @@ describe('HUD bottom tabs', () => {
     vi.restoreAllMocks();
   });
 
-  it('creates roster, stash, and policies panels with roster active by default', () => {
+  it('creates roster and policies panels with roster active by default', () => {
     const layout = ensureHudLayout(overlay);
     const { tabs } = layout;
 
     expect(tabs.panels.roster.dataset.hudTabPanel).toBe('roster');
-    expect(tabs.panels.stash.dataset.hudTabPanel).toBe('stash');
     expect(tabs.panels.policies.dataset.hudTabPanel).toBe('policies');
 
     expect(tabs.panels.roster.hidden).toBe(false);
-    expect(tabs.panels.stash.hidden).toBe(true);
-
-    tabs.setActive('stash');
-
-    expect(tabs.panels.stash.hidden).toBe(false);
-    expect(tabs.panels.roster.hidden).toBe(true);
     expect(tabs.panels.policies.hidden).toBe(true);
+
+    tabs.setActive('policies');
+
+    expect(tabs.panels.policies.hidden).toBe(false);
+    expect(tabs.panels.roster.hidden).toBe(true);
   });
 
   it('sets badges and emits change notifications', () => {
     const { tabs } = ensureHudLayout(overlay);
-    const stashTab = overlay.querySelector<HTMLButtonElement>('[data-hud-tab="stash"]');
-    expect(stashTab).not.toBeNull();
+    const policiesTab = overlay.querySelector<HTMLButtonElement>('[data-hud-tab="policies"]');
+    expect(policiesTab).not.toBeNull();
 
-    tabs.setBadge('stash', 12);
-    expect(stashTab?.getAttribute('data-badge')).toBe('12');
+    tabs.setBadge('policies', 12);
+    expect(policiesTab?.getAttribute('data-badge')).toBe('12');
 
     const received: HudBottomTabId[] = [];
     const unsubscribe = tabs.onChange((id) => {


### PR DESCRIPTION
## Summary
- replace the stash bottom tab with a polished inventory toggle button and popup drawer
- adjust stash panel styling for the new popup layout and add overlay scrim support in the HUD CSS
- update HUD layout, tests, and changelog to reflect the new stash entry point

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d50fa10a2c8330bc1c5a93e0a43f97