### PR TITLE
Fix Pages artifact name collision

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist
+          name: site-dist
 
   deploy:
     needs: build
@@ -55,3 +56,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: site-dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Update the GitHub Pages workflow to upload a uniquely named deployment
+  artifact so reruns never collide on the default `github-pages` bundle and the
+  publishing job can deploy our polished builds without manual retries.
+
 - Refresh the HUD inventory toggle so it renders the sauna bucket crest from
   `inventory-saunabucket-01.png`, keeping the quartermaster control aligned with
   the polished stash artwork.


### PR DESCRIPTION
## Summary
- give the Pages upload step a unique artifact name and point the deploy step at it so the job no longer collides with duplicate `github-pages` bundles
- log the Pages workflow change in the Unreleased changelog section

## Testing
- npm run build
- npm test *(fails: src/game.test.ts > game logging > caps event log at 150 messages timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68d51f3f3b18833098efdcfddcb6a21e