### PR TITLE
Improve stash upgrade selection for auto-equip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Teach the quartermaster auto-equip pass to rank stash gear by slot power,
+  cascading past blocked upgrades so loot pickups and Replace actions keep our
+  attendants in the highest-tier equipment available.
+
 - Update the GitHub Pages workflow to upload a uniquely named deployment
   artifact so reruns never collide on the default `github-pages` bundle and the
   publishing job can deploy our polished builds without manual retries.

--- a/src/items/equip.test.ts
+++ b/src/items/equip.test.ts
@@ -1,19 +1,28 @@
 import { describe, expect, it } from 'vitest';
 import { makeSaunoja } from '../units/saunoja.ts';
 import type { SaunojaItem } from '../units/saunoja.ts';
-import { equip, unequip, matchesSlot, loadoutItems } from './equip.ts';
+import { equip, unequip, matchesSlot, loadoutItems, rankEquipmentCandidates } from './equip.ts';
 
 describe('items/equip', () => {
   const weapon: SaunojaItem = {
     id: 'glacier-brand',
     name: 'Glacier Brand',
-    quantity: 1
+    quantity: 1,
+    rarity: 'rare'
   };
 
   const alternateWeapon: SaunojaItem = {
     id: 'emberglass-arrow',
     name: 'Emberglass Arrow',
-    quantity: 1
+    quantity: 1,
+    rarity: 'rare'
+  };
+
+  const legendaryWeapon: SaunojaItem = {
+    id: 'emberglass-arrow',
+    name: 'Emberglass Arrow',
+    quantity: 1,
+    rarity: 'legendary'
   };
 
   const supply: SaunojaItem = {
@@ -32,12 +41,43 @@ describe('items/equip', () => {
     expect(unit.items).toHaveLength(1);
   });
 
-  it('rejects conflicting equipment occupying the same slot', () => {
+  it('rejects conflicting equipment occupying the same slot when not an upgrade', () => {
     const unit = makeSaunoja({ id: 's2' });
     expect(equip(unit, weapon).success).toBe(true);
     const outcome = equip(unit, alternateWeapon);
     expect(outcome.success).toBe(false);
     expect(outcome.reason).toBe('slot-occupied');
+    expect(unit.equipment.weapon?.id).toBe('glacier-brand');
+  });
+
+  it('replaces equipped items when the incoming gear is higher tier', () => {
+    const unit = makeSaunoja({ id: 's5' });
+    expect(equip(unit, weapon).success).toBe(true);
+    const outcome = equip(unit, legendaryWeapon);
+    expect(outcome.success).toBe(true);
+    expect(outcome.removed?.id).toBe('glacier-brand');
+    expect(unit.equipment.weapon?.id).toBe('emberglass-arrow');
+  });
+
+  it('ranks stash candidates by slot and power', () => {
+    const ranked = rankEquipmentCandidates(
+      [
+        { ...legendaryWeapon },
+        { ...weapon },
+        { ...supply }
+      ],
+      'weapon'
+    );
+    expect(ranked).toEqual([0, 1]);
+    expect(rankEquipmentCandidates([{ ...supply }], 'weapon')).toHaveLength(0);
+  });
+
+  it('allows downgrading when explicitly permitted', () => {
+    const unit = makeSaunoja({ id: 's6' });
+    expect(equip(unit, legendaryWeapon).success).toBe(true);
+    const downgrade = equip(unit, weapon, { allowDowngrade: true });
+    expect(downgrade.success).toBe(true);
+    expect(downgrade.removed?.id).toBe('emberglass-arrow');
     expect(unit.equipment.weapon?.id).toBe('glacier-brand');
   });
 


### PR DESCRIPTION
## Summary
- rank stash equipment candidates by slot + power and expose helper for reuse
- update equip/game flows to capture returned items, gate downgrades, and walk candidates when replacing
- extend equip and inventory tests plus changelog to cover the new ranking and fallback behaviour

## Testing
- npm run build
- npm run test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d54164eea8833085900916fd010e5e