### PR TITLE
Fix asset base path for subdirectory hosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fix the asset loader failing on GitHub Pages by switching the Vite base path
+  to relative URLs so the polished unit portraits and enemy renders resolve
+  correctly when the site is served from a subdirectory.
+
 - Sync the GitHub Pages shell with the latest build assets so the docs site
   loads the fresh hashed bundles, and copy the non-cacheable headers across to
   prevent browsers from clinging to outdated scripts and styles.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,8 +21,8 @@ try {
 // Vite configuration
 export default defineConfig({
   root: 'src',
-  // Ensure assets resolve correctly when hosted on GitHub Pages.
-  base: '/',
+  // Ensure assets resolve correctly when hosted from a subdirectory (e.g. GitHub Pages).
+  base: './',
   publicDir: '../public',
   plugins: [tailwindcss()],
   build: {


### PR DESCRIPTION
## Summary
- switch the Vite base path to relative URLs so bundles resolve when the site is served from a subdirectory
- document the asset loading fix in the unreleased changelog section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5580abed08330b008954f7a1cb90b