### PR TITLE
Add policy toggle lifecycle support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Extend policy lifecycle handling so toggleable edicts can be disabled and
+  re-enabled without repaying their costs, emit dedicated revoke events for
+  listeners, persist the enabled state in saves, and refresh the HUD plus logs
+  to reflect the new lifecycle hooks.
+
 - Teach the build metadata pipeline to honor a `SOURCE_COMMIT` override so
   release tooling can inject the freshly committed hash before mirroring the
   docs bundle, keeping the published build badge in perfect sync, and relax the

--- a/src/events/policies.ts
+++ b/src/events/policies.ts
@@ -1,11 +1,16 @@
 import { eventBus } from './EventBus';
-import { listPolicies, type PolicyAppliedEvent, type PolicyEffectHook, type PolicyDefinition } from '../data/policies.ts';
+import {
+  listPolicies,
+  type PolicyEffectHook,
+  type PolicyDefinition,
+  type PolicyEffectPayload
+} from '../data/policies.ts';
 
 const disposers: Array<() => void> = [];
 
 function subscribeEffect(definition: PolicyDefinition, effect: PolicyEffectHook): void {
-  const seenStates = new WeakSet<PolicyAppliedEvent['state']>();
-  const listener = (payload: PolicyAppliedEvent): void => {
+  const seenStates = new WeakSet<PolicyEffectPayload['state']>();
+  const listener = (payload: PolicyEffectPayload): void => {
     if (payload.policy.id !== definition.id) {
       return;
     }
@@ -18,7 +23,7 @@ function subscribeEffect(definition: PolicyDefinition, effect: PolicyEffectHook)
     }
   };
 
-  eventBus.on<PolicyAppliedEvent>(effect.event, listener);
+  eventBus.on<PolicyEffectPayload>(effect.event, listener);
   disposers.push(() => eventBus.off(effect.event, listener));
 }
 


### PR DESCRIPTION
## Summary
- add a policy revoke lifecycle event and mark the eco mandate as toggleable with matching hooks
- persist enabled/unlocked state in `GameState`, expose toggle helpers, and update listeners plus UI to handle revokes
- expand the `GameState` tests and changelog to document the new policy lifecycle behaviour

## Testing
- `npx vitest run src/core/GameState.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d62fbdd6688330b003092c537046d6