### PR TITLE
Start the game clock immediately on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Start the main game clock immediately after assets load, stop it during
+  general cleanup to avoid lingering intervals, and add a regression test that
+  guards the lifecycle hook.
+
 - Extract HUD coordination, selection overlay, and progression helpers from
   `src/game.ts` into dedicated modules, wire the orchestrator through the new
   interfaces, and add focused unit tests for each subsystem to lock in the

--- a/src/game.ts
+++ b/src/game.ts
@@ -2332,6 +2332,7 @@ eventBus.on('unitDied', onUnitDied);
 
 export function cleanup(): void {
   running = false;
+  clock.stop();
   gameLoopCallback = null;
   idleFrameCount = 0;
   unitVisionSnapshots.clear();
@@ -2429,6 +2430,7 @@ export async function start(): Promise<void> {
     return;
   }
   running = true;
+  clock.start();
   if (!pauseListenerAttached) {
     eventBus.on('game:pause-changed', onPauseChanged);
     pauseListenerAttached = true;

--- a/tests/game/gameStart.test.ts
+++ b/tests/game/gameStart.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GameClock } from '../../src/core/GameClock.ts';
+import { resetAssetsForTest, setAssets } from '../../src/game/assets.ts';
+import type { LoadedAssets } from '../../src/loader.ts';
+
+describe('game start', () => {
+  let originalRequestAnimationFrame: typeof globalThis.requestAnimationFrame | undefined;
+  let originalCancelAnimationFrame: typeof globalThis.cancelAnimationFrame | undefined;
+
+  beforeEach(() => {
+    originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+      // Do not invoke the callback to avoid recursively scheduling frames during tests.
+      return 1;
+    });
+    const cancelAnimationFrameMock = vi.fn();
+    globalThis.requestAnimationFrame = requestAnimationFrameMock as unknown as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = cancelAnimationFrameMock as unknown as typeof globalThis.cancelAnimationFrame;
+  });
+
+  afterEach(() => {
+    resetAssetsForTest();
+    if (originalRequestAnimationFrame) {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    } else {
+      delete (globalThis as { requestAnimationFrame?: typeof globalThis.requestAnimationFrame }).requestAnimationFrame;
+    }
+    if (originalCancelAnimationFrame) {
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    } else {
+      delete (globalThis as { cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame }).cancelAnimationFrame;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('starts the game clock when the game starts', async () => {
+    const assets: LoadedAssets = {
+      images: {} as LoadedAssets['images'],
+      sounds: {} as LoadedAssets['sounds'],
+      atlases: { units: null }
+    };
+    const clockStartSpy = vi.spyOn(GameClock.prototype, 'start');
+    const game = await import('../../src/game.ts');
+
+    try {
+      game.cleanup();
+      setAssets(assets);
+      await game.start();
+      expect(clockStartSpy).toHaveBeenCalled();
+    } finally {
+      clockStartSpy.mockRestore();
+      game.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- start the main game clock as soon as assets are confirmed and stop it during cleanup so the interval driver never lingers
- document the lifecycle change in the changelog
- add a regression test that spies on the clock start behavior and keeps animation frame mocks isolated

## Testing
- npx vitest run tests/game/gameStart.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d779a12b4883308e818f2f608d8c5a