### PR TITLE
Gate GameClock interval when animation frames run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Gate the `GameClock` interval whenever the animation-frame driver is active so
+  the simulation tick only fires once per cadence, expose an interval toggle on
+  the clock for future drivers, and add regression coverage that advances fake
+  frames alongside timers to guard against double ticks.
+
 - Start the main game clock immediately after assets load, stop it during
   general cleanup to avoid lingering intervals, and add a regression test that
   guards the lifecycle hook.

--- a/src/core/GameClock.test.ts
+++ b/src/core/GameClock.test.ts
@@ -7,15 +7,41 @@ describe('GameClock', () => {
     const cb = vi.fn();
     const clock = new GameClock(1000, cb);
 
-    clock.start();
-    vi.advanceTimersByTime(1000);
-    expect(cb).toHaveBeenCalledTimes(1);
+    try {
+      clock.start();
+      vi.advanceTimersByTime(1000);
+      expect(cb).toHaveBeenCalledTimes(1);
 
-    clock.setSpeed(2); // double speed -> half interval
-    vi.advanceTimersByTime(500);
-    expect(cb).toHaveBeenCalledTimes(2);
+      clock.setSpeed(2); // double speed -> half interval
+      vi.advanceTimersByTime(500);
+      expect(cb).toHaveBeenCalledTimes(2);
+    } finally {
+      clock.stop();
+      vi.useRealTimers();
+    }
+  });
 
-    clock.stop();
-    vi.useRealTimers();
+  it('fires at most once per base interval when driven by animation frames', () => {
+    vi.useFakeTimers();
+    const cb = vi.fn();
+    const clock = new GameClock(100, cb);
+
+    try {
+      clock.start();
+      clock.setIntervalEnabled(false);
+
+      for (let i = 0; i < 5; i += 1) {
+        clock.tick(20);
+        vi.advanceTimersByTime(20);
+      }
+
+      expect(cb).toHaveBeenCalledTimes(1);
+
+      clock.tick(100);
+      expect(cb).toHaveBeenCalledTimes(2);
+    } finally {
+      clock.stop();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/core/GameClock.ts
+++ b/src/core/GameClock.ts
@@ -9,28 +9,24 @@ export class GameClock {
   private speed = 1;
   private lastTick = 0;
   private accumulator = 0;
+  private running = false;
+  private intervalEnabled = true;
 
   constructor(private readonly baseInterval: number, private readonly onTick: TickCallback) {}
 
   /** Start ticking. */
   start(): void {
     this.stop();
+    this.running = true;
+    this.accumulator = 0;
     this.lastTick = Date.now();
-    const interval = this.baseInterval / this.speed;
-    this.timer = setInterval(() => {
-      const now = Date.now();
-      const delta = now - this.lastTick;
-      this.lastTick = now;
-      this.onTick(delta);
-    }, interval);
+    this.setupTimer();
   }
 
   /** Stop ticking. */
   stop(): void {
-    if (this.timer !== null) {
-      clearInterval(this.timer);
-      this.timer = null;
-    }
+    this.running = false;
+    this.clearTimer();
   }
 
   /** Set the speed multiplier and restart ticking if running. */
@@ -39,8 +35,8 @@ export class GameClock {
       throw new Error('Speed multiplier must be positive');
     }
     this.speed = multiplier;
-    if (this.timer !== null) {
-      this.start();
+    if (this.running && this.intervalEnabled) {
+      this.setupTimer();
     }
   }
 
@@ -57,10 +53,53 @@ export class GameClock {
    * animation frame loop to keep ticks in sync with rendering.
    */
   tick(deltaMs: number): void {
+    if (this.timer !== null) {
+      return;
+    }
     this.accumulator += deltaMs * this.speed;
     while (this.accumulator >= this.baseInterval) {
       this.accumulator -= this.baseInterval;
       this.onTick(this.baseInterval);
+    }
+  }
+
+  /**
+   * Enable or disable the internal interval driver. When disabled, the clock
+   * can still be advanced via {@link tick}.
+   */
+  setIntervalEnabled(enabled: boolean): void {
+    if (this.intervalEnabled === enabled) {
+      return;
+    }
+    this.intervalEnabled = enabled;
+    if (!enabled) {
+      this.clearTimer();
+      return;
+    }
+    if (this.running) {
+      this.lastTick = Date.now();
+      this.setupTimer();
+    }
+  }
+
+  private setupTimer(): void {
+    this.clearTimer();
+    if (!this.running || !this.intervalEnabled) {
+      return;
+    }
+    const interval = this.baseInterval / this.speed;
+    this.timer = setInterval(() => {
+      const now = Date.now();
+      const delta = now - this.lastTick;
+      this.lastTick = now;
+      this.onTick(delta);
+    }, interval);
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
     }
   }
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -2430,6 +2430,8 @@ export async function start(): Promise<void> {
     return;
   }
   running = true;
+  const supportsAnimationFrame = typeof requestAnimationFrame === 'function';
+  clock.setIntervalEnabled(true);
   clock.start();
   if (!pauseListenerAttached) {
     eventBus.on('game:pause-changed', onPauseChanged);
@@ -2444,6 +2446,9 @@ export async function start(): Promise<void> {
     animationFrameId = null;
     if (!running) {
       return;
+    }
+    if (supportsAnimationFrame) {
+      clock.setIntervalEnabled(false);
     }
     const delta = now - last;
     last = now;


### PR DESCRIPTION
## Summary
- add an interval toggle to `GameClock` so manual frame drivers can disable the timer safely
- switch the main game loop to suspend the timer whenever requestAnimationFrame drives ticks
- cover the frame-driven cadence with a new unit test and document the change in the changelog

## Testing
- npx vitest run src/core/GameClock.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7936acfb48330a29125b442b6e300