### PR TITLE
Guard GameClock interval during pauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Pause toggles now disable the game clock interval while the sauna is paused,
+  restart it on resume, and ship a regression test to ensure no background ticks
+  sneak through the pause gate.
+
 - Gate the `GameClock` interval whenever the animation-frame driver is active so
   the simulation tick only fires once per cadence, expose an interval toggle on
   the clock for future drivers, and add regression coverage that advances fake

--- a/src/game.ts
+++ b/src/game.ts
@@ -178,6 +178,7 @@ import {
   subscribeRosterEntries as hudSubscribeRosterEntries,
   subscribeHudTime as hudSubscribeHudTime,
   subscribeEnemyRamp as hudSubscribeEnemyRamp,
+  notifyEnemyRamp,
   getHudElapsedMs as getHudElapsedMsSnapshot,
   resetHudTracking,
   setLastRosterEntries,
@@ -306,6 +307,8 @@ function scheduleGameLoop(): void {
 }
 
 const onPauseChanged = () => {
+  const paused = isGamePaused();
+  clock.setIntervalEnabled(!paused);
   invalidateFrame();
 };
 
@@ -2431,7 +2434,7 @@ export async function start(): Promise<void> {
   }
   running = true;
   const supportsAnimationFrame = typeof requestAnimationFrame === 'function';
-  clock.setIntervalEnabled(true);
+  clock.setIntervalEnabled(!isGamePaused());
   clock.start();
   if (!pauseListenerAttached) {
     eventBus.on('game:pause-changed', onPauseChanged);

--- a/tests/game/pauseClock.test.ts
+++ b/tests/game/pauseClock.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GameState } from '../../src/core/GameState.ts';
+import { resetAssetsForTest, setAssets } from '../../src/game/assets.ts';
+import { resetGamePause, setGamePaused } from '../../src/game/pause.ts';
+import type { LoadedAssets } from '../../src/loader.ts';
+
+describe('game pause clock integration', () => {
+  let originalRequestAnimationFrame: typeof globalThis.requestAnimationFrame | undefined;
+  let originalCancelAnimationFrame: typeof globalThis.cancelAnimationFrame | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    const requestAnimationFrameMock = vi.fn(() => 1);
+    const cancelAnimationFrameMock = vi.fn();
+    globalThis.requestAnimationFrame = requestAnimationFrameMock as unknown as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = cancelAnimationFrameMock as unknown as typeof globalThis.cancelAnimationFrame;
+  });
+
+  afterEach(() => {
+    resetAssetsForTest();
+    resetGamePause();
+    if (originalRequestAnimationFrame) {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    } else {
+      delete (globalThis as { requestAnimationFrame?: typeof globalThis.requestAnimationFrame }).requestAnimationFrame;
+    }
+    if (originalCancelAnimationFrame) {
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    } else {
+      delete (globalThis as { cancelAnimationFrame?: typeof globalThis.cancelAnimationFrame }).cancelAnimationFrame;
+    }
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('halts clock ticks while paused and resumes on unpause', async () => {
+    const assets: LoadedAssets = {
+      images: {} as LoadedAssets['images'],
+      sounds: {} as LoadedAssets['sounds'],
+      atlases: { units: null }
+    };
+    const tickSpy = vi.spyOn(GameState.prototype, 'tick');
+    const game = await import('../../src/game.ts');
+    try {
+      game.cleanup();
+      setAssets(assets);
+      await game.start();
+
+      vi.advanceTimersByTime(1000);
+      expect(tickSpy).toHaveBeenCalled();
+
+      tickSpy.mockClear();
+      setGamePaused(true);
+      vi.advanceTimersByTime(5000);
+      expect(tickSpy).not.toHaveBeenCalled();
+
+      setGamePaused(false);
+      vi.advanceTimersByTime(1000);
+      expect(tickSpy).toHaveBeenCalled();
+    } finally {
+      resetGamePause();
+      tickSpy.mockRestore();
+      game.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- stop the GameClock interval driver whenever the pause flag is set and re-enable it on resume
- start the clock with the correct interval state, wire the HUD notifier import, and document the change
- add a Vitest regression that toggles pause to confirm no ticks fire while paused

## Testing
- npx vitest run tests/game/pauseClock.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d79603a0788330972684426001565a