### PR TITLE
Refactor HUD setup into helper module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Refactor game HUD initialization into dedicated helpers that configure
+  classic and modern overlays with shared ability wiring, centralize right panel
+  lifecycle management, and cover both flows with targeted unit tests to ease
+  future HUD tweaks.
+
 - Introduce combat doctrine policies that boost roster attack, defense, and hit
   reliability while raising upkeep, propagate toggle events through Saunoja
   stat recalculations, and wire combat resolution plus economy ticks to respect

--- a/src/game/setup/hud.test.ts
+++ b/src/game/setup/hud.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest';
+import { initializeClassicHud, initializeModernHud } from './hud.ts';
+import type { Sauna } from '../../sim/sauna.ts';
+import type { RosterEntry } from '../../ui/rightPanel.tsx';
+import type { RosterHudSummary } from '../../ui/rosterHUD.ts';
+import type { SaunaUIOptions } from '../../ui/sauna.tsx';
+import type { Resource } from '../../core/GameState.ts';
+import type { EnemyRampSummary } from '../../ui/topbar.ts';
+
+describe('initializeClassicHud', () => {
+  it('installs roster renderers and refreshes classic HUD controllers', () => {
+    const resourceBarEl = document.createElement('div');
+    const rosterEntries: RosterEntry[] = [{} as RosterEntry];
+    const rosterSummary = { total: 3 } as unknown as RosterHudSummary;
+    const previousDispose = vi.fn();
+    const installRenderer = vi.fn();
+    const renderRoster = vi.fn();
+    const updateSummary = vi.fn();
+    const rosterHud = {
+      installRenderer,
+      renderRoster,
+      updateSummary,
+      setExpanded: vi.fn(),
+      toggleExpanded: vi.fn(),
+      destroy: vi.fn()
+    };
+
+    let capturedSaunaOptions: SaunaUIOptions | null = null;
+    const saunaController = { update: vi.fn(), dispose: vi.fn() };
+    const topbarControls = {
+      update: vi.fn(),
+      setEnemyRampSummary: vi.fn(),
+      dispose: vi.fn()
+    };
+    const actionBarController = { destroy: vi.fn() };
+    const inventoryController = { destroy: vi.fn() };
+    const addEventSpy = vi.fn();
+    const disposeRightPanel = vi.fn();
+    const updateRosterDisplay = vi.fn();
+    const startTutorialIfNeeded = vi.fn();
+    const setActiveTier = vi.fn(() => true);
+
+    const syncRoster = vi.fn();
+    const panelRenderer = vi.fn();
+    const createRightPanel = vi.fn((onReady: (renderer: (entries: RosterEntry[]) => void) => void) => {
+      onReady(panelRenderer);
+      return {
+        addEvent: addEventSpy,
+        dispose: disposeRightPanel
+      };
+    });
+
+    const result = initializeClassicHud({
+      resourceBarEl,
+      rosterIcon: 'roster.svg',
+      sauna: {} as Sauna,
+      previousDisposeRightPanel: previousDispose,
+      pendingRosterRenderer: null,
+      pendingRosterEntries: rosterEntries,
+      pendingRosterSummary: rosterSummary,
+      setupRosterHUD: vi.fn(() => rosterHud),
+      setupSaunaUi: vi.fn((_sauna, options) => {
+        capturedSaunaOptions = options;
+        return saunaController;
+      }),
+      getActiveTierId: () => 'ember-circuit',
+      setActiveTier,
+      getTierContext: () => null,
+      setupTopbar: vi.fn(() => topbarControls),
+      setupActionBar: vi.fn(() => actionBarController),
+      actionBarAbilities: {},
+      setupInventoryHud: vi.fn(() => inventoryController),
+      createRightPanel,
+      syncSaunojaRosterWithUnits: syncRoster,
+      updateRosterDisplay,
+      startTutorialIfNeeded
+    });
+
+    expect(previousDispose).toHaveBeenCalledTimes(1);
+    expect(installRenderer).toHaveBeenCalledTimes(1);
+    expect(renderRoster).toHaveBeenCalledWith(rosterEntries);
+    expect(updateSummary).toHaveBeenCalledWith(rosterSummary);
+    expect(result.pendingRosterEntries).toBeNull();
+    expect(result.pendingRosterSummary).toBeNull();
+    expect(typeof result.pendingRosterRenderer).toBe('function');
+    expect(result.rosterHud).toBe(rosterHud);
+    expect(result.saunaUiController).toBe(saunaController);
+    expect(result.topbarControls).toBe(topbarControls);
+    expect(result.actionBarController).toBe(actionBarController);
+    expect(result.inventoryHudController).toBe(inventoryController);
+    expect(result.disposeRightPanel).toBe(disposeRightPanel);
+    expect(result.addEvent).toBe(addEventSpy);
+    expect(result.uiV2RosterController).toBeNull();
+
+    expect(result.pendingRosterRenderer).toBe(panelRenderer);
+    expect(createRightPanel).toHaveBeenCalledTimes(1);
+    expect(result.postSetup).toBeTypeOf('function');
+    result.postSetup?.();
+    expect(syncRoster).toHaveBeenCalledTimes(1);
+    expect(updateRosterDisplay).toHaveBeenCalledTimes(1);
+    expect(startTutorialIfNeeded).toHaveBeenCalledTimes(1);
+
+    capturedSaunaOptions?.setActiveTierId?.('aurora-ward', { persist: true });
+    expect(result.saunaUiController?.update).toHaveBeenCalled();
+    expect(setActiveTier).toHaveBeenCalledWith('aurora-ward', { persist: true });
+    expect(updateRosterDisplay).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('initializeModernHud', () => {
+  it('creates modern HUD controllers and forwards subscriptions', () => {
+    const previousDispose = vi.fn();
+    const actionBarController = { destroy: vi.fn() };
+
+    const rosterSummary = {
+      getSummary: vi.fn(() => ({} as RosterHudSummary | null)),
+      subscribeSummary: vi.fn(() => vi.fn()),
+      getEntries: vi.fn(() => [] as RosterEntry[]),
+      subscribeEntries: vi.fn(() => vi.fn())
+    };
+
+    const rosterController = { dispose: vi.fn(), getSnapshot: vi.fn(), subscribe: vi.fn() };
+    const topbarController = { dispose: vi.fn() };
+    const inventoryController = { dispose: vi.fn() };
+    const logController = { dispose: vi.fn() };
+    const saunaController = { dispose: vi.fn() };
+
+    const createRosterController = vi.fn(() => rosterController);
+    const createTopbarController = vi.fn(() => topbarController);
+    const createInventoryController = vi.fn(() => inventoryController);
+    const createLogController = vi.fn(() => logController);
+    const createSaunaController = vi.fn(() => saunaController);
+
+    const topbar = {
+      getResource: vi.fn((_resource: Resource) => 1),
+      subscribeResourceChange: vi.fn((listener: (payload: { resource: Resource; total: number; amount: number }) => void) => {
+        listener({ resource: 0 as Resource, total: 0, amount: 0 });
+        return vi.fn();
+      }),
+      getArtocoinBalance: vi.fn(() => 0),
+      subscribeArtocoinChange: vi.fn(() => vi.fn()),
+      getElapsedMs: vi.fn(() => 0),
+      subscribeHudTime: vi.fn(() => vi.fn()),
+      getEnemyRamp: vi.fn(() => null as EnemyRampSummary | null),
+      subscribeEnemyRamp: vi.fn(() => vi.fn())
+    };
+
+    const setupActionBar = vi.fn(() => actionBarController);
+
+    const modernResult = initializeModernHud({
+      previousDisposeRightPanel: previousDispose,
+      setupActionBar,
+      actionBarAbilities: {},
+      createRosterController,
+      rosterSummary,
+      createTopbarController,
+      topbar,
+      createInventoryController,
+      inventory: {
+        buildSaunaShopViewModel: vi.fn(() => ({})),
+        subscribeToSaunaShop: vi.fn(() => vi.fn()),
+        getUseUiV2: vi.fn(() => true),
+        setUseUiV2: vi.fn()
+      },
+      createLogController,
+      log: {
+        getHistory: vi.fn(() => []),
+        subscribe: vi.fn(() => vi.fn())
+      },
+      createSaunaController,
+      sauna: {
+        getSauna: vi.fn(() => ({} as Sauna)),
+        setupSaunaUi: vi.fn(),
+        setExternalController: vi.fn(),
+        getActiveTierId: vi.fn(() => 'ember-circuit'),
+        setActiveTierId: vi.fn(() => true),
+        getTierContext: vi.fn(() => null)
+      }
+    });
+
+    expect(previousDispose).toHaveBeenCalledTimes(1);
+    expect(modernResult.actionBarController).toBe(actionBarController);
+    expect(modernResult.uiV2RosterController).toBe(rosterController);
+    expect(modernResult.uiV2TopbarController).toBe(topbarController);
+    expect(modernResult.uiV2InventoryController).toBe(inventoryController);
+    expect(modernResult.uiV2LogController).toBe(logController);
+    expect(modernResult.uiV2SaunaController).toBe(saunaController);
+    expect(modernResult.disposeRightPanel).toBeNull();
+    expect(modernResult.addEvent).toBeTypeOf('function');
+    expect(modernResult.pendingRosterRenderer).toBeNull();
+    expect(modernResult.pendingRosterEntries).toBeNull();
+    expect(modernResult.pendingRosterSummary).toBeNull();
+    expect(modernResult.postSetup).toBeUndefined();
+    expect(() => modernResult.addEvent({} as never)).not.toThrow();
+
+    expect(createRosterController).toHaveBeenCalledTimes(1);
+    expect(createTopbarController).toHaveBeenCalledTimes(1);
+    expect(createInventoryController).toHaveBeenCalledTimes(1);
+    expect(createLogController).toHaveBeenCalledTimes(1);
+    expect(createSaunaController).toHaveBeenCalledTimes(1);
+    expect(setupActionBar).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/game/setup/hud.ts
+++ b/src/game/setup/hud.ts
@@ -1,0 +1,310 @@
+import type { Sauna } from '../../sim/sauna.ts';
+import type {
+  ActionBarAbilityHandlers,
+  ActionBarController
+} from '../../ui/action-bar/index.tsx';
+import type { GameEvent, RosterEntry } from '../../ui/rightPanel.tsx';
+import type {
+  RosterHudController,
+  RosterHudSummary
+} from '../../ui/rosterHUD.ts';
+import type { SaunaUIController, SaunaUIOptions } from '../../ui/sauna.tsx';
+import type { TopbarControls } from '../../ui/topbar.ts';
+import type { Resource } from '../../core/GameState.ts';
+import type { SaunaTierContext, SaunaTierId } from '../../sauna/tiers.ts';
+import type { EnemyRampSummary } from '../../ui/topbar.ts';
+import type { UiV2RosterController } from '../../uiV2/rosterController.ts';
+import type { UiV2TopbarController } from '../../uiV2/topbarController.ts';
+import type { UiV2InventoryController } from '../../uiV2/inventoryController.ts';
+import type { UiV2LogController } from '../../uiV2/logController.ts';
+import type { UiV2SaunaController } from '../../uiV2/saunaController.ts';
+
+type InventoryHudController = { destroy(): void };
+
+type RightPanelBridge = {
+  addEvent: (event: GameEvent) => void;
+  dispose: () => void;
+};
+
+type SaunaUiFactory = (sauna: Sauna, options: SaunaUIOptions) => SaunaUIController;
+
+type TopbarFactory = () => TopbarControls;
+
+type ActionBarFactory = (abilities: ActionBarAbilityHandlers) => ActionBarController;
+
+type InventoryHudFactory = () => InventoryHudController;
+
+type RightPanelFactory = (
+  onRosterRendererReady: (renderer: (entries: RosterEntry[]) => void) => void
+) => RightPanelBridge;
+
+type UiV2RosterFactory = (options: {
+  getSummary: () => RosterHudSummary | null;
+  subscribeSummary: (listener: (summary: RosterHudSummary) => void) => () => void;
+  getEntries: () => RosterEntry[];
+  subscribeEntries: (listener: (entries: RosterEntry[]) => void) => () => void;
+}) => UiV2RosterController;
+
+type UiV2TopbarFactory = (options: {
+  getResource: (resource: Resource) => number;
+  subscribeResourceChange: (
+    listener: (payload: { resource: Resource; total: number; amount: number }) => void
+  ) => () => void;
+  getArtocoinBalance: () => number;
+  subscribeArtocoinChange: (listener: (total: number) => void) => () => void;
+  getElapsedMs: () => number;
+  subscribeHudTime: (listener: (elapsed: number) => void) => () => void;
+  getEnemyRamp: () => EnemyRampSummary | null;
+  subscribeEnemyRamp: (listener: (summary: EnemyRampSummary | null) => void) => () => void;
+}) => UiV2TopbarController;
+
+type UiV2InventoryFactory = (options: {
+  buildSaunaShopViewModel: () => unknown;
+  subscribeToSaunaShop: (listener: () => void) => () => void;
+  getUseUiV2: () => boolean;
+  setUseUiV2: (next: boolean) => void;
+}) => UiV2InventoryController;
+
+type UiV2LogFactory = (options: {
+  getHistory: () => unknown[];
+  subscribe: (listener: (history: unknown[]) => void) => () => void;
+}) => UiV2LogController;
+
+type UiV2SaunaFactory = (options: {
+  getSauna: () => Sauna;
+  setupSaunaUi: SaunaUiFactory;
+  setExternalController: (controller: SaunaUIController | null) => void;
+  getActiveTierId: () => SaunaTierId;
+  setActiveTierId: (tierId: SaunaTierId, options?: { persist?: boolean }) => boolean;
+  getTierContext: () => SaunaTierContext | null;
+}) => UiV2SaunaController;
+
+type ClassicHudDependencies = {
+  resourceBarEl: HTMLElement;
+  rosterIcon: string;
+  sauna: Sauna;
+  previousDisposeRightPanel: (() => void) | null;
+  pendingRosterRenderer: ((entries: RosterEntry[]) => void) | null;
+  pendingRosterEntries: RosterEntry[] | null;
+  pendingRosterSummary: RosterHudSummary | null;
+  setupRosterHUD: (resourceBar: HTMLElement, options: { rosterIcon: string }) => RosterHudController;
+  setupSaunaUi: SaunaUiFactory;
+  getActiveTierId: () => SaunaTierId;
+  setActiveTier: (tierId: SaunaTierId, options?: { persist?: boolean }) => boolean;
+  getTierContext: () => SaunaTierContext | null;
+  setupTopbar: TopbarFactory;
+  setupActionBar: ActionBarFactory;
+  actionBarAbilities: ActionBarAbilityHandlers;
+  setupInventoryHud: InventoryHudFactory;
+  createRightPanel: RightPanelFactory;
+  syncSaunojaRosterWithUnits: () => boolean;
+  updateRosterDisplay: () => void;
+  startTutorialIfNeeded: () => void;
+};
+
+type ModernHudDependencies = {
+  previousDisposeRightPanel: (() => void) | null;
+  setupActionBar: ActionBarFactory;
+  actionBarAbilities: ActionBarAbilityHandlers;
+  createRosterController: UiV2RosterFactory;
+  rosterSummary: {
+    getSummary: () => RosterHudSummary | null;
+    subscribeSummary: (listener: (summary: RosterHudSummary) => void) => () => void;
+    getEntries: () => RosterEntry[];
+    subscribeEntries: (listener: (entries: RosterEntry[]) => void) => () => void;
+  };
+  createTopbarController: UiV2TopbarFactory;
+  topbar: {
+    getResource: (resource: Resource) => number;
+    subscribeResourceChange: (
+      listener: (payload: { resource: Resource; total: number; amount: number }) => void
+    ) => () => void;
+    getArtocoinBalance: () => number;
+    subscribeArtocoinChange: (listener: (total: number) => void) => () => void;
+    getElapsedMs: () => number;
+    subscribeHudTime: (listener: (elapsed: number) => void) => () => void;
+    getEnemyRamp: () => EnemyRampSummary | null;
+    subscribeEnemyRamp: (listener: (summary: EnemyRampSummary | null) => void) => () => void;
+  };
+  createInventoryController: UiV2InventoryFactory;
+  inventory: {
+    buildSaunaShopViewModel: () => unknown;
+    subscribeToSaunaShop: (listener: () => void) => () => void;
+    getUseUiV2: () => boolean;
+    setUseUiV2: (next: boolean) => void;
+  };
+  createLogController: UiV2LogFactory;
+  log: {
+    getHistory: () => unknown[];
+    subscribe: (listener: (history: unknown[]) => void) => () => void;
+  };
+  createSaunaController: UiV2SaunaFactory;
+  sauna: {
+    getSauna: () => Sauna;
+    setupSaunaUi: SaunaUiFactory;
+    setExternalController: (controller: SaunaUIController | null) => void;
+    getActiveTierId: () => SaunaTierId;
+    setActiveTierId: (tierId: SaunaTierId, options?: { persist?: boolean }) => boolean;
+    getTierContext: () => SaunaTierContext | null;
+  };
+};
+
+export type HudInitializationResult = {
+  rosterHud: RosterHudController | null;
+  pendingRosterRenderer: ((entries: RosterEntry[]) => void) | null;
+  pendingRosterEntries: RosterEntry[] | null;
+  pendingRosterSummary: RosterHudSummary | null;
+  saunaUiController: SaunaUIController | null;
+  topbarControls: TopbarControls | null;
+  actionBarController: ActionBarController | null;
+  inventoryHudController: InventoryHudController | null;
+  disposeRightPanel: (() => void) | null;
+  addEvent: (event: GameEvent) => void;
+  uiV2RosterController: UiV2RosterController | null;
+  uiV2TopbarController: UiV2TopbarController | null;
+  uiV2InventoryController: UiV2InventoryController | null;
+  uiV2LogController: UiV2LogController | null;
+  uiV2SaunaController: UiV2SaunaController | null;
+  postSetup?: () => void;
+};
+
+export function initializeClassicHud(deps: ClassicHudDependencies): HudInitializationResult {
+  deps.previousDisposeRightPanel?.();
+
+  const rosterHud = deps.setupRosterHUD(deps.resourceBarEl, { rosterIcon: deps.rosterIcon });
+
+  let pendingRosterEntries = deps.pendingRosterEntries;
+  let pendingRosterRenderer = deps.pendingRosterRenderer;
+  let pendingRosterSummary = deps.pendingRosterSummary;
+
+  if (pendingRosterRenderer) {
+    rosterHud.installRenderer(pendingRosterRenderer);
+  }
+
+  if (pendingRosterEntries) {
+    rosterHud.renderRoster(pendingRosterEntries);
+    pendingRosterEntries = null;
+  }
+
+  if (pendingRosterSummary) {
+    rosterHud.updateSummary(pendingRosterSummary);
+    pendingRosterSummary = null;
+  }
+
+  const saunaUiController = deps.setupSaunaUi(deps.sauna, {
+    getActiveTierId: deps.getActiveTierId,
+    setActiveTierId: (tierId, options) => {
+      const unlocked = deps.setActiveTier(tierId, options);
+      if (unlocked) {
+        saunaUiController.update();
+        deps.updateRosterDisplay();
+      }
+      return unlocked;
+    },
+    getTierContext: deps.getTierContext
+  });
+
+  const topbarControls = deps.setupTopbar();
+  const actionBarController = deps.setupActionBar(deps.actionBarAbilities);
+  const inventoryHudController = deps.setupInventoryHud();
+
+  const handleRosterRendererReady = (renderer: (entries: RosterEntry[]) => void): void => {
+    pendingRosterRenderer = renderer;
+    rosterHud.installRenderer(renderer);
+    if (pendingRosterEntries) {
+      rosterHud.renderRoster(pendingRosterEntries);
+      pendingRosterEntries = null;
+    }
+  };
+
+  const rightPanel = deps.createRightPanel(handleRosterRendererReady);
+
+  const postSetup = (): void => {
+    deps.syncSaunojaRosterWithUnits();
+    deps.updateRosterDisplay();
+    deps.startTutorialIfNeeded();
+  };
+
+  return {
+    rosterHud,
+    pendingRosterRenderer,
+    pendingRosterEntries,
+    pendingRosterSummary,
+    saunaUiController,
+    topbarControls,
+    actionBarController,
+    inventoryHudController,
+    disposeRightPanel: rightPanel.dispose,
+    addEvent: rightPanel.addEvent,
+    uiV2RosterController: null,
+    uiV2TopbarController: null,
+    uiV2InventoryController: null,
+    uiV2LogController: null,
+    uiV2SaunaController: null,
+    postSetup
+  };
+}
+
+export function initializeModernHud(deps: ModernHudDependencies): HudInitializationResult {
+  deps.previousDisposeRightPanel?.();
+
+  const actionBarController = deps.setupActionBar(deps.actionBarAbilities);
+
+  const uiV2RosterController = deps.createRosterController({
+    getSummary: deps.rosterSummary.getSummary,
+    subscribeSummary: deps.rosterSummary.subscribeSummary,
+    getEntries: deps.rosterSummary.getEntries,
+    subscribeEntries: deps.rosterSummary.subscribeEntries
+  });
+
+  const uiV2TopbarController = deps.createTopbarController({
+    getResource: deps.topbar.getResource,
+    subscribeResourceChange: deps.topbar.subscribeResourceChange,
+    getArtocoinBalance: deps.topbar.getArtocoinBalance,
+    subscribeArtocoinChange: deps.topbar.subscribeArtocoinChange,
+    getElapsedMs: deps.topbar.getElapsedMs,
+    subscribeHudTime: deps.topbar.subscribeHudTime,
+    getEnemyRamp: deps.topbar.getEnemyRamp,
+    subscribeEnemyRamp: deps.topbar.subscribeEnemyRamp
+  });
+
+  const uiV2InventoryController = deps.createInventoryController({
+    buildSaunaShopViewModel: deps.inventory.buildSaunaShopViewModel,
+    subscribeToSaunaShop: deps.inventory.subscribeToSaunaShop,
+    getUseUiV2: deps.inventory.getUseUiV2,
+    setUseUiV2: deps.inventory.setUseUiV2
+  });
+
+  const uiV2LogController = deps.createLogController({
+    getHistory: deps.log.getHistory,
+    subscribe: deps.log.subscribe
+  });
+
+  const uiV2SaunaController = deps.createSaunaController({
+    getSauna: deps.sauna.getSauna,
+    setupSaunaUi: deps.sauna.setupSaunaUi,
+    setExternalController: deps.sauna.setExternalController,
+    getActiveTierId: deps.sauna.getActiveTierId,
+    setActiveTierId: deps.sauna.setActiveTierId,
+    getTierContext: deps.sauna.getTierContext
+  });
+
+  return {
+    rosterHud: null,
+    pendingRosterRenderer: null,
+    pendingRosterEntries: null,
+    pendingRosterSummary: null,
+    saunaUiController: null,
+    topbarControls: null,
+    actionBarController,
+    inventoryHudController: null,
+    disposeRightPanel: null,
+    addEvent: () => {},
+    uiV2RosterController,
+    uiV2TopbarController,
+    uiV2InventoryController,
+    uiV2LogController,
+    uiV2SaunaController,
+    postSetup: undefined
+  };
+}


### PR DESCRIPTION
## Summary
- extract classic and modern HUD initialization helpers with explicit dependencies
- update setupGame to delegate HUD wiring to the new helpers and keep shared reset logic local
- cover both HUD helpers with focused unit tests and document the refactor in the changelog

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d7c7ba470c8330a567cd8fda5ca081