### PR TITLE
Guard modifier runtime onApply failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Guard modifier application so `onApply` failures unwind partial state, skip
+  addition events, and cover the regression with a focused runtime test to keep
+  gameplay modifiers cleanly indexed.
+
 - Refactor game HUD initialization into dedicated helpers that configure
   classic and modern overlays with shared ability wiring, centralize right panel
   lifecycle management, and cover both flows with targeted unit tests to ease

--- a/src/mods/runtime.ts
+++ b/src/mods/runtime.ts
@@ -120,7 +120,13 @@ export class ModifierRuntime {
     this.indexHooks(active);
 
     const context: ModifierHookContext = { runtime: this, modifier: active };
-    definition.onApply?.(context);
+    try {
+      definition.onApply?.(context);
+    } catch (error) {
+      this.modifiers.delete(active.id);
+      this.unindexHooks(active);
+      throw error;
+    }
 
     this.emit('modifierAdded', { modifier: active });
     this.emitter?.emit('modifierAdded', { modifier: active });

--- a/tests/mods/runtime.test.ts
+++ b/tests/mods/runtime.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ModifierRuntime } from '../../src/mods/runtime.ts';
+
+describe('ModifierRuntime', () => {
+  it('cleans up state when onApply throws', () => {
+    const runtime = new ModifierRuntime(null);
+    const listener = vi.fn();
+    runtime.on('modifierAdded', listener);
+
+    expect(() =>
+      runtime.add({
+        id: 'unstable-mod',
+        duration: 5,
+        hooks: {
+          tick: () => {}
+        },
+        onApply: () => {
+          throw new Error('kaboom');
+        }
+      })
+    ).toThrowError('kaboom');
+
+    expect(runtime.has('unstable-mod')).toBe(false);
+    expect(runtime.list()).toHaveLength(0);
+
+    const internals = runtime as unknown as {
+      hookIndex: Map<string, Set<string>>;
+    };
+    expect(internals.hookIndex.has('tick')).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- guard the modifier runtime so onApply failures unwind partial registration before any events fire
- document the regression fix in the changelog for visibility
- add a focused modifier runtime test that asserts no lingering modifier or hook index entries remain after a thrown onApply

## Testing
- npx vitest run tests/mods/runtime.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7d1a5dbac8330a1b4ed138547b5f5