### PR TITLE
Refactor sauna lifecycle into setup helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Extract sauna lifecycle wiring into `game/setup/sauna.ts`, add a reusable
+  right-panel initializer, and adjust game setup to consume the new helpers with
+  focused unit coverage for tier persistence, UI toggling, and spawn queue
+  management.
+
 - Guard modifier application so `onApply` failures unwind partial state, skip
   addition events, and cover the regression with a focused runtime test to keep
   gameplay modifiers cleanly indexed.

--- a/src/game/setup/rightPanel.ts
+++ b/src/game/setup/rightPanel.ts
@@ -1,0 +1,69 @@
+import type { GameState } from '../../core/GameState.ts';
+import type { Sauna } from '../../sim/sauna.ts';
+import type { Saunoja } from '../../units/saunoja.ts';
+import type { Unit } from '../../unit/index.ts';
+import { setupRightPanel, type GameEvent, type RosterEntry } from '../../ui/rightPanel.tsx';
+import type { EquipmentSlotId } from '../../items/types.ts';
+
+export interface RightPanelDependencies {
+  state: GameState;
+  sauna: Sauna;
+  getSaunojas: () => Saunoja[];
+  getAttachedUnitFor: (attendant: Saunoja) => Unit | null;
+  focusSaunojaById: (unitId: string) => void;
+  equipSlotFromStash: (unitId: string, slot: EquipmentSlotId) => boolean;
+  unequipSlotToStash: (unitId: string, slot: EquipmentSlotId) => boolean;
+  saveUnits: () => void;
+  updateRosterDisplay: () => void;
+  getActiveTierLimit: () => number;
+  updateRosterCap: (value: number, options?: { persist?: boolean }) => number;
+}
+
+export interface RightPanelBridge {
+  addEvent: (event: GameEvent) => void;
+  dispose: () => void;
+}
+
+export function initializeRightPanel(
+  deps: RightPanelDependencies,
+  onRosterRendererReady: (renderer: (entries: RosterEntry[]) => void) => void
+): RightPanelBridge {
+  const rightPanel = setupRightPanel(deps.state, {
+    onRosterSelect: deps.focusSaunojaById,
+    onRosterRendererReady: (renderer) => {
+      onRosterRendererReady(renderer);
+    },
+    onRosterEquipSlot: deps.equipSlotFromStash,
+    onRosterUnequipSlot: deps.unequipSlotToStash,
+    onRosterBehaviorChange: (unitId, nextBehavior) => {
+      const attendant = deps.getSaunojas().find((unit) => unit.id === unitId);
+      if (!attendant) {
+        return;
+      }
+      if (attendant.behavior === nextBehavior) {
+        return;
+      }
+      attendant.behavior = nextBehavior;
+      const attachedUnit = deps.getAttachedUnitFor(attendant);
+      attachedUnit?.setBehavior(nextBehavior);
+      deps.saveUnits();
+      deps.updateRosterDisplay();
+    },
+    getRosterCap: () => Math.max(0, Math.floor(deps.sauna.maxRosterSize)),
+    getRosterCapLimit: () => deps.getActiveTierLimit(),
+    updateMaxRosterSize: (value, opts) => {
+      const next = deps.updateRosterCap(value, { persist: opts?.persist });
+      if (opts?.persist) {
+        deps.updateRosterDisplay();
+      }
+      return next;
+    }
+  });
+
+  onRosterRendererReady(rightPanel.renderRoster);
+
+  return {
+    addEvent: rightPanel.addEvent,
+    dispose: rightPanel.dispose
+  } satisfies RightPanelBridge;
+}

--- a/src/game/setup/sauna.ts
+++ b/src/game/setup/sauna.ts
@@ -1,0 +1,263 @@
+import type { HexMap } from '../../hexmap.ts';
+import { createSauna, type Sauna } from '../../sim/sauna.ts';
+import {
+  DEFAULT_SAUNA_TIER_ID,
+  evaluateSaunaTier,
+  getSaunaTier,
+  listSaunaTiers,
+  type SaunaTier,
+  type SaunaTierContext,
+  type SaunaTierId
+} from '../../sauna/tiers.ts';
+import { createPlayerSpawnTierQueue, type PlayerSpawnTierHelpers } from '../../world/spawn/tier_helpers.ts';
+import {
+  getArtocoinBalance,
+  getPurchasedTierIds,
+  setPurchasedTierIds
+} from '../saunaShopState.ts';
+import { loadSaunaSettings, saveSaunaSettings } from '../saunaSettings.ts';
+import { grantSaunaTier } from '../../progression/saunaShop.ts';
+import type { NgPlusState } from '../../progression/ngplus.ts';
+import type { LogEventPayload } from '../../ui/logging.ts';
+
+export interface SaunaLifecycleOptions {
+  map: HexMap;
+  ngPlusState: NgPlusState;
+  getActiveRosterCount: () => number;
+  logEvent: (event: LogEventPayload) => void;
+  minSpawnLimit: number;
+}
+
+export interface SaunaTierChangeContext {
+  previousTierId: SaunaTierId;
+  nextTierId: SaunaTierId;
+}
+
+export interface SaunaLifecycleResult {
+  sauna: Sauna;
+  getTierContext: () => SaunaTierContext;
+  getActiveTierId: () => SaunaTierId;
+  getActiveTierLimit: () => number;
+  getUseUiV2: () => boolean;
+  setUseUiV2: (next: boolean) => void;
+  updateRosterCap: (value: number, options?: { persist?: boolean }) => number;
+  setActiveTier: (
+    tierId: SaunaTierId,
+    options?: { persist?: boolean; onTierChanged?: (context: SaunaTierChangeContext) => void }
+  ) => boolean;
+  syncActiveTierWithUnlocks: (
+    options?: { persist?: boolean; onTierChanged?: (context: SaunaTierChangeContext) => void }
+  ) => void;
+  resolveSpawnLimit: () => number;
+  spawnTierQueue: PlayerSpawnTierHelpers;
+}
+
+export function clampRosterCap(value: number, limit: number): number {
+  const maxCap = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 0;
+  if (!Number.isFinite(value)) {
+    return maxCap;
+  }
+  const sanitized = Math.max(0, Math.floor(value));
+  return Math.max(0, Math.min(maxCap, sanitized));
+}
+
+export function createSaunaLifecycle(options: SaunaLifecycleOptions): SaunaLifecycleResult {
+  const { map, ngPlusState, getActiveRosterCount, logEvent, minSpawnLimit } = options;
+
+  const saunaSettings = loadSaunaSettings();
+
+  if (ngPlusState.unlockSlots >= 2) {
+    setPurchasedTierIds(grantSaunaTier('aurora-ward'));
+  }
+  if (ngPlusState.ngPlusLevel >= 3) {
+    setPurchasedTierIds(grantSaunaTier('mythic-conclave'));
+  }
+  if (
+    saunaSettings.activeTierId !== DEFAULT_SAUNA_TIER_ID &&
+    !getPurchasedTierIds().has(saunaSettings.activeTierId)
+  ) {
+    setPurchasedTierIds(grantSaunaTier(saunaSettings.activeTierId));
+  }
+
+  const resolveTierContext = (): SaunaTierContext => ({
+    artocoinBalance: getArtocoinBalance(),
+    ownedTierIds: getPurchasedTierIds()
+  });
+
+  let currentTierId: SaunaTierId = saunaSettings.activeTierId;
+  let useUiV2 = saunaSettings.useUiV2;
+  const initialTierStatus = evaluateSaunaTier(getSaunaTier(currentTierId), resolveTierContext());
+  if (!initialTierStatus.unlocked) {
+    currentTierId = DEFAULT_SAUNA_TIER_ID;
+  }
+  const activeTier = getSaunaTier(currentTierId);
+
+  const getActiveTierLimit = (): number => {
+    const tier = getSaunaTier(currentTierId);
+    const cap = Math.max(0, Math.floor(tier.rosterCap));
+    return cap;
+  };
+
+  const initialRosterCap = clampRosterCap(saunaSettings.maxRosterSize, getActiveTierLimit());
+  if (
+    initialRosterCap !== saunaSettings.maxRosterSize ||
+    saunaSettings.activeTierId !== currentTierId ||
+    saunaSettings.useUiV2 !== useUiV2
+  ) {
+    saveSaunaSettings({
+      maxRosterSize: initialRosterCap,
+      activeTierId: currentTierId,
+      useUiV2
+    });
+  }
+
+  const sauna = createSauna(
+    {
+      q: Math.floor(map.width / 2),
+      r: Math.floor(map.height / 2)
+    },
+    undefined,
+    { maxRosterSize: initialRosterCap, tier: activeTier }
+  );
+
+  const sanitizeVisionRange = (value: number): number =>
+    Math.max(0, Math.floor(Number.isFinite(value) ? value : 0));
+
+  const updateSaunaVisionFromTier = (tier: SaunaTier, options: { reveal?: boolean } = {}): void => {
+    const resolved = sanitizeVisionRange(tier.visionRange);
+    if (resolved !== sauna.visionRange) {
+      sauna.visionRange = resolved;
+    }
+    if (options.reveal) {
+      map.revealAround(sauna.pos, sauna.visionRange);
+    }
+  };
+
+  updateSaunaVisionFromTier(activeTier);
+
+  const resolveSpawnLimit = (): number => Math.max(minSpawnLimit, sauna.maxRosterSize);
+
+  const getUseUiV2 = (): boolean => useUiV2;
+
+  const spawnTierQueue = createPlayerSpawnTierQueue({
+    getTier: () => getSaunaTier(currentTierId),
+    getRosterLimit: () => getActiveTierLimit(),
+    getRosterCount: () => getActiveRosterCount(),
+    log: (event) => logEvent(event),
+    queueCapacity: 3
+  });
+
+  let lastPersistedRosterCap = initialRosterCap;
+  let lastPersistedTierId = currentTierId;
+
+  const persistSaunaSettings = (cap: number, overrides?: { useUiV2?: boolean }): void => {
+    if (typeof overrides?.useUiV2 === 'boolean') {
+      useUiV2 = overrides.useUiV2;
+    }
+    saveSaunaSettings({ maxRosterSize: cap, activeTierId: currentTierId, useUiV2 });
+    lastPersistedRosterCap = cap;
+    lastPersistedTierId = currentTierId;
+  };
+
+  const getTierContext = (): SaunaTierContext => resolveTierContext();
+
+  const updateRosterCap = (
+    value: number,
+    options: { persist?: boolean } = {}
+  ): number => {
+    const limit = getActiveTierLimit();
+    const sanitized = clampRosterCap(value, limit);
+    const changed = sanitized !== sauna.maxRosterSize;
+    if (changed) {
+      sauna.maxRosterSize = sanitized;
+    }
+    if (options.persist) {
+      const tierChanged = currentTierId !== lastPersistedTierId;
+      if (tierChanged || sanitized !== lastPersistedRosterCap) {
+        persistSaunaSettings(sanitized);
+      }
+    }
+    return sanitized;
+  };
+
+  const syncActiveTierWithUnlocks = (
+    options: { persist?: boolean; onTierChanged?: (context: SaunaTierChangeContext) => void } = {}
+  ): void => {
+    const context = getTierContext();
+    const tiers = listSaunaTiers();
+    let highestUnlockedId = DEFAULT_SAUNA_TIER_ID;
+    for (const tier of tiers) {
+      const status = evaluateSaunaTier(tier, context);
+      if (status.unlocked) {
+        highestUnlockedId = tier.id;
+      } else {
+        break;
+      }
+    }
+
+    const currentStatus = evaluateSaunaTier(getSaunaTier(currentTierId), context);
+    const tierChanged = !currentStatus.unlocked || currentTierId !== highestUnlockedId;
+    if (tierChanged) {
+      const previousTierId = currentTierId;
+      currentTierId = highestUnlockedId;
+      const nextTier = getSaunaTier(currentTierId);
+      updateSaunaVisionFromTier(nextTier, { reveal: true });
+      spawnTierQueue.clearQueue?.('tier-change');
+      updateRosterCap(sauna.maxRosterSize, { persist: options.persist });
+      options.onTierChanged?.({ previousTierId, nextTierId: currentTierId });
+      return;
+    }
+
+    if (options.persist) {
+      updateRosterCap(sauna.maxRosterSize, { persist: true });
+    }
+  };
+
+  const setUseUiV2 = (next: boolean): void => {
+    const normalized = Boolean(next);
+    if (useUiV2 === normalized) {
+      return;
+    }
+    persistSaunaSettings(sauna.maxRosterSize, { useUiV2: normalized });
+  };
+
+  const setActiveTier = (
+    tierId: SaunaTierId,
+    options: { persist?: boolean; onTierChanged?: (context: SaunaTierChangeContext) => void } = {}
+  ): boolean => {
+    const tier = getSaunaTier(tierId);
+    const status = evaluateSaunaTier(tier, getTierContext());
+    if (!status.unlocked) {
+      return false;
+    }
+    if (tier.id === currentTierId) {
+      if (options.persist && currentTierId !== lastPersistedTierId) {
+        persistSaunaSettings(sauna.maxRosterSize);
+      }
+      return true;
+    }
+    const previousTierId = currentTierId;
+    currentTierId = tier.id;
+    updateSaunaVisionFromTier(tier, { reveal: true });
+    spawnTierQueue.clearQueue?.('tier-change');
+    updateRosterCap(sauna.maxRosterSize, { persist: options.persist });
+    options.onTierChanged?.({ previousTierId, nextTierId: currentTierId });
+    return true;
+  };
+
+  syncActiveTierWithUnlocks({ persist: true });
+
+  return {
+    sauna,
+    getTierContext,
+    getActiveTierId: () => currentTierId,
+    getActiveTierLimit,
+    getUseUiV2,
+    setUseUiV2,
+    updateRosterCap,
+    setActiveTier,
+    syncActiveTierWithUnlocks,
+    resolveSpawnLimit,
+    spawnTierQueue
+  } satisfies SaunaLifecycleResult;
+}

--- a/tests/setup/sauna.test.ts
+++ b/tests/setup/sauna.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { HexMap } from '../../src/hexmap.ts';
+import {
+  DEFAULT_SAUNA_TIER_ID,
+  listSaunaTiers,
+  type SaunaTierId
+} from '../../src/sauna/tiers.ts';
+import type { NgPlusState } from '../../src/progression/ngplus.ts';
+import { createSaunaLifecycle } from '../../src/game/setup/sauna.ts';
+
+const {
+  loadSaunaSettingsMock,
+  saveSaunaSettingsMock,
+  getArtocoinBalanceMock,
+  getPurchasedTierIdsMock,
+  setPurchasedTierIdsMock,
+  grantSaunaTierMock
+} = vi.hoisted(() => ({
+  loadSaunaSettingsMock: vi.fn(),
+  saveSaunaSettingsMock: vi.fn(),
+  getArtocoinBalanceMock: vi.fn(),
+  getPurchasedTierIdsMock: vi.fn<[], Set<SaunaTierId>>(),
+  setPurchasedTierIdsMock: vi.fn<(ids: Set<SaunaTierId>) => void>(),
+  grantSaunaTierMock: vi.fn<(tierId: SaunaTierId) => Set<SaunaTierId>>()
+}));
+
+vi.mock('../../src/game/saunaSettings.ts', () => ({
+  loadSaunaSettings: loadSaunaSettingsMock,
+  saveSaunaSettings: saveSaunaSettingsMock
+}));
+
+vi.mock('../../src/game/saunaShopState.ts', () => ({
+  getArtocoinBalance: getArtocoinBalanceMock,
+  getPurchasedTierIds: getPurchasedTierIdsMock,
+  setPurchasedTierIds: setPurchasedTierIdsMock
+}));
+
+vi.mock('../../src/progression/saunaShop.ts', () => ({
+  grantSaunaTier: grantSaunaTierMock
+}));
+
+const purchasedTierIds = new Set<SaunaTierId>();
+
+const ngPlusState: NgPlusState = {
+  runSeed: 1,
+  ngPlusLevel: 0,
+  unlockSlots: 0,
+  enemyTuning: { aggressionMultiplier: 1, cadenceMultiplier: 1, strengthMultiplier: 1 }
+};
+
+const createLifecycle = () =>
+  createSaunaLifecycle({
+    map: new HexMap(10, 10, 32),
+    ngPlusState,
+    getActiveRosterCount: () => 0,
+    logEvent: vi.fn(),
+    minSpawnLimit: 3
+  });
+
+beforeEach(() => {
+  purchasedTierIds.clear();
+  purchasedTierIds.add(DEFAULT_SAUNA_TIER_ID);
+  getPurchasedTierIdsMock.mockReset();
+  getPurchasedTierIdsMock.mockImplementation(() => new Set(purchasedTierIds));
+  getArtocoinBalanceMock.mockReset();
+  getArtocoinBalanceMock.mockReturnValue(0);
+  loadSaunaSettingsMock.mockReset();
+  loadSaunaSettingsMock.mockReturnValue({
+    maxRosterSize: 2,
+    activeTierId: DEFAULT_SAUNA_TIER_ID,
+    useUiV2: false
+  });
+  saveSaunaSettingsMock.mockReset();
+  setPurchasedTierIdsMock.mockReset();
+  setPurchasedTierIdsMock.mockImplementation((ids: Set<SaunaTierId>) => {
+    purchasedTierIds.clear();
+    for (const id of ids) {
+      purchasedTierIds.add(id);
+    }
+  });
+  grantSaunaTierMock.mockReset();
+  grantSaunaTierMock.mockImplementation((tierId: SaunaTierId) => {
+    purchasedTierIds.add(tierId);
+    return new Set(purchasedTierIds);
+  });
+});
+
+describe('createSaunaLifecycle', () => {
+  it('persists roster cap when updateRosterCap runs with persist', () => {
+    const lifecycle = createLifecycle();
+    saveSaunaSettingsMock.mockClear();
+
+    const limit = lifecycle.getActiveTierLimit();
+    const next = lifecycle.updateRosterCap(limit + 5, { persist: true });
+
+    expect(next).toBe(limit);
+    expect(saveSaunaSettingsMock).toHaveBeenCalledTimes(1);
+    expect(saveSaunaSettingsMock).toHaveBeenLastCalledWith({
+      maxRosterSize: limit,
+      activeTierId: lifecycle.getActiveTierId(),
+      useUiV2: false
+    });
+  });
+
+  it('persists when toggling UI v2 usage', () => {
+    const lifecycle = createLifecycle();
+    saveSaunaSettingsMock.mockClear();
+
+    lifecycle.setUseUiV2(true);
+
+    expect(saveSaunaSettingsMock).toHaveBeenCalledWith({
+      maxRosterSize: lifecycle.sauna.maxRosterSize,
+      activeTierId: lifecycle.getActiveTierId(),
+      useUiV2: true
+    });
+  });
+
+  it('clears the spawn queue when switching tiers', () => {
+    const tiers = listSaunaTiers();
+    expect(tiers.length).toBeGreaterThan(1);
+
+    const lifecycle = createLifecycle();
+    purchasedTierIds.add(tiers[1].id);
+    const queue = lifecycle.spawnTierQueue;
+    const snapshot = queue.getSnapshot();
+    expect(snapshot).not.toBeNull();
+    const queued = queue.queueBlockedSpawn(snapshot!, () => true);
+    expect(queued).toBe(true);
+    expect(queue.hasQueuedSpawn()).toBe(true);
+
+    const changed = lifecycle.setActiveTier(tiers[1].id, { persist: true });
+    expect(changed).toBe(true);
+    expect(queue.hasQueuedSpawn()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- extract sauna lifecycle management into a dedicated setup helper that syncs tiers, roster caps, UI toggle state, and spawn queues
- move right panel initialization into its own setup module and rewire the game bootstrap to use the new bridges
- add targeted sauna lifecycle unit tests and document the refactor in the changelog

## Testing
- npx vitest run tests/setup/sauna.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7d2c7276883309b081cf6ed61f424