### PR TITLE
Fix Unit stats readonly reassignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Stop reassigning the Unit stat block readonly reference during construction by
+  dropping the immutability marker, keeping health normalization intact while
+  cloning stats so combatants initialize with polished, predictable values.
+
 - Normalize freshly spawned units so their health always matches the computed
   maximum, clone archetype stat blocks before adjustment, and cover the
   regression with focused unit and factory tests to keep reinforcements battle

--- a/src/units/Unit.ts
+++ b/src/units/Unit.ts
@@ -57,7 +57,7 @@ export class Unit {
   private behavior: UnitBehavior;
   private appearanceId: string;
 
-  public readonly stats: UnitStats;
+  public stats: UnitStats;
   public combatHooks: CombatHookMap | null = null;
   public combatKeywords: CombatKeywordRegistry | null = null;
 


### PR DESCRIPTION
## Summary
- drop the readonly modifier from the Unit stat block so cloning no longer reassigns an immutable property
- document the Unit construction fix in the changelog

## Testing
- npx vitest run src/units/Unit.test.ts src/units/UnitFactory.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3e04782808330818dce5506d4f07c