### PR TITLE
feat: mirror behavior controls in roster HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Extend the roster HUD with polished behavior toggles that mirror the right panel,
+  share a unified change handler across both surfaces, and cover the refreshed
+  interaction with updated tests and styling tweaks.
+
 
 - Split the classic HUD orchestration into runtime UI adapters so `GameRuntime`
   composes action bar, top bar, sauna overlay, inventory HUD, and right panel

--- a/src/style.css
+++ b/src/style.css
@@ -1772,11 +1772,91 @@ body > #game-container {
 }
 
 .saunoja-card__behavior {
-  margin: 6px 0 0;
-  font-size: clamp(11px, 1.5vw, 12px);
-  letter-spacing: 0.14em;
+  margin: 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.saunoja-card__behavior-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: clamp(10px, 1.4vw, 11px);
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: color-mix(in srgb, #38bdf8 65%, white 35%);
+  color: color-mix(in srgb, var(--color-muted) 65%, white 35%);
+}
+
+.saunoja-card__behavior-label {
+  font-weight: 600;
+}
+
+.saunoja-card__behavior-value {
+  font-size: clamp(12px, 1.6vw, 13px);
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, #38bdf8 75%, white 25%);
+  text-shadow: 0 0 12px rgba(56, 189, 248, 0.35);
+}
+
+.saunoja-card__behavior-options {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 10px;
+  padding: 6px;
+  border-radius: 999px;
+  background:
+    linear-gradient(145deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.55)),
+    rgba(15, 23, 42, 0.45);
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.22),
+    0 16px 28px rgba(15, 23, 42, 0.42);
+  backdrop-filter: blur(14px);
+}
+
+.saunoja-card__behavior-options[aria-disabled='true'] {
+  opacity: 0.6;
+  filter: grayscale(0.2);
+}
+
+.saunoja-card__behavior-option {
+  appearance: none;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  padding: 6px 16px;
+  font-size: clamp(10px, 1.4vw, 11px);
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-muted) 70%, white 30%);
+  background: linear-gradient(140deg, rgba(30, 41, 59, 0.78), rgba(15, 23, 42, 0.9));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  transition: color 160ms ease, background 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.saunoja-card__behavior-option:is(:hover, :focus-visible) {
+  border-color: rgba(148, 163, 184, 0.6);
+  color: color-mix(in srgb, white 70%, #38bdf8 30%);
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.3),
+    0 14px 24px rgba(15, 23, 42, 0.45);
+}
+
+.saunoja-card__behavior-option.is-active {
+  border-color: rgba(148, 163, 184, 0.65);
+  color: color-mix(in srgb, white 82%, #38bdf8 18%);
+  background: linear-gradient(140deg, rgba(56, 189, 248, 0.42), rgba(37, 99, 235, 0.52));
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.35),
+    0 18px 28px rgba(15, 23, 42, 0.5);
+}
+
+.saunoja-card__behavior-option:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
 }
 
 .saunoja-card__traits {

--- a/src/ui/rosterHUD.test.ts
+++ b/src/ui/rosterHUD.test.ts
@@ -78,9 +78,17 @@ describe('rosterHUD', () => {
       expect(callouts?.textContent).toContain('+7 Focus');
       expect(callouts?.textContent).toContain('+5 Resolve');
 
-      const behavior = root?.querySelector('.saunoja-card__behavior');
-      expect(behavior?.textContent).toBe('Behavior: Attack');
-      expect(behavior?.title).toBe('Behavior: Attack');
+      const behaviorValue = root?.querySelector('.saunoja-card__behavior-value');
+      expect(behaviorValue?.textContent).toBe('Attack');
+      expect(behaviorValue?.title).toBe('Behavior: Attack');
+
+      const behaviorGroup = root?.querySelector('.saunoja-card__behavior-options');
+      expect(behaviorGroup?.getAttribute('aria-disabled')).toBe('true');
+      const activeBehavior = behaviorGroup?.querySelector<HTMLButtonElement>(
+        '.saunoja-card__behavior-option.is-active'
+      );
+      expect(activeBehavior?.dataset.behavior).toBe('attack');
+      expect(activeBehavior?.disabled).toBe(true);
 
       const traits = root?.querySelector('.saunoja-card__traits');
       expect(traits?.textContent).toBe('Brave, Sage');
@@ -179,6 +187,53 @@ describe('rosterHUD', () => {
       hud.destroy();
     } finally {
       overlay.remove();
+    }
+  });
+
+  it('notifies behavior changes when the behavior buttons are clicked', () => {
+    const container = makeContainer();
+    const onBehaviorChange = vi.fn();
+
+    try {
+      const hud = setupRosterHUD(container, {
+        rosterIcon: '/icon.svg',
+        onBehaviorChange
+      });
+
+      hud.updateSummary({
+        count: 1,
+        card: {
+          id: 'saunoja-9',
+          name: 'Veikko',
+          traits: [],
+          upkeep: 12,
+          behavior: 'defend',
+          progression: {
+            level: 3,
+            xp: 300,
+            xpIntoLevel: 20,
+            xpForNext: 200,
+            progress: 20 / 200,
+            statBonuses: { vigor: 0, focus: 0, resolve: 0 }
+          }
+        }
+      });
+
+      const rosterRoot = container.querySelector('.sauna-roster');
+      const toggle = rosterRoot?.querySelector<HTMLButtonElement>('.sauna-roster__toggle');
+      toggle?.click();
+
+      const behaviorGroup = rosterRoot?.querySelector('.saunoja-card__behavior-options');
+      expect(behaviorGroup?.getAttribute('aria-disabled')).toBe('false');
+      const attackButton = behaviorGroup?.querySelector<HTMLButtonElement>(
+        ".saunoja-card__behavior-option[data-behavior='attack']"
+      );
+      expect(attackButton?.disabled).toBe(false);
+      attackButton?.click();
+
+      expect(onBehaviorChange).toHaveBeenCalledWith('saunoja-9', 'attack');
+    } finally {
+      destroyContainer(container);
     }
   });
 });


### PR DESCRIPTION
## Summary
- add an accessible behavior toggle group to the roster HUD card that calls an optional callback
- share a right panel behavior-change helper and expose it through the bridge so the HUD can reuse it
- refresh HUD tests, styling, and changelog coverage for the new controls

## Testing
- npm run build
- npx vitest run src/ui/rosterHUD.test.ts src/game/setup/hud.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e41954e3b88330934b7afb023da40c