### PR TITLE
Refactor roster orchestration and fix persistence tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Extract the roster orchestrator into `game/orchestrators/roster.ts`, wire it
+  through the runtime dependency hooks, update HUD and test imports, and cover
+  roster entry sorting plus summary selection with focused Vitest cases.
+
+- Rehydrate Saunoja attachments after loading roster storage so experience,
+  coordinates, and baselines persist across saves, extend the affected Vitest
+  cases with longer async windows, and update the animation loop test to track
+  the runtime game loop callback directly.
+
 - Extract the game runtime bootstrap into `game/runtime/index.ts`, re-export the
   lazy singleton API from `game.ts`, and add coverage to confirm the runtime is
   configured on-demand through the new entry point.

--- a/src/game/orchestrators/roster.test.ts
+++ b/src/game/orchestrators/roster.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildRosterEntries,
+  buildRosterSummary,
+  configureRosterOrchestrator,
+  saunojas,
+  saunojaToUnit,
+  unitToSaunoja
+} from './roster.ts';
+import type { Unit } from '../../unit/index.ts';
+import { makeSaunoja } from '../../units/saunoja.ts';
+
+const makeStubUnit = (
+  id: string,
+  options: { health?: number; maxHealth?: number; shield?: number; dead?: boolean } = {}
+): Unit => {
+  const health = options.health ?? 10;
+  const stats = {
+    health,
+    attackDamage: 3,
+    attackRange: 1,
+    movementRange: 2,
+    defense: 0
+  };
+  return {
+    id,
+    stats,
+    getMaxHealth: () => options.maxHealth ?? health,
+    getShield: () => options.shield ?? 0,
+    isDead: () => Boolean(options.dead)
+  } as unknown as Unit;
+};
+
+describe('roster orchestrator', () => {
+  const unitsById = new Map<string, Unit>();
+  let activeRosterCount = 0;
+
+  beforeEach(() => {
+    saunojas.splice(0, saunojas.length);
+    saunojaToUnit.clear();
+    unitToSaunoja.clear();
+    unitsById.clear();
+    activeRosterCount = 0;
+
+    configureRosterOrchestrator({
+      getUnitById: (id) => unitsById.get(id),
+      getAttachedUnitFor: (attendant) => {
+        const attachedId = saunojaToUnit.get(attendant.id);
+        return attachedId ? unitsById.get(attachedId) ?? null : null;
+      },
+      getActiveRosterCount: () => activeRosterCount,
+      syncSelectionOverlay: () => {}
+    });
+  });
+
+  it('sorts roster entries by status and name', () => {
+    const engagedAlpha = makeSaunoja({ id: 'alpha', name: 'Alpha' });
+    const engagedBravo = makeSaunoja({ id: 'bravo', name: 'Bravo' });
+    const reserve = makeSaunoja({ id: 'reserve', name: 'Charlie' });
+    const downed = makeSaunoja({ id: 'downed', name: 'Delta', hp: 0 });
+
+    const alphaUnit = makeStubUnit('unit-alpha', { health: 12 });
+    const bravoUnit = makeStubUnit('unit-bravo', { health: 8 });
+
+    saunojas.push(reserve, downed, engagedBravo, engagedAlpha);
+    saunojaToUnit.set(engagedAlpha.id, alphaUnit.id);
+    saunojaToUnit.set(engagedBravo.id, bravoUnit.id);
+    unitToSaunoja.set(alphaUnit.id, engagedAlpha);
+    unitToSaunoja.set(bravoUnit.id, engagedBravo);
+    unitsById.set(alphaUnit.id, alphaUnit);
+    unitsById.set(bravoUnit.id, bravoUnit);
+
+    const entries = buildRosterEntries();
+    expect(entries.map((entry) => [entry.status, entry.name])).toEqual([
+      ['engaged', 'Alpha'],
+      ['engaged', 'Bravo'],
+      ['reserve', 'Charlie'],
+      ['downed', 'Delta']
+    ]);
+  });
+
+  it('builds roster summary with the selected attendant and active count', () => {
+    activeRosterCount = 7;
+
+    const selected = makeSaunoja({ id: 'sel', name: 'Selena', behavior: 'attack', selected: true });
+    selected.upkeep = 3.4;
+    const reserve = makeSaunoja({ id: 'reserve', name: 'Rune' });
+    const downed = makeSaunoja({ id: 'downed', name: 'Dormant', hp: 0 });
+
+    saunojas.push(downed, reserve, selected);
+
+    const summary = buildRosterSummary();
+    expect(summary.count).toBe(7);
+    expect(summary.card).not.toBeNull();
+    expect(summary.card?.id).toBe(selected.id);
+    expect(summary.card?.behavior).toBe('attack');
+    expect(summary.card?.upkeep).toBe(3);
+  });
+
+  it('falls back to the first living Saunoja when none are selected', () => {
+    activeRosterCount = 2;
+    const downed = makeSaunoja({ id: 'downed', name: 'Dormant', hp: 0, selected: false });
+    const living = makeSaunoja({ id: 'living', name: 'Lyra', selected: false });
+
+    saunojas.push(downed, living);
+
+    const summary = buildRosterSummary();
+    expect(summary.count).toBe(2);
+    expect(summary.card?.id).toBe('living');
+  });
+});

--- a/src/game/orchestrators/roster.ts
+++ b/src/game/orchestrators/roster.ts
@@ -1,0 +1,360 @@
+import { getGameRuntime } from '../runtime/index.ts';
+import { EQUIPMENT_SLOT_IDS, type EquipmentModifier } from '../../items/types.ts';
+import { getSlotDefinition } from '../../items/equip.ts';
+import type { RosterEntry, RosterStats } from '../../ui/panels/RosterPanel.tsx';
+import type { RosterHudSummary, RosterCardViewModel } from '../../ui/rosterHUD.ts';
+import type { Saunoja } from '../../units/saunoja.ts';
+import type { Unit } from '../../unit/index.ts';
+import type { UnitBehavior } from '../../unit/types.ts';
+import { getLevelProgress, getTotalStatAwards } from '../../progression/experiencePlan.ts';
+import type { RosterPersonaBaseline } from '../runtime/rosterService.ts';
+import type { GameRuntime } from '../runtime/GameRuntime.ts';
+
+type RosterSummaryListener = (summary: RosterHudSummary) => void;
+type RosterEntriesListener = (entries: RosterEntry[]) => void;
+
+type RosterOrchestratorDependencies = {
+  getUnitById(unitId: string): Unit | undefined;
+  getAttachedUnitFor(attendant: Saunoja): Unit | null;
+  getActiveRosterCount(): number;
+  syncSelectionOverlay(): void;
+};
+
+let orchestratorDeps: RosterOrchestratorDependencies | null = null;
+
+function requireDeps(): RosterOrchestratorDependencies {
+  if (!orchestratorDeps) {
+    throw new Error('Roster orchestrator has not been configured.');
+  }
+  return orchestratorDeps;
+}
+
+export function configureRosterOrchestrator(deps: RosterOrchestratorDependencies): void {
+  orchestratorDeps = deps;
+}
+
+export const saunojas: Saunoja[] = [];
+export const unitToSaunoja = new Map<string, Saunoja>();
+export const saunojaToUnit = new Map<string, string>();
+export type SaunojaPolicyBaseline = RosterPersonaBaseline;
+export const saunojaPolicyBaselines = new WeakMap<Saunoja, SaunojaPolicyBaseline>();
+
+const rosterSummaryListeners = new Set<RosterSummaryListener>();
+const rosterEntriesListeners = new Set<RosterEntriesListener>();
+let localLastRosterSummary: RosterHudSummary | null = null;
+let localLastRosterEntries: RosterEntry[] = [];
+
+function tryGetRuntime(): GameRuntime | null {
+  try {
+    return getGameRuntime();
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('not been configured')) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function notifyRosterSummary(summary: RosterHudSummary): void {
+  localLastRosterSummary = summary;
+  const runtime = tryGetRuntime();
+  runtime?.setLastRosterSummary(summary);
+  for (const listener of rosterSummaryListeners) {
+    try {
+      listener(summary);
+    } catch (error) {
+      console.warn('Failed to notify roster summary listener', error);
+    }
+  }
+}
+
+function notifyRosterEntries(entries: RosterEntry[]): void {
+  localLastRosterEntries = entries;
+  const runtime = tryGetRuntime();
+  runtime?.setLastRosterEntries(entries);
+  for (const listener of rosterEntriesListeners) {
+    try {
+      listener(entries);
+    } catch (error) {
+      console.warn('Failed to notify roster entries listener', error);
+    }
+  }
+}
+
+function scaleModifiers(modifiers: EquipmentModifier, quantity: number): EquipmentModifier {
+  const stacks = Math.max(1, Math.round(quantity));
+  const scaled: EquipmentModifier = {};
+  if (typeof modifiers.health === 'number') {
+    scaled.health = modifiers.health * stacks;
+  }
+  if (typeof modifiers.attackDamage === 'number') {
+    scaled.attackDamage = modifiers.attackDamage * stacks;
+  }
+  if (typeof modifiers.attackRange === 'number') {
+    scaled.attackRange = modifiers.attackRange * stacks;
+  }
+  if (typeof modifiers.movementRange === 'number') {
+    scaled.movementRange = modifiers.movementRange * stacks;
+  }
+  if (typeof modifiers.defense === 'number') {
+    scaled.defense = modifiers.defense * stacks;
+  }
+  if (typeof modifiers.shield === 'number') {
+    scaled.shield = modifiers.shield * stacks;
+  }
+  return scaled;
+}
+
+export function buildProgression(attendant: Saunoja): RosterEntry['progression'] {
+  const progress = getLevelProgress(attendant.xp);
+  return {
+    level: progress.level,
+    xp: Math.max(0, Math.floor(attendant.xp)),
+    xpIntoLevel: progress.xpIntoLevel,
+    xpForNext: progress.xpForNext,
+    progress: progress.progressToNext,
+    statBonuses: getTotalStatAwards(progress.level)
+  } satisfies RosterEntry['progression'];
+}
+
+export function buildRosterEntries(): RosterEntry[] {
+  const deps = requireDeps();
+  const statusRank: Record<RosterEntry['status'], number> = {
+    engaged: 0,
+    reserve: 1,
+    downed: 2
+  };
+
+  const entries = saunojas.map((attendant) => {
+    const attachedUnitId = saunojaToUnit.get(attendant.id);
+    const fallbackUnit = deps.getAttachedUnitFor(attendant);
+    const unit = attachedUnitId
+      ? deps.getUnitById(attachedUnitId) ?? fallbackUnit ?? undefined
+      : fallbackUnit ?? undefined;
+    const unitAlive = unit ? !unit.isDead() && unit.stats.health > 0 : false;
+
+    const effectiveStats = attendant.effectiveStats;
+    const baseStats = attendant.baseStats;
+    const currentHealth = unit
+      ? Math.round(Math.max(0, unit.stats.health))
+      : Math.round(Math.max(0, attendant.hp));
+    const maxHealth = unit
+      ? Math.round(Math.max(1, unit.getMaxHealth()))
+      : Math.round(Math.max(1, effectiveStats.health));
+    const attackDamage = unit
+      ? Math.round(Math.max(0, unit.stats.attackDamage))
+      : Math.round(Math.max(0, effectiveStats.attackDamage));
+    const attackRange = unit
+      ? Math.round(Math.max(0, unit.stats.attackRange))
+      : Math.round(Math.max(0, effectiveStats.attackRange));
+    const movementRange = unit
+      ? Math.round(Math.max(0, unit.stats.movementRange))
+      : Math.round(Math.max(0, effectiveStats.movementRange));
+    const defenseSource = unit?.stats.defense ?? effectiveStats.defense ?? 0;
+    const defense = Math.round(Math.max(0, defenseSource));
+    const shieldSource = unit ? unit.getShield() : effectiveStats.shield ?? attendant.shield;
+    const shield = Math.round(Math.max(0, shieldSource));
+    const upkeep = Math.max(0, Math.round(attendant.upkeep));
+    const status: RosterEntry['status'] =
+      currentHealth <= 0 ? 'downed' : unitAlive ? 'engaged' : 'reserve';
+
+    const progression = buildProgression(attendant);
+
+    const items = attendant.items.map((item) => ({ ...item }));
+    const modifiers = attendant.modifiers.map((modifier) => ({ ...modifier }));
+
+    const equipmentSlots = EQUIPMENT_SLOT_IDS.map((slotId) => {
+      const slotDefinition = getSlotDefinition(slotId);
+      const equipped = attendant.equipment[slotId];
+      const rosterItem = equipped
+        ? {
+            id: equipped.id,
+            name: equipped.name,
+            description: equipped.description,
+            icon: equipped.icon,
+            rarity: equipped.rarity,
+            quantity: equipped.quantity,
+            slot: slotId
+          }
+        : null;
+      const aggregated = equipped ? scaleModifiers(equipped.modifiers, equipped.quantity) : null;
+      return {
+        id: slotId,
+        label: slotDefinition.label,
+        description: slotDefinition.description,
+        maxStacks: slotDefinition.maxStacks,
+        item: rosterItem,
+        modifiers: aggregated
+      };
+    });
+
+    const rosterBase: RosterStats = {
+      health: Math.round(Math.max(0, baseStats.health)),
+      maxHealth: Math.round(Math.max(1, baseStats.health)),
+      attackDamage: Math.round(Math.max(0, baseStats.attackDamage)),
+      attackRange: Math.round(Math.max(0, baseStats.attackRange)),
+      movementRange: Math.round(Math.max(0, baseStats.movementRange)),
+      defense:
+        typeof baseStats.defense === 'number' && baseStats.defense > 0
+          ? Math.round(baseStats.defense)
+          : undefined,
+      shield:
+        typeof baseStats.shield === 'number' && baseStats.shield > 0
+          ? Math.round(baseStats.shield)
+          : undefined
+    } satisfies RosterStats;
+
+    const behavior: UnitBehavior = attendant.behavior ?? 'defend';
+
+    return {
+      id: attendant.id,
+      name: attendant.name,
+      upkeep,
+      status,
+      selected: Boolean(attendant.selected),
+      behavior,
+      traits: [...attendant.traits],
+      stats: {
+        health: currentHealth,
+        maxHealth,
+        attackDamage,
+        attackRange,
+        movementRange,
+        defense: defense > 0 ? defense : undefined,
+        shield: shield > 0 ? shield : undefined
+      },
+      baseStats: rosterBase,
+      progression,
+      equipment: equipmentSlots,
+      items,
+      modifiers
+    } satisfies RosterEntry;
+  });
+
+  entries.sort((a, b) => {
+    const statusDelta = statusRank[a.status] - statusRank[b.status];
+    if (statusDelta !== 0) {
+      return statusDelta;
+    }
+    return a.name.localeCompare(b.name, 'en');
+  });
+
+  return entries;
+}
+
+function pickFeaturedSaunoja(): Saunoja | null {
+  if (saunojas.length === 0) {
+    return null;
+  }
+  return (
+    saunojas.find((unit) => unit.selected) ??
+    saunojas.find((unit) => unit.hp > 0) ??
+    saunojas[0]
+  );
+}
+
+export function buildRosterSummary(): RosterHudSummary {
+  const deps = requireDeps();
+  const total = deps.getActiveRosterCount();
+  const featured = pickFeaturedSaunoja();
+  let card: RosterCardViewModel | null = null;
+  if (featured) {
+    const behavior: UnitBehavior = featured.behavior ?? 'defend';
+    card = {
+      id: featured.id,
+      name: featured.name || 'Saunoja',
+      traits: [...featured.traits],
+      upkeep: Math.max(0, Math.round(featured.upkeep)),
+      progression: buildProgression(featured),
+      behavior
+    } satisfies RosterCardViewModel;
+  }
+  return { count: total, card } satisfies RosterHudSummary;
+}
+
+export function refreshRosterPanel(entries?: RosterEntry[]): void {
+  const view = entries ?? buildRosterEntries();
+  const runtime = tryGetRuntime();
+  runtime?.setPendingRosterEntries(view);
+  notifyRosterEntries(view);
+  requireDeps().syncSelectionOverlay();
+  const rosterHud = runtime?.getRosterHud();
+  if (!rosterHud) {
+    return;
+  }
+  rosterHud.renderRoster(view);
+}
+
+export function updateRosterDisplay(): void {
+  const summary = buildRosterSummary();
+  notifyRosterSummary(summary);
+  const runtime = tryGetRuntime();
+  const rosterHud = runtime?.getRosterHud();
+  if (rosterHud) {
+    rosterHud.updateSummary(summary);
+    runtime?.setPendingRosterSummary(null);
+  } else {
+    runtime?.setPendingRosterSummary(summary);
+  }
+  refreshRosterPanel();
+  requireDeps().syncSelectionOverlay();
+}
+
+export function getRosterSummarySnapshot(): RosterHudSummary {
+  const runtime = tryGetRuntime();
+  if (runtime) {
+    const lastSummary = runtime.getLastRosterSummary();
+    if (lastSummary) {
+      return lastSummary;
+    }
+    const pendingSummary = runtime.getPendingRosterSummary();
+    if (pendingSummary) {
+      return pendingSummary;
+    }
+  } else if (localLastRosterSummary) {
+    return localLastRosterSummary;
+  }
+  return buildRosterSummary();
+}
+
+export function getRosterEntriesSnapshot(): RosterEntry[] {
+  const runtime = tryGetRuntime();
+  if (runtime) {
+    const cachedEntries = runtime.getLastRosterEntries();
+    if (cachedEntries.length > 0) {
+      return cachedEntries;
+    }
+    const pendingEntries = runtime.getPendingRosterEntries();
+    if (pendingEntries && pendingEntries.length > 0) {
+      return pendingEntries;
+    }
+  } else if (localLastRosterEntries.length > 0) {
+    return localLastRosterEntries;
+  }
+  return buildRosterEntries();
+}
+
+export function subscribeRosterSummary(listener: RosterSummaryListener): () => void {
+  rosterSummaryListeners.add(listener);
+  try {
+    listener(getRosterSummarySnapshot());
+  } catch (error) {
+    console.warn('Failed to deliver roster summary snapshot', error);
+  }
+  return () => {
+    rosterSummaryListeners.delete(listener);
+  };
+}
+
+export function subscribeRosterEntries(listener: RosterEntriesListener): () => void {
+  rosterEntriesListeners.add(listener);
+  try {
+    listener(getRosterEntriesSnapshot());
+  } catch (error) {
+    console.warn('Failed to deliver roster entries snapshot', error);
+  }
+  return () => {
+    rosterEntriesListeners.delete(listener);
+  };
+}
+

--- a/src/game/runtime/index.test.ts
+++ b/src/game/runtime/index.test.ts
@@ -6,6 +6,7 @@ import {
   getGameStateInstance,
   getRosterCapLimit,
   getRosterCapValue,
+  getRosterService,
   getSaunaInstance,
   getSaunaTierContextSnapshot,
   setActiveSaunaTier,
@@ -134,11 +135,12 @@ describe('runtime bootstrap', () => {
   let updateRosterCap: ReturnType<typeof vi.fn>;
   let setActiveTier: ReturnType<typeof vi.fn>;
   let createContext: ReturnType<typeof vi.fn>;
+  let rosterService: RosterService;
 
   beforeEach(() => {
     updateRosterCap = vi.fn((value: number) => value);
     setActiveTier = vi.fn(() => true);
-    const rosterService = createStubRosterService();
+    rosterService = createStubRosterService();
     const context = createStubContext({
       state,
       map,
@@ -179,6 +181,7 @@ describe('runtime bootstrap', () => {
     expect(getSaunaInstance()).toBe(sauna);
     expect(getActiveSaunaTierId()).toBe(activeTier);
     expect(getSaunaTierContextSnapshot()).toBe(tierContext);
+    expect(getRosterService()).toBe(rosterService);
     expect(getRosterCapValue()).toBe(7);
     expect(getRosterCapLimit()).toBe(4);
     expect(setRosterCapValue(9)).toBe(9);

--- a/src/game/runtime/index.ts
+++ b/src/game/runtime/index.ts
@@ -101,3 +101,7 @@ export function setRosterCapValue(
 ): number {
   return requireBootstrap().updateRosterCap(value, options);
 }
+
+export function getRosterService(): RosterService {
+  return requireBootstrap().rosterService;
+}


### PR DESCRIPTION
## Summary
- extract the roster helpers into `src/game/orchestrators/roster.ts` with focused tests
- rehydrate roster attachments when loading units and expose the runtime roster service getter
- extend the affected Vitest suites with higher timeouts and updated game loop detection

## Testing
- CI=1 npm run test > /tmp/fulltest.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68e4a184d17c83309ac6a369164c5f57