### PR TITLE
Fix HUD overlay grid class reapplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Restore the HUD overlay grid so the base and region classes persist across
+  variant switches, keeping roster and icon panels visible after toggling the
+  right-side collapse.
+
 - Extract the roster orchestrator into `game/orchestrators/roster.ts`, wire it
   through the runtime dependency hooks, update HUD and test imports, and cover
   roster entry sorting plus summary selection with focused Vitest cases.

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -170,13 +170,30 @@ function ensureCommandDockSection(
 }
 
 function applyVariantClasses(overlay: HTMLElement, regions: HudLayoutRegions): void {
-  overlay.classList.remove(...OVERLAY_GRID_CLASSES.base);
-  overlay.classList.remove(OVERLAY_GRID_CLASSES.collapsed);
+  const { base, collapsed } = OVERLAY_GRID_CLASSES;
+
+  const overlayVariantClasses = Array.from(overlay.classList).filter(
+    (className) => className.startsWith('hud-grid--') && className !== collapsed,
+  );
+  if (overlayVariantClasses.length > 0) {
+    overlay.classList.remove(...overlayVariantClasses);
+  }
+
+  overlay.classList.add(...base);
+  overlay.classList.remove(collapsed);
+
   for (const [name, classes] of Object.entries(REGION_GRID_CLASSES) as Array<[
     keyof HudLayoutRegions,
     string[]
   ]>) {
-    regions[name].classList.remove(...classes);
+    const region = regions[name];
+    const regionVariantClasses = Array.from(region.classList).filter((className) =>
+      className.startsWith('hud-region--'),
+    );
+    if (regionVariantClasses.length > 0) {
+      region.classList.remove(...regionVariantClasses);
+    }
+    region.classList.add(...classes);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the HUD overlay restores its base grid classes and reapplies region grid classes after clearing variant-specific entries
- document the fix in the changelog for visibility

## Testing
- npm run build
- npx vitest run tests/ui/action-bar.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e55330d4848330aae145b9da2b2e52