### PR TITLE
Refine HUD combat log layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Detach the combat log from the events tab into a fixed console footer with a
+  collapsible header, persist the collapse preference, and refresh styling plus
+  HUD tests for the compact UX.
+
 - Restore the HUD overlay grid so the base and region classes persist across
   variant switches, keeping roster and icon panels visible after toggling the
   right-side collapse.

--- a/src/style.css
+++ b/src/style.css
@@ -2702,17 +2702,45 @@ body > #game-container {
 }
 
 .panel-log {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  min-height: 100%;
+  gap: clamp(12px, 1.8vw, 18px);
+  padding: clamp(16px, 2vw, 20px);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.92), rgba(15, 23, 42, 0.88));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12), 0 24px 38px rgba(2, 6, 23, 0.55);
+  flex: 0 0 auto;
+  overflow: hidden;
+  transition: background var(--transition-snappy), box-shadow var(--transition-snappy),
+    padding var(--transition-snappy), gap var(--transition-snappy);
+}
+
+.panel-log::after {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.12), rgba(56, 189, 248, 0.08));
+  opacity: 0.65;
+  mix-blend-mode: screen;
 }
 
 .panel-log__header {
+  position: relative;
+  z-index: 1;
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
+}
+
+.panel-log__headline {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .panel-log__title {
@@ -2727,13 +2755,82 @@ body > #game-container {
   font-size: 12px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-muted) 85%, white 15%);
+  color: color-mix(in srgb, var(--color-muted) 80%, white 20%);
+}
+
+.panel-log__toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: color-mix(in srgb, rgba(30, 41, 59, 0.94) 70%, rgba(94, 234, 212, 0.22) 30%);
+  color: color-mix(in srgb, var(--color-foreground) 88%, white 12%);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform var(--transition-snappy), border-color var(--transition-snappy),
+    background var(--transition-snappy), color var(--transition-snappy),
+    box-shadow var(--transition-snappy);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16), 0 14px 28px rgba(2, 6, 23, 0.45);
+}
+
+.panel-log__toggle:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, rgba(148, 163, 184, 0.6) 60%, rgba(94, 234, 212, 0.3) 40%);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.22), 0 18px 32px rgba(2, 6, 23, 0.52);
+}
+
+.panel-log__toggle:active {
+  transform: translateY(0);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.32), 0 12px 22px rgba(2, 6, 23, 0.4);
+}
+
+.panel-log__toggle-label {
+  pointer-events: none;
+}
+
+.panel-log__chevron {
+  width: 10px;
+  height: 10px;
+  border-bottom: 2px solid currentColor;
+  border-right: 2px solid currentColor;
+  border-radius: 2px;
+  transform: rotate(45deg);
+  transition: transform var(--transition-snappy);
+  pointer-events: none;
+}
+
+.panel-log__body {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: min(360px, 45vh);
 }
 
 .panel-log__filters {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+}
+
+.panel-log--collapsed {
+  gap: clamp(6px, 1vw, 10px);
+  padding-bottom: clamp(10px, 1.4vw, 14px);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1), 0 16px 26px rgba(2, 6, 23, 0.45);
+}
+
+.panel-log--collapsed .panel-log__chevron {
+  transform: rotate(-135deg);
+}
+
+.panel-log--collapsed .panel-log__total {
+  color: color-mix(in srgb, var(--color-muted) 90%, white 10%);
 }
 
 .log-chip {
@@ -2794,6 +2891,8 @@ body > #game-container {
   flex-direction: column;
   gap: 12px;
   min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
   padding-bottom: 4px;
 }
 

--- a/tests/ui/logging.test.ts
+++ b/tests/ui/logging.test.ts
@@ -85,6 +85,13 @@ describe('right panel log filters', () => {
 
     await settle();
 
+    const logPanel = document.querySelector<HTMLElement>('#right-panel-log');
+    expect(logPanel).toBeTruthy();
+    expect(logPanel?.classList.contains('panel-log--collapsed')).toBe(false);
+
+    const collapseToggle = document.querySelector<HTMLButtonElement>('.panel-log__toggle');
+    expect(collapseToggle?.getAttribute('aria-expanded')).toBe('true');
+
     const combatEntry = document.querySelector<HTMLElement>(
       '#event-log .panel-log-entry[data-log-type="combat"]'
     );
@@ -96,6 +103,15 @@ describe('right panel log filters', () => {
     expect(lootEntry).toBeTruthy();
     expect(combatEntry?.hidden).toBe(false);
     expect(lootEntry?.hidden).toBe(false);
+
+    collapseToggle?.click();
+
+    await settle();
+
+    const logBody = document.querySelector<HTMLElement>('#panel-log-body');
+    expect(logPanel?.classList.contains('panel-log--collapsed')).toBe(true);
+    expect(logBody?.hidden).toBe(true);
+    expect(collapseToggle?.getAttribute('aria-expanded')).toBe('false');
 
     const combatFilter = document.querySelector<HTMLButtonElement>(
       '.log-chip[data-log-filter="combat"]'
@@ -110,12 +126,16 @@ describe('right panel log filters', () => {
 
     const prefs = readLogPreferences();
     expect(prefs.mutedTypes).toContain('combat');
+    expect(prefs.isCollapsed).toBe(true);
 
     controller.dispose();
 
     renderShell();
     const controllerAgain = setupRightPanel(state);
     await settle();
+
+    const restoredLogPanel = document.querySelector<HTMLElement>('#right-panel-log');
+    expect(restoredLogPanel?.classList.contains('panel-log--collapsed')).toBe(true);
 
     const combatFilterAgain = document.querySelector<HTMLButtonElement>(
       '.log-chip[data-log-filter="combat"]'


### PR DESCRIPTION
## Summary
- move the combat log out of the events view into a fixed footer section with a collapsible header and persisted preference
- update log preference storage, right panel controller logic, and Vitest coverage for the new collapse toggle
- refresh the combat log styling for the expanded and collapsed states and document the UX change in the changelog

## Testing
- npx vitest run tests/ui/logging.test.ts tests/ui/hudNavigation.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e5e66671988330a420913a44f746a4