### PR TITLE
Add Saunakunnia upgrade flow to sauna tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Major Changes
+- Split sauna tier progression into artocoin unlocks followed by Saunakunnia
+  upgrades, refreshing lifecycle logic, UI flows, persistence, and tests so
+  hall activations now consume prestige before expanding the roster.
 - Force a fresh December 2024 save reset keyed off `autobattles:storage-reset:v2024-12-fresh-start` so corrupted slots clear once on load while rosters, NG+ progress, inventories, shops, and unlocks rebuild on a stable foundation.
 - Empowered Glacial Rhythm and Celestial Reserve with tri-hex sauna healing auras, updating lifecycle logic, UI copy, and tests to surface the 1.5 HP/s passive restoration.
 - Extended sauna tiers through the Celestial Reserve, standardizing vision radius, spawn multipliers, and NG+ unlock behavior across every hall.

--- a/docs/progression/artocoin-economy.md
+++ b/docs/progression/artocoin-economy.md
@@ -92,12 +92,14 @@ progress.
 ## Steamforge Atelier
 
 Artocoins now flow into the Steamforge Atelier—an in-run shop pinned beside the
-inventory stash. Each tier upgrade advertises its commission cost and unlocks
-instantly once purchased, letting players convert a streak of victories into new
-roster capacity without chasing legacy NG+ milestones. The top bar exposes the
-treasury through a dedicated artocoin badge that mirrors the resource animation
-language (delta ticks, accessible announcements) used for beer, sisu, and
-saunakunnia.
+inventory stash. Each sauna hall publishes its commission cost in artocoins and
+opens the contract immediately, but the roster expansion only comes online once
+commanders channel the required Saunakunnia back at the sauna. This two-step
+flow keeps the atelier focused on economic progress while prestige—the new
+Saunakunnia spend—signals when the crew has invested enough glory to renovate
+the benches. The top bar exposes the treasury through a dedicated artocoin badge
+that mirrors the resource animation language (delta ticks, accessible
+announcements) used for beer, sisu, and saunakunnia.
 
 Run summaries close with an "Artocoin ledger" panel that breaks down how many
 coins were earned, spent, and banked during the session. The ledger uses the

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -465,27 +465,37 @@ describe('game logging', () => {
     expect(rosterButton?.dataset.status).toBe('downed');
   }, 15000);
 
-  it('promotes the active sauna tier when NG+ unlocks a higher hall', async () => {
-    window.localStorage?.setItem?.(
-      'progression:ngPlusState',
-      JSON.stringify({ runSeed: 17, ngPlusLevel: 5, unlockSlots: 4 })
-    );
-    window.localStorage?.setItem?.(
+  it(
+    'retains the active sauna tier until Saunakunnia upgrades confirm ownership',
+    async () => {
+      window.localStorage?.setItem?.(
+        'progression:ngPlusState',
+        JSON.stringify({ runSeed: 17, ngPlusLevel: 5, unlockSlots: 4 })
+      );
+      window.localStorage?.setItem?.(
       'autobattles:sauna-settings',
       JSON.stringify({ maxRosterSize: 2, activeTierId: 'ember-circuit' })
     );
 
     const { __getActiveTierIdForTest } = await initGame();
 
-    expect(__getActiveTierIdForTest()).toBe('celestial-reserve');
+    expect(__getActiveTierIdForTest()).toBe('ember-circuit');
 
     const stored = window.localStorage?.getItem?.('autobattles:sauna-settings') ?? '';
     const parsed = stored
-      ? (JSON.parse(stored) as { maxRosterSize: number; activeTierId: string })
+      ? (JSON.parse(stored) as {
+          maxRosterSize: number;
+          activeTierId: string;
+          ownedTierIds?: string[];
+        })
       : null;
-    expect(parsed?.activeTierId).toBe('celestial-reserve');
+    expect(parsed?.activeTierId).toBe('ember-circuit');
     expect(parsed?.maxRosterSize).toBeLessThanOrEqual(6);
-  });
+    expect(parsed?.ownedTierIds ?? []).toContain('ember-circuit');
+    expect(parsed?.ownedTierIds ?? []).not.toContain('celestial-reserve');
+  },
+    20000
+  );
 
   it('promotes a level 12 Saunoja, resetting XP and storing the class', async () => {
     const {

--- a/src/game.ts
+++ b/src/game.ts
@@ -188,12 +188,12 @@ import {
   addArtocoinSpend,
   getArtocoinBalance,
   getArtocoinsSpentThisRun,
-  getPurchasedTierIds,
+  getUnlockedTierIds,
   setPurchasedLootUpgradeIds,
   notifySaunaShopSubscribers,
   reloadSaunaShopState,
   setArtocoinBalance,
-  setPurchasedTierIds,
+  setUnlockedTierIds,
   subscribeToSaunaShop as subscribeToSaunaShopState
 } from './game/saunaShopState.ts';
 import { initializeClassicHud } from './game/setup/hud.ts';
@@ -222,6 +222,7 @@ import {
   getNgPlusState,
   getResolveSpawnLimitRef as getResolveSpawnLimitAccessor,
   getSetActiveTierRef as getSetActiveTierAccessor,
+  getUpgradeTierRef as getUpgradeTierAccessor,
   getSpawnTierQueue,
   getTierContextRef as getTierContextRefAccessor,
   getUpdateRosterCapRef as getUpdateRosterCapAccessor,
@@ -418,6 +419,10 @@ let setActiveTierRef: (
   tierId: SaunaTierId,
   options?: { persist?: boolean; onTierChanged?: SaunaTierChangeContext }
 ) => boolean = getSetActiveTierAccessor();
+let upgradeTierRef: (
+  tierId: SaunaTierId,
+  options?: { persist?: boolean; activate?: boolean; onTierChanged?: SaunaTierChangeContext }
+) => boolean = getUpgradeTierAccessor();
 let spawnTierQueue: PlayerSpawnTierHelpers = getSpawnTierQueue();
 
 const IDLE_FRAME_LIMIT = 10;
@@ -1447,6 +1452,7 @@ getActiveSpawnSpeedMultiplierRef = getActiveSpawnSpeedMultiplierAccessor();
 updateRosterCapRef = getUpdateRosterCapAccessor();
 resolveSpawnLimitRef = getResolveSpawnLimitAccessor();
 setActiveTierRef = getSetActiveTierAccessor();
+upgradeTierRef = getUpgradeTierAccessor();
 spawnTierQueue = getSpawnTierQueue();
 
 const syncLifecycleWithUnlocks = withLifecycleSync(
@@ -1506,6 +1512,7 @@ function buildGameRuntimeContext(): GameRuntimeContext {
     getTierContext: () => getTierContextRef(),
     getActiveTierId: () => getActiveTierIdRef(),
     setActiveTier: (tierId, options) => setActiveTierRef(tierId, options),
+    upgradeTier: (tierId, options) => upgradeTierRef(tierId, options),
     getActiveTierLimit: () => getActiveTierLimitRef(),
     updateRosterCap: (value, options) => updateRosterCapRef(value, options),
     syncSaunojaRosterWithUnits: () => syncSaunojaRosterWithUnits(),
@@ -1586,14 +1593,15 @@ configureGameRuntime({
   getActiveTierLimit: () => getActiveTierLimitRef(),
   getRosterCap: () => sauna.maxRosterSize,
   updateRosterCap: (value, options) => updateRosterCapRef(value, options),
-  setActiveTier: (tierId, options) => setActiveTierRef(tierId, options)
+  setActiveTier: (tierId, options) => setActiveTierRef(tierId, options),
+  upgradeTier: (tierId, options) => upgradeTierRef(tierId, options)
 });
 
 onSaunaShopChange((event: SaunaShopChangeEvent) => {
   if (event.type === 'purchase' && event.cost && event.spendResult?.success) {
     addArtocoinSpend(event.cost);
   }
-  setPurchasedTierIds(event.purchased);
+  setUnlockedTierIds(event.unlocked);
   notifySaunaShopSubscribers();
   syncLifecycleWithUnlocks({ persist: true });
 });

--- a/src/game/runtime/GameRuntime.test.ts
+++ b/src/game/runtime/GameRuntime.test.ts
@@ -291,6 +291,7 @@ describe('GameRuntime', () => {
       getTierContext: vi.fn(() => ({}) as SaunaTierContext),
       getActiveTierId: vi.fn(() => 'tier-1' as SaunaTierId),
       setActiveTier: vi.fn(() => true),
+      upgradeTier: vi.fn(() => true),
       getActiveTierLimit: vi.fn(() => 6),
       updateRosterCap: vi.fn(() => 6),
       syncSaunojaRosterWithUnits: vi.fn(() => true),

--- a/src/game/runtime/GameRuntime.ts
+++ b/src/game/runtime/GameRuntime.ts
@@ -78,6 +78,10 @@ export interface GameRuntimeContext {
     tierId: SaunaTierId,
     options?: { persist?: boolean; onTierChanged?: SaunaTierChangeContext }
   ): boolean;
+  upgradeTier(
+    tierId: SaunaTierId,
+    options?: { persist?: boolean; activate?: boolean; onTierChanged?: SaunaTierChangeContext }
+  ): boolean;
   getActiveTierLimit(): number;
   updateRosterCap(value: number, options?: { persist?: boolean }): number;
   syncSaunojaRosterWithUnits(): boolean;
@@ -575,6 +579,7 @@ export class GameRuntime {
       updateRosterDisplay: () => this.ctx.updateRosterDisplay(),
       getActiveTierLimit: () => this.ctx.getActiveTierLimit(),
       updateRosterCap: (value, opts) => this.ctx.updateRosterCap(value, opts),
+      upgradeTier: (tierId, opts) => this.ctx.upgradeTier(tierId, opts),
       promoteSaunoja: (unitId, klass) => this.ctx.promoteSaunoja(unitId, klass)
     });
 
@@ -590,6 +595,7 @@ export class GameRuntime {
       setupSaunaUi: uiAdapters.createSaunaUiController,
       getActiveTierId: () => this.ctx.getActiveTierId(),
       setActiveTier: (tierId, options) => this.ctx.setActiveTier(tierId, options),
+      upgradeTier: (tierId, options) => this.ctx.upgradeTier(tierId, options),
       getTierContext: () => this.ctx.getTierContext(),
       setupTopbar: uiAdapters.createTopbarControls,
       setupActionBar: uiAdapters.createActionBarController,

--- a/src/game/runtime/index.ts
+++ b/src/game/runtime/index.ts
@@ -23,6 +23,10 @@ export interface GameRuntimeBootstrap {
     tierId: SaunaTierId,
     options?: { persist?: boolean; onTierChanged?: SaunaTierChangeContext }
   ): boolean;
+  upgradeTier(
+    tierId: SaunaTierId,
+    options?: { persist?: boolean; activate?: boolean; onTierChanged?: SaunaTierChangeContext }
+  ): boolean;
 }
 
 let runtimeInstance: GameRuntime | null = null;
@@ -89,6 +93,13 @@ export function setActiveSaunaTier(
   options: { persist?: boolean } = {}
 ): boolean {
   return requireBootstrap().setActiveTier(tierId, options);
+}
+
+export function upgradeSaunaTier(
+  tierId: SaunaTierId,
+  options: { persist?: boolean; activate?: boolean } = {}
+): boolean {
+  return requireBootstrap().upgradeTier(tierId, options);
 }
 
 export function getRosterCapValue(): number {

--- a/src/game/runtime/saunaLifecycleManager.ts
+++ b/src/game/runtime/saunaLifecycleManager.ts
@@ -26,6 +26,8 @@ type LifecycleSyncHook = (options?: LifecycleSyncOptions) => void;
 
 const EMPTY_CONTEXT: SaunaTierContext = {
   artocoinBalance: 0,
+  saunakunniaBalance: 0,
+  unlockedTierIds: Object.freeze(new Set<SaunaTierId>()) as ReadonlySet<SaunaTierId>,
   ownedTierIds: Object.freeze(new Set<SaunaTierId>()) as ReadonlySet<SaunaTierId>
 };
 
@@ -60,6 +62,10 @@ let setActiveTierRef: (
   tierId: SaunaTierId,
   options?: { persist?: boolean; onTierChanged?: SaunaTierChangeContext }
 ) => boolean = () => false;
+let upgradeTierRef: (
+  tierId: SaunaTierId,
+  options?: { persist?: boolean; activate?: boolean; onTierChanged?: SaunaTierChangeContext }
+) => boolean = () => false;
 let spawnTierQueueRef: PlayerSpawnTierHelpers = EMPTY_SPAWN_QUEUE;
 let lifecycleSync: LifecycleSyncHook | null = null;
 
@@ -91,6 +97,7 @@ export function initSaunaLifecycle(options: SaunaLifecycleOptions): SaunaLifecyc
   updateRosterCapRef = lifecycle.updateRosterCap;
   resolveSpawnLimitRef = lifecycle.resolveSpawnLimit;
   setActiveTierRef = lifecycle.setActiveTier;
+  upgradeTierRef = lifecycle.upgradeTier;
   spawnTierQueueRef = lifecycle.spawnTierQueue;
   return lifecycle;
 }
@@ -138,6 +145,13 @@ export function getSetActiveTierRef(): (
   options?: { persist?: boolean; onTierChanged?: SaunaTierChangeContext }
 ) => boolean {
   return setActiveTierRef;
+}
+
+export function getUpgradeTierRef(): (
+  tierId: SaunaTierId,
+  options?: { persist?: boolean; activate?: boolean; onTierChanged?: SaunaTierChangeContext }
+) => boolean {
+  return upgradeTierRef;
 }
 
 export function getSpawnTierQueue(): PlayerSpawnTierHelpers {

--- a/src/game/runtime/uiAdapters.ts
+++ b/src/game/runtime/uiAdapters.ts
@@ -60,6 +60,10 @@ export interface UiAdapterDependencies {
   readonly updateRosterDisplay: () => void;
   readonly getActiveTierLimit: () => number;
   readonly updateRosterCap: (value: number, options?: { persist?: boolean }) => number;
+  readonly upgradeTier: (
+    tierId: SaunaTierId,
+    options?: { persist?: boolean; activate?: boolean }
+  ) => boolean;
   readonly promoteSaunoja: (unitId: string, klass: SaunojaClass) => boolean;
 }
 

--- a/src/game/saunaSettings.test.ts
+++ b/src/game/saunaSettings.test.ts
@@ -15,24 +15,34 @@ describe('saunaSettings', () => {
     const settings = loadSaunaSettings(4);
     expect(settings.maxRosterSize).toBe(3);
     expect(settings.activeTierId).toBe(DEFAULT_SAUNA_TIER_ID);
+    expect(settings.ownedTierIds).toContain(DEFAULT_SAUNA_TIER_ID);
   });
 
   it('clamps stored values to the unlock ceiling', () => {
     window.localStorage?.setItem(
       SAUNA_SETTINGS_STORAGE_KEY,
-      JSON.stringify({ maxRosterSize: 99, activeTierId: 'mythic-conclave' })
+      JSON.stringify({ maxRosterSize: 99, activeTierId: 'mythic-conclave', ownedTierIds: [] })
     );
     const settings = loadSaunaSettings(1);
     expect(settings.maxRosterSize).toBe(1);
     expect(settings.activeTierId).toBe('mythic-conclave');
+    expect(settings.ownedTierIds).toContain('mythic-conclave');
   });
 
   it('persists sanitized roster caps', () => {
-    saveSaunaSettings({ maxRosterSize: 7, activeTierId: 'mythic-conclave' });
+    saveSaunaSettings({
+      maxRosterSize: 7,
+      activeTierId: 'mythic-conclave',
+      ownedTierIds: ['mythic-conclave']
+    });
     const raw = window.localStorage?.getItem(SAUNA_SETTINGS_STORAGE_KEY);
     expect(raw).toBeTypeOf('string');
     const parsed = raw ? JSON.parse(raw) : null;
-    expect(parsed).toEqual({ maxRosterSize: 5, activeTierId: 'mythic-conclave' });
+    expect(parsed?.maxRosterSize).toBe(5);
+    expect(parsed?.activeTierId).toBe('mythic-conclave');
+    expect(new Set(parsed?.ownedTierIds ?? [])).toEqual(
+      new Set(['ember-circuit', 'mythic-conclave'])
+    );
   });
 
   it('handles malformed payloads gracefully', () => {
@@ -51,11 +61,12 @@ describe('saunaSettings', () => {
   it('falls back to the default tier when an unknown id is stored', () => {
     window.localStorage?.setItem(
       SAUNA_SETTINGS_STORAGE_KEY,
-      JSON.stringify({ maxRosterSize: 3, activeTierId: 'unknown-tier' })
+      JSON.stringify({ maxRosterSize: 3, activeTierId: 'unknown-tier', ownedTierIds: ['unknown-tier'] })
     );
     const settings = loadSaunaSettings(4);
     expect(settings.activeTierId).toBe(DEFAULT_SAUNA_TIER_ID);
     expect(settings.maxRosterSize).toBe(3);
+    expect(settings.ownedTierIds).toContain(DEFAULT_SAUNA_TIER_ID);
   });
 
   it('respects tier roster caps when loading', () => {
@@ -63,9 +74,10 @@ describe('saunaSettings', () => {
     expect(premium).toBeDefined();
     window.localStorage?.setItem(
       SAUNA_SETTINGS_STORAGE_KEY,
-      JSON.stringify({ maxRosterSize: 99, activeTierId: premium?.id })
+      JSON.stringify({ maxRosterSize: 99, activeTierId: premium?.id, ownedTierIds: [premium?.id] })
     );
     const settings = loadSaunaSettings(10);
     expect(settings.maxRosterSize).toBe(premium?.rosterCap ?? 4);
+    expect(settings.ownedTierIds).toContain(premium?.id ?? DEFAULT_SAUNA_TIER_ID);
   });
 });

--- a/src/game/saunaShopState.ts
+++ b/src/game/saunaShopState.ts
@@ -3,20 +3,24 @@ import {
   getPurchasedLootUpgrades,
   type LootUpgradeId
 } from '../progression/lootUpgrades.ts';
-import { getPurchasedSaunaTiers } from '../progression/saunaShop.ts';
+import { getUnlockedSaunaTiers } from '../progression/saunaShop.ts';
+import { loadSaunaSettings } from './saunaSettings.ts';
 import type { SaunaTierId } from '../sauna/tiers.ts';
 
 export type SaunaShopListener = () => void;
 
 let artocoinBalance = loadArtocoinBalance();
 let artocoinsSpentThisRun = 0;
-let purchasedTierIds = new Set<SaunaTierId>(getPurchasedSaunaTiers());
+let unlockedTierIds = new Set<SaunaTierId>(getUnlockedSaunaTiers());
+let upgradedTierIds = new Set<SaunaTierId>();
 let purchasedLootUpgrades = new Set<LootUpgradeId>(getPurchasedLootUpgrades());
 const listeners = new Set<SaunaShopListener>();
 
 export function reloadSaunaShopState(): void {
   artocoinBalance = loadArtocoinBalance();
-  purchasedTierIds = new Set(getPurchasedSaunaTiers());
+  unlockedTierIds = new Set(getUnlockedSaunaTiers());
+  const saunaSettings = loadSaunaSettings();
+  upgradedTierIds = new Set(saunaSettings.ownedTierIds);
   purchasedLootUpgrades = new Set(getPurchasedLootUpgrades());
   artocoinsSpentThisRun = 0;
 }
@@ -29,12 +33,20 @@ export function setArtocoinBalance(next: number): void {
   artocoinBalance = Number.isFinite(next) ? next : 0;
 }
 
-export function getPurchasedTierIds(): ReadonlySet<SaunaTierId> {
-  return purchasedTierIds;
+export function getUnlockedTierIds(): ReadonlySet<SaunaTierId> {
+  return unlockedTierIds;
 }
 
-export function setPurchasedTierIds(tiers: Iterable<SaunaTierId>): void {
-  purchasedTierIds = new Set(tiers);
+export function setUnlockedTierIds(tiers: Iterable<SaunaTierId>): void {
+  unlockedTierIds = new Set(tiers);
+}
+
+export function getUpgradedTierIds(): ReadonlySet<SaunaTierId> {
+  return upgradedTierIds;
+}
+
+export function setUpgradedTierIds(tiers: Iterable<SaunaTierId>): void {
+  upgradedTierIds = new Set(tiers);
 }
 
 export function getPurchasedLootUpgradeIds(): ReadonlySet<LootUpgradeId> {

--- a/src/game/setup/hud.test.ts
+++ b/src/game/setup/hud.test.ts
@@ -42,6 +42,7 @@ describe('initializeClassicHud', () => {
     const updateRosterDisplay = vi.fn();
     const startTutorialIfNeeded = vi.fn();
     const setActiveTier = vi.fn(() => true);
+    const upgradeTier = vi.fn(() => false);
 
     const syncRoster = vi.fn();
     const panelRenderer = vi.fn();
@@ -75,6 +76,7 @@ describe('initializeClassicHud', () => {
       }),
       getActiveTierId: () => 'ember-circuit',
       setActiveTier,
+      upgradeTier,
       getTierContext: () => null,
       setupTopbar: vi.fn(() => topbarControls),
       setupActionBar: vi.fn(() => actionBarController),
@@ -144,6 +146,9 @@ describe('initializeClassicHud', () => {
     expect(result.saunaUiController?.update).toHaveBeenCalled();
     expect(setActiveTier).toHaveBeenCalledWith('aurora-ward', { persist: true });
     expect(updateRosterDisplay).toHaveBeenCalledTimes(2);
+
+    capturedSaunaOptions?.upgradeTierId?.('glacial-rhythm', { persist: true, activate: true });
+    expect(upgradeTier).toHaveBeenCalledWith('glacial-rhythm', { persist: true, activate: true });
   });
 });
 

--- a/src/game/setup/hud.ts
+++ b/src/game/setup/hud.ts
@@ -50,6 +50,10 @@ type ClassicHudDependencies = {
   setupSaunaUi: SaunaUiFactory;
   getActiveTierId: () => SaunaTierId;
   setActiveTier: (tierId: SaunaTierId, options?: { persist?: boolean }) => boolean;
+  upgradeTier: (
+    tierId: SaunaTierId,
+    options?: { persist?: boolean; activate?: boolean }
+  ) => boolean;
   getTierContext: () => SaunaTierContext | null;
   setupTopbar: TopbarFactory;
   setupActionBar: ActionBarFactory;
@@ -120,6 +124,7 @@ export function initializeClassicHud(deps: ClassicHudDependencies): HudInitializ
       }
       return unlocked;
     },
+    upgradeTierId: (tierId, upgradeOptions) => deps.upgradeTier(tierId, upgradeOptions),
     getTierContext: deps.getTierContext
   });
 

--- a/src/sauna/tiers.test.ts
+++ b/src/sauna/tiers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { evaluateSaunaTier, getSaunaTier, listSaunaTiers, type SaunaTierId } from './tiers.ts';
+import {
+  evaluateSaunaTier,
+  getSaunaTier,
+  listSaunaTiers,
+  type SaunaTierId
+} from './tiers.ts';
 
 describe('sauna tiers', () => {
   it('lists the current progression lineup from Ember Circuit through Celestial Reserve', () => {
@@ -37,13 +42,59 @@ describe('sauna tiers', () => {
     }
   });
 
-  it('surfaces the healing aura perk in the upgrade requirement copy', () => {
-    const tier = getSaunaTier('glacial-rhythm');
-    const status = evaluateSaunaTier(tier, {
-      artocoinBalance: 999,
+  it('tracks unlocks separately from Saunakunnia upgrades', () => {
+    const tier = getSaunaTier('aurora-ward');
+    const locked = evaluateSaunaTier(tier, {
+      artocoinBalance: 40,
+      saunakunniaBalance: 10,
+      unlockedTierIds: new Set<SaunaTierId>(['ember-circuit']),
       ownedTierIds: new Set<SaunaTierId>(['ember-circuit'])
     });
 
+    expect(locked.unlocked).toBe(false);
+    expect(locked.owned).toBe(false);
+    expect(locked.unlock.requirementLabel).toContain('Need 30 more');
+    expect(Math.round(locked.unlock.progress * 100)).toBe(57);
+    expect(locked.requirementLabel).toBe(locked.unlock.requirementLabel);
+
+    const unlocked = evaluateSaunaTier(tier, {
+      artocoinBalance: 80,
+      saunakunniaBalance: 60,
+      unlockedTierIds: new Set<SaunaTierId>(['ember-circuit', 'aurora-ward']),
+      ownedTierIds: new Set<SaunaTierId>(['ember-circuit'])
+    });
+
+    expect(unlocked.unlocked).toBe(true);
+    expect(unlocked.owned).toBe(false);
+    expect(unlocked.unlock.progress).toBe(1);
+    expect(Math.round(unlocked.upgrade.progress * 100)).toBe(75);
+    expect(unlocked.requirementLabel).toContain('80 Saunakunnia');
+
+    const owned = evaluateSaunaTier(tier, {
+      artocoinBalance: 120,
+      saunakunniaBalance: 200,
+      unlockedTierIds: new Set<SaunaTierId>(['ember-circuit', 'aurora-ward']),
+      ownedTierIds: new Set<SaunaTierId>(['ember-circuit', 'aurora-ward'])
+    });
+
+    expect(owned.unlocked).toBe(true);
+    expect(owned.owned).toBe(true);
+    expect(owned.upgrade.progress).toBe(1);
+    expect(owned.requirementLabel).toBe('Roster cap 4');
+  });
+
+  it('surfaces the healing aura perk when prestige is required', () => {
+    const tier = getSaunaTier('glacial-rhythm');
+    const status = evaluateSaunaTier(tier, {
+      artocoinBalance: 150,
+      saunakunniaBalance: 20,
+      unlockedTierIds: new Set<SaunaTierId>(['ember-circuit', 'glacial-rhythm']),
+      ownedTierIds: new Set<SaunaTierId>(['ember-circuit'])
+    });
+
+    expect(status.unlocked).toBe(true);
+    expect(status.owned).toBe(false);
     expect(status.requirementLabel).toContain('Healing aura 3-hex (1.5 HP/s)');
+    expect(status.upgrade.requirementLabel).toContain('Need 120 more');
   });
 });

--- a/src/ui/inventoryHud.ts
+++ b/src/ui/inventoryHud.ts
@@ -328,10 +328,10 @@ export function setupInventoryHud(
     shopButton.dataset.balance = balanceLabel;
     shopButton.title = `Artocoins ${balanceLabel}`;
     const tierReady = view.tiers.some(
-      (entry) => !entry.status.owned && entry.status.affordable
+      (entry) => !entry.status.unlocked && entry.status.unlock.affordable
     );
     const tierLocked = view.tiers.some(
-      (entry) => !entry.status.owned && !entry.status.affordable
+      (entry) => !entry.status.unlocked && !entry.status.unlock.affordable
     );
     const upgradeEntries = (view.lootCategories ?? []).flatMap((category) =>
       category.upgrades ?? []
@@ -379,7 +379,7 @@ export function setupInventoryHud(
         return {
           success: false,
           balance: fallback.balance,
-          purchased: new Set<SaunaTierId>(),
+          unlocked: new Set<SaunaTierId>(),
           reason: 'unsupported'
         } satisfies PurchaseSaunaTierResult;
       }

--- a/tests/progression/saunaShop.test.ts
+++ b/tests/progression/saunaShop.test.ts
@@ -59,7 +59,7 @@ describe('purchaseSaunaTier', () => {
     const artocoinModule = await import('../../src/progression/artocoin.ts');
     const spendSpy = vi.spyOn(artocoinModule, 'spendArtocoins');
 
-    const { purchaseSaunaTier, getPurchasedSaunaTiers } = await import(
+    const { purchaseSaunaTier, getUnlockedSaunaTiers } = await import(
       '../../src/progression/saunaShop.ts'
     );
     const { getSaunaTier } = await import('../../src/sauna/tiers.ts');
@@ -78,7 +78,7 @@ describe('purchaseSaunaTier', () => {
     expect(result.reason).toBeUndefined();
     expect(result.shortfall).toBeUndefined();
     expect(spendSpy).not.toHaveBeenCalled();
-    expect(getPurchasedSaunaTiers().has(tier.id)).toBe(true);
+    expect(getUnlockedSaunaTiers().has(tier.id)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- separate sauna tier unlocks from Saunakunnia upgrades, updating evaluation logic and persistence
- require Saunakunnia spending before activating tiers in the lifecycle/runtime layers and UI
- refresh docs and regression tests to cover the two-step sauna progression flow

## Testing
- npm run build
- npx vitest run src/sauna/tiers.test.ts src/game/runtime/index.test.ts src/ui/sauna.test.ts tests/ui/saunaShopPanel.test.ts --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68fb8158ef2883308d065556ff71062d