### PR TITLE
Fix sauna lifecycle to use actual GameState during upgrades

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -1436,6 +1436,7 @@ state.setEnemyScalingBase({
 });
 saunaLifecycle = initSaunaLifecycle({
   map,
+  state,
   ngPlusState: currentNgPlusState,
   getActiveRosterCount: () => getActiveRosterCount(),
   logEvent,

--- a/src/game/setup/sauna.ts
+++ b/src/game/setup/sauna.ts
@@ -114,10 +114,11 @@ export function createSaunaLifecycle(options: SaunaLifecycleOptions): SaunaLifec
     onVisionRangeChanged
   } = options;
 
-  const gameState = state ?? ({
-    getResource: () => 0,
-    spendResource: () => false
-  } as unknown as GameState);
+  if (!state) {
+    throw new Error('createSaunaLifecycle requires a GameState instance.');
+  }
+
+  const gameState = state;
 
   const saunaSettings = loadSaunaSettings();
   const storage = (() => {


### PR DESCRIPTION
## Summary
- pass the live GameState into the sauna lifecycle bootstrap so Saunakunnia upgrades can spend currency
- throw when createSaunaLifecycle is invoked without a GameState to prevent silent stub usage

## Testing
- npx vitest run tests/setup/sauna.test.ts

------
https://chatgpt.com/codex/tasks/task_b_6901b375a97c83338c9d6a23bc873bec